### PR TITLE
Optimize getPackageDir() function

### DIFF
--- a/src/main/os/OS.cpp
+++ b/src/main/os/OS.cpp
@@ -157,3 +157,31 @@ void OS::getProcessMemoryUsage(size_t& realMem, size_t& virtualMem)
   virtualMem = 100;
 #endif
 }
+
+std::string OS::executeCommand(std::string command)
+{
+#if defined(NTA_PLATFORM_win32) && defined(_MSC_VER)
+  FILE* pipe = _popen(&command[0], "r");
+#else
+  FILE* pipe = popen(&command[0], "r");
+#endif
+  if (!pipe)
+  {
+    return "ERROR";
+  }
+  char buffer[128];
+  std::string result = "";
+  while(!feof(pipe))
+  {
+    if(fgets(buffer, 128, pipe) != NULL)
+    {
+      result += buffer;
+    }
+  }
+#if defined(NTA_PLATFORM_win32) && defined(_MSC_VER)
+  _pclose(pipe);
+#else
+  pclose(pipe);
+#endif
+  return result;
+}

--- a/src/main/os/OS.hpp
+++ b/src/main/os/OS.hpp
@@ -125,7 +125,17 @@ namespace nta
      */
     static void getProcessMemoryUsage(size_t& realMem, size_t& virtualMem);
 
+    /**
+     * Execute a command and and return its output.
+     *
+     * @param command
+     *        The command to execute
+     * @returns
+     *        The output of the command.
+     */
+     static std::string executeCommand(std::string command);
   };
 }
 
 #endif // NTA_OS_HPP
+


### PR DESCRIPTION
Use rootDir to store NuPIC package dir in RegionImplFactory.cpp

In the current file, the shell command to get the package dir is called every time that the getPackageDir() function is called. With this PR, the path of the NuPIC package is stored once in `rootDir_` in the constructor and getPackageDir() return packages by join the `rootDir_` previsously stored and the relative paths of the submodules. This improves the performance issue pointed by @utensil .

Solves: https://github.com/numenta/nupic.core/issues/114
