### PR TITLE
Remove $NTA reference

### DIFF
--- a/src/main/engine/RegionImplFactory.cpp
+++ b/src/main/engine/RegionImplFactory.cpp
@@ -67,22 +67,10 @@ namespace nta
     {
       // To find the pynode plugin we need the nupic
       // installation directory.
-      std::string libDir;
-      bool found = Env::get("NTA", libDir);
-      if (!found)
-      {
-        NTA_THROW << "Unable to find the pynode dynamic library because NTA is not set";
-      }
-      else
-      {
-        found = false;
-        if (Path::exists(libDir) && Path::isDirectory(libDir))
-        {
-          found = true;
-        }
-      }
-      if (!found)
-        NTA_THROW << "Unable to find NuPIC installation dir from NTA";
+      std::string command = "python -c 'import sys;import os;import nupic;sys.stdout.write(os.path.abspath(os.path.join(nupic.__file__, \"../..\")))'";
+      rootDir_ = OS::executeCommand(command);
+      if (!Path::exists(rootDir_))
+        NTA_THROW << "Unable to find NuPIC library in '" << rootDir_ << "'";
       
       
 #if defined(NTA_PLATFORM_darwin64)
@@ -99,16 +87,10 @@ namespace nta
       const char * filename = "cpp_region.dll";
 #endif
 
-      std::string libName = Path::join(libDir, "lib", filename); 
+      std::string libName = Path::join(rootDir_, "nupic", filename);
 
       if (!Path::exists(libName))
-        NTA_THROW << "Unable to find library " << filename 
-                  << " in NuPIC installation folder '" << libDir << "'";
-
-      std::string command = "python -c 'import sys;import os;import nupic;sys.stdout.write(os.path.abspath(os.path.join(nupic.__file__, \"../..\")))'";
-      rootDir_ = OS::executeCommand(command);
-      if (!Path::exists(rootDir_))
-        NTA_THROW << "Unable to find NuPIC library path";
+        NTA_THROW << "Unable to find library '" << libName << "'";
 
       std::string errorString;
       DynamicLibrary * p = 


### PR DESCRIPTION
Supports https://github.com/numenta/nupic/issues/809.

This PR should be merged together with https://github.com/numenta/nupic/pull/917 (pip-installable). This is because `lib_cppregion.so` will be installed too. In the current implementation, this file is obtained from $NTA/lib.
