### PR TITLE
remove >register< keyword (deprecated)

### DIFF
--- a/algorithms/linear.cpp
+++ b/algorithms/linear.cpp
@@ -175,7 +175,7 @@ namespace nta {
 		 int *incy)
       {
 	long i, m, ix, iy, nn = *n, iincx = *incx, iincy = *incy;
-	register float ssa = *sa;
+	float ssa = *sa;
 
 	if( nn > 0 && ssa != 0.0f)
 	  {


### PR DESCRIPTION
or not advised by clang for c++11 (and not supported by most compilers at all)
