### PR TITLE
Add binary dependencies to install.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -475,6 +475,8 @@ install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/gtest"
         FILES_MATCHING PATTERN "*.h*")
 install(FILES "${PROJECT_BINARY_DIR}/Version.hpp"
         DESTINATION include/nupic/)
+install(DIRECTORY "${REPOSITORY_DIR}/external/${PLATFORM}${BITNESS}/bin/"
+        DESTINATION bin USE_SOURCE_PERMISSIONS)
 install(DIRECTORY "${REPOSITORY_DIR}/external/${PLATFORM}${BITNESS}/lib/"
         DESTINATION lib)
 install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/"


### PR DESCRIPTION
Relates to https://github.com/numenta/nupic/issues/1435
