### PR TITLE
Revert "Revert "use POSIX version of esrerror_r""

### DIFF
--- a/src/main/os/FStream.cpp
+++ b/src/main/os/FStream.cpp
@@ -181,9 +181,7 @@ void *ZLib::fopen(const std::string &filename, const std::string &mode,
           case Z_MEM_ERROR: message = "Zlib memory error."; break;
           case Z_BUF_ERROR: message = "Zlib buffer error."; break;
           case Z_VERSION_ERROR: message = "Zlib version error."; break;
-          default:
-            message = ::strerror(error);
-            break;
+          default: message = ::strerror(error); break;
         }   
         if(errorMessage) {
           *errorMessage = message;


### PR DESCRIPTION
This reverts commit ecd6ba76783c7f3cf2bd4bacce760bc37c17007f.

Because it introduced problems on OSX
Use strerror only, simplify

Should fix #53 
