### PR TITLE
remove NULL pointer test (dereferencing NULL)

### DIFF
--- a/src/main/engine/Input.cpp
+++ b/src/main/engine/Input.cpp
@@ -41,10 +41,6 @@ Input::Input(Region& region, NTA_BasicType dataType, bool isRegionLevel) :
   region_(region), isRegionLevel_(isRegionLevel), 
   initialized_(false),  data_(dataType), name_("Unnamed")
 {
-  if (&region == NULL)
-  {
-    NTA_THROW << "Attempt to create Input with a null region";
-  }
 }
 
 Input::~Input()

--- a/src/test/testeverything/engine/InputTest.cpp
+++ b/src/test/testeverything/engine/InputTest.cpp
@@ -43,8 +43,6 @@ void InputTest::RunTests()
     //Test constructor
     Input x(*r1, NTA_BasicType_Int32, true);
     Input y(*r2, NTA_BasicType_Byte, false);
-    Region * rn = NULL;
-    SHOULDFAIL(Input z(*rn, NTA_BasicType_Int32, true));
     SHOULDFAIL(Input i(*r1, (NTA_BasicType)(NTA_BasicType_Last + 1), true));
 
     //test getRegion()


### PR DESCRIPTION
references should never be null, actuall code does not compile under clang 3.5 that enforces that
please review
env: c++11, clang-3.5+, stdlib=libstdc++ (gcc4.8)
fixes #180 
