### PR TITLE
Adding a missing include required by clang.

### DIFF
--- a/types/Exception.hpp
+++ b/types/Exception.hpp
@@ -29,6 +29,7 @@
 
 #include <nta/types/types.hpp>
 #include <stdexcept>
+#include <string>
 
 //----------------------------------------------------------------------
 


### PR DESCRIPTION
Later versions of clang are stricter and cause errors if this is not
included explicitly.

Fixes #25.
