### PR TITLE
Fix `nupic.core` master build failure

### DIFF
--- a/src/examples/regions/helloregions.cpp
+++ b/src/examples/regions/helloregions.cpp
@@ -25,7 +25,7 @@
 #include <nta/engine/Region.hpp>
 #include <nta/ntypes/Dimensions.hpp>
 #include <nta/ntypes/ArrayRef.hpp>
-#include <nta/OS/Path.hpp>
+#include <nta/os/Path.hpp>
 
 
 


### PR DESCRIPTION
Fixes #162 which caused `nupic.core` master build failure .
