### PR TITLE
workaround strerror_r ignoring return value warning

### DIFF
--- a/os/FStream.cpp
+++ b/os/FStream.cpp
@@ -183,11 +183,9 @@ void *ZLib::fopen(const std::string &filename, const std::string &mode,
           case Z_VERSION_ERROR: message = "Zlib version error."; break;
           default:
             char errbuf[256];
-            int retval = ::strerror_r(error, errbuf, 256);
-            if(retval != 0) {
+            char* retval = ::strerror_r(error, errbuf, 256);
+            if(retval != NULL) {
                 //empty code to silence -Werror=unused-variable warning
-                std::cerr << "Error: Failed function strerror_r " << std::endl;
-                exit(1);
             }
             message = errbuf;
             break;


### PR DESCRIPTION
fix (workaround) issue #39
because of Werror, just a hack. Affected: ubuntu 13.04 gcc
