### PR TITLE
Resume #else clause to fix linux 32 build for count_gt()

### DIFF
--- a/src/main/math/ArrayAlgo.hpp
+++ b/src/main/math/ArrayAlgo.hpp
@@ -3985,6 +3985,8 @@ namespace nta {
 
       return (int) count;
 
+#else
+      return std::count_if(begin, end, std::bind2nd(std::greater<nta::Real32>(), threshold));
 #endif
     } else {
       return std::count_if(begin, end, std::bind2nd(std::greater<nta::Real32>(), threshold));


### PR DESCRIPTION
Fixes #115 .

Still testing on a linux32 machine, please don't merge yet.
