### PR TITLE
Add -static-libgcc -static-libstdc++ to CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,7 +74,7 @@ include_directories(SYSTEM
                     "${PROJECT_SOURCE_DIR}"
                     "${PROJECT_BINARY_DIR}")
 
-set(COMPILE_FLAGS "-fPIC -std=c++11 ${STDLIB} -m${BITNESS} ${STDLIB} -fvisibility=hidden -Wall -Wreturn-type -Wunused -Wno-unused-parameter")
+set(COMPILE_FLAGS "-fPIC -std=c++11 -m${BITNESS} ${STDLIB} -fvisibility=hidden -Wall -Wreturn-type -Wunused -Wno-unused-parameter")
 
 #
 # Extract current git sha and record in nta/Version.hpp


### PR DESCRIPTION
@oxtopus @rhyolight This worked on CentOS 6.5 with GNU 4.8. I build nupic.core in $NUPIC_CORE (/home/ec2-user/tmp/nupic.core)

After that, I could build NuPIC by running this : `python setup.py develop --install-dir="$REPOSITORY/build/release/lib/python2.7/site-packages" --cmake_options="-DNUPIC_CORE=${NUPIC_CORE}/build/release"`
