### PR TITLE
Decrease unnecessary builds in travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-compilers:
+compiler:
   - clang
   - gcc
 


### PR DESCRIPTION
Fixes #89.

Travis-CI [sets `CC` and `CXX`](http://docs.travis-ci.com/user/languages/cpp/), so we don't need to. This cuts our build load in half.
