### PR TITLE
Included python_support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,6 +197,58 @@ capnp_generate_cpp(
 )
 
 #
+# Checks if Python is installed and gets its variables.
+# Minimum version of Python is 2.6 -- earlier versions *will* fail.
+#
+# Please don't use 'find_package' for finding Python (System version), it has presented several conflicting results.
+# Instead we just use a shell command to execute a simple python command, if exit code is 0 ('success') then we have python installed.
+#
+
+#
+# Check for user-defined PYTHON env variable
+#
+if(NOT "$ENV{PYTHON}" STREQUAL "")
+  set(PYTHON "$ENV{PYTHON}")
+else()
+  set(PYTHON "python")
+endif()
+
+#
+# Gives the version of Python necessary to get installation directories
+# for use with ${PYTHON_VERSION}, etc.
+#
+execute_process(COMMAND ${PYTHON} -c "import sys;sys.stdout.write(str(sys.version_info[0]) + '.' + str(sys.version_info[1]))"
+                OUTPUT_VARIABLE PYTHON_VERSION
+                RESULT_VARIABLE EXIT_CODE)
+if(NOT EXIT_CODE EQUAL 0)
+  message(FATAL_ERROR "System Python not found. You do not have a system version of Python or it is not set on environment path.")
+endif()
+if(NOT(${PYTHON_VERSION} EQUAL "2.6" OR ${PYTHON_VERSION} EQUAL "2.7"))
+  message(FATAL_ERROR "Only these versions of Python are accepted: 2.6, 2.7")
+endif()
+
+#
+# Find out where system installation of python is.
+#
+execute_process(COMMAND ${PYTHON} -c "import sys;sys.stdout.write(sys.prefix)"
+                OUTPUT_VARIABLE PYTHON_PREFIX)
+string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX ${PYTHON_PREFIX})
+set(PYTHON_INCLUDE_DIR "${PYTHON_PREFIX}/include/python${PYTHON_VERSION}")
+
+#
+# Setup libpython_support
+#
+set(LIB_STATIC_PYTHONSUPPORT python_support)
+include_directories(${PYTHON_INCLUDE_DIR})
+add_library(${LIB_STATIC_PYTHONSUPPORT}
+            python_support/NumpyVector.cpp
+            python_support/PyArray.cpp
+            python_support/PyHelpers.cpp
+            python_support/PythonStream.cpp)
+set_target_properties(${LIB_STATIC_PYTHONSUPPORT} PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS})
+set_target_properties(${LIB_STATIC_PYTHONSUPPORT} PROPERTIES LINK_FLAGS "-m${BITNESS} ${STDLIB} -static")
+
+#
 # Setup libnupic_core
 #
 set(LIB_STATIC_NUPICCORE nupic_core_solo)
@@ -211,7 +263,7 @@ elseif("${PLATFORM}" STREQUAL "darwin")
   set(COMPILE_FLAGS "${COMPILE_FLAGS} -O3")
 endif()
 
-ADD_LIBRARY(${LIB_STATIC_NUPICCORE}
+add_library(${LIB_STATIC_NUPICCORE}
             STATIC
             ${CAPNP_SRCS}
             nupic/algorithms/BitHistory.cpp

--- a/src/python_support/NumpyVector.cpp
+++ b/src/python_support/NumpyVector.cpp
@@ -1,0 +1,220 @@
+#ifdef NTA_PYTHON_SUPPORT
+
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ */
+
+
+
+//#define NO_IMPORT_ARRAY
+#include <Python.h>
+
+#include <numpy/arrayobject.h>
+
+// workaround for change in numpy config.h for python2.5 on windows
+// Must come after python includes.
+#ifndef SIZEOF_FLOAT
+#define SIZEOF_FLOAT 32
+#endif
+
+#ifndef SIZEOF_DOUBLE
+#define SIZEOF_DOUBLE 64
+#endif
+
+#include <python_support/NumpyVector.hpp>
+
+#include <stdexcept>
+#include <iostream>
+
+using namespace std;
+using namespace nupic;
+
+// --------------------------------------------------------------
+// Auto-convert a compile-time type to a Numpy dtype.
+// --------------------------------------------------------------
+
+template<typename T>
+class NumpyDTypeTraits {};
+
+template<typename T>
+int LookupNumpyDTypeT(const T *)
+  { return NumpyDTypeTraits<T>::numpyDType; }
+
+#define NTA_DEF_NUMPY_DTYPE_TRAIT(a, b) \
+template<> class NumpyDTypeTraits<a> { public: enum { numpyDType=b }; }; \
+int nupic::LookupNumpyDType(const a *p) { return LookupNumpyDTypeT(p); }
+
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Byte, PyArray_BYTE);
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Int16, PyArray_INT16);
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::UInt16, PyArray_UINT16);
+
+#if defined(NTA_PLATFORM_linux64) || defined(NTA_PLATFORM_sparc64) || defined(NTA_PLATFORM_darwin64)
+NTA_DEF_NUMPY_DTYPE_TRAIT(size_t, PyArray_UINT64);
+#else
+NTA_DEF_NUMPY_DTYPE_TRAIT(size_t, PyArray_UINT32);
+#endif
+
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Int32, PyArray_INT32);
+
+#if !defined(NTA_PLATFORM_linux32) && !defined(NTA_PLATFORM_linux32arm) && !defined(NTA_PLATFORM_linux32armv7)
+// size_t (above) is the same as UInt32 on linux32
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::UInt32, PyArray_UINT32);
+#endif
+
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Int64, PyArray_INT64);
+
+#if !defined(NTA_PLATFORM_linux64) && !defined(NTA_PLATFORM_sparc64) && !defined(NTA_PLATFORM_darwin64)
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::UInt64, PyArray_UINT64);
+#endif
+
+
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Real32, PyArray_FLOAT32);
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Real64, PyArray_FLOAT64);
+
+#ifdef NTA_QUAD_PRECISION
+NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Real128, PyArray_FLOAT128);
+#endif
+
+// --------------------------------------------------------------
+
+
+void NumpyArray::init()
+{
+  int rc = _import_array();
+  if (rc < 0) {
+    throw std::runtime_error("NumpyArray::init(): "
+      "numpy.core.multiarray failed to import.");
+  }
+}
+
+inline void CheckInit()
+  { NumpyArray::init(); }
+
+NumpyArray::NumpyArray(int nd, const int *ndims, int dtype)
+  : p_(0), dtype_(dtype)
+{
+
+  // declare static to avoid new/delete with every call
+  static npy_intp ndims_intp[NPY_MAXDIMS];
+
+  CheckInit();
+
+  if(nd < 0)
+    throw runtime_error("Negative dimensioned arrays not supported.");
+
+  if (nd > NPY_MAXDIMS)
+    throw runtime_error("Too many dimensions specified for NumpyArray()");
+
+  /* copy into array with elements that are the correct size.
+   * npy_intp is an integer that can hold a pointer. On 64-bit
+   * systems this is not the same as an int.
+   */
+  for (int i = 0; i < nd; i++)
+  {
+    ndims_intp[i] = (npy_intp)ndims[i];
+  }
+
+  p_ = (PyArrayObject *) PyArray_SimpleNew(nd, ndims_intp, dtype);
+
+}
+
+NumpyArray::NumpyArray(PyObject *p, int dtype, int requiredDimension)
+  : p_(0), dtype_(dtype)
+{
+  CheckInit();
+
+  PyObject *contiguous = PyArray_ContiguousFromObject(p, PyArray_NOTYPE, 0, 0);
+  if(!contiguous)
+    throw std::runtime_error("Array could not be made contiguous.");
+  if(!PyArray_Check(contiguous))
+    throw std::logic_error("Failed to convert to array.");
+
+  PyObject *casted = PyArray_Cast((PyArrayObject *) contiguous, dtype);
+  Py_CLEAR(contiguous);
+
+  if(!casted) throw std::runtime_error("Array could not be cast to requested type.");
+  if(!PyArray_Check(casted)) throw std::logic_error("Array is not contiguous.");
+  PyArrayObject *final = (PyArrayObject *) casted;
+  if((requiredDimension != 0) && (final->nd != requiredDimension))
+    throw std::runtime_error("Array is not of the required dimension.");
+  p_ = final;
+}
+
+NumpyArray::~NumpyArray()
+{
+  PyObject *generic = (PyObject *) p_;
+  p_ = 0;
+  Py_CLEAR(generic);
+}
+
+int NumpyArray::getRank() const
+{
+  if(!p_) throw runtime_error("Null NumpyArray.");
+  return p_->nd;
+}
+
+int NumpyArray::dimension(int i) const
+{
+  if(!p_) throw runtime_error("Null NumpyArray.");
+  if(i < 0) throw runtime_error("Negative dimension requested.");
+  if(i >= p_->nd) throw out_of_range("Dimension exceeds number available.");
+  return int(p_->dimensions[i]);
+}
+
+void NumpyArray::getDims(int *out) const
+{
+  if(!p_) throw runtime_error("Null NumpyArray.");
+  int n = p_->nd;
+  for(int i=0; i<n; ++i) out[i] = int(p_->dimensions[i]); // npy_intp? New type in latest numpy headers.
+}
+
+const char *NumpyArray::addressOf0() const
+{
+  if(!p_) throw runtime_error("Null NumpyArray.");
+  return p_->data;
+}
+char *NumpyArray::addressOf0()
+{
+  if(!p_) throw runtime_error("Numpy NumpyArray.");
+  return p_->data;
+}
+
+int NumpyArray::stride(int i) const
+{
+  if(!p_) throw runtime_error("Numpy NumpyArray.");
+  return int(p_->strides[i]); // npy_intp? New type in latest numpy headers.
+}
+
+PyObject *NumpyArray::forPython() {
+  if(p_) {
+    Py_XINCREF(p_);
+    PyObject *toReturn = PyArray_Return((PyArrayObject *)p_);
+    return toReturn;
+  }
+  else return 0;
+}
+
+#endif // NTA_PYTHON_SUPPORT
+
+

--- a/src/python_support/NumpyVector.hpp
+++ b/src/python_support/NumpyVector.hpp
@@ -1,0 +1,430 @@
+#ifndef NTA_NUMPY_VECTOR_HPP
+#define NTA_NUMPY_VECTOR_HPP
+
+#ifdef NTA_PYTHON_SUPPORT
+
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * Contains the NumpyArray class, a wrapper for Python numpy arrays.
+ */
+
+#include <nupic/types/Types.hpp> // For nupic::Real.
+#include <algorithm> // For std::copy.
+#include <numpy/arrayobject.h>
+
+namespace nupic {
+
+  extern int LookupNumpyDType(const size_t *);
+  extern int LookupNumpyDType(const nupic::Byte *);
+  extern int LookupNumpyDType(const nupic::Int16 *);
+  extern int LookupNumpyDType(const nupic::UInt16 *);
+  extern int LookupNumpyDType(const nupic::Int32 *);
+  extern int LookupNumpyDType(const nupic::UInt32 *);
+  extern int LookupNumpyDType(const nupic::Int64 *);
+  extern int LookupNumpyDType(const nupic::UInt64 *);
+  extern int LookupNumpyDType(const nupic::Real32 *);
+  extern int LookupNumpyDType(const nupic::Real64 *);
+#if defined(NTA_QUAD_PRECISION)
+  extern int LookupNumpyDType(const nupic::Real128 *);
+#endif
+  /**
+   * Concrete Numpy multi-d array wrapper who's implementation cannot be visible
+   * due to the specifics of dynamically loading the Numpy C function API.
+   */
+  class NumpyArray
+  {
+
+    NumpyArray(const NumpyArray &); // Verboten.
+    NumpyArray &operator=(const NumpyArray &); // Verboten.
+
+  protected:
+    const PyArrayObject *p_;
+    int dtype_;
+
+    const char *addressOf0() const;
+    char *addressOf0();
+    int stride(int i) const;
+
+    NumpyArray(int nd, const int *dims, int dtype);
+    NumpyArray(PyObject *p, int dtype, int requiredDimension=0);
+
+  public:
+
+    ///////////////////////////////////////////////////////////
+    /// Destructor.
+    ///
+    /// Releases the reference to the internal numpy array.
+    ///////////////////////////////////////////////////////////
+    virtual ~NumpyArray();
+
+    ///////////////////////////////////////////////////////////
+    /// Initializes the numpy library.
+    /// Called automatically when constructing a NumpyArray.
+    ///////////////////////////////////////////////////////////
+    static void init();
+
+    ///////////////////////////////////////////////////////////
+    /// The number of dimensions of the internal numpy array.
+    ///
+    /// Will always be 1, as enforced by the constructors.
+    ///////////////////////////////////////////////////////////
+    int numDimensions() const { return getRank(); }
+
+    int getRank() const;
+
+    ///////////////////////////////////////////////////////////
+    /// Gets the size of the array along dimension i.
+    ///
+    /// Does not check the validity of the passed-in dimension.
+    ///////////////////////////////////////////////////////////
+    int dimension(int i) const;
+
+
+    void getDims(int *) const;
+
+    ///////////////////////////////////////////////////////////
+    /// Gets the size of the array (along dimension 0).
+    ///////////////////////////////////////////////////////////
+    int size() const { return dimension(0); }
+
+    ///////////////////////////////////////////////////////////
+    /// Returns a PyObject that can be returned from C code to Python.
+    ///
+    /// The PyObject returned is a new reference, and the caller must
+    /// dereference the object when done.
+    /// The PyObject is produced by PyArray_Return (whatever that does).
+    ///////////////////////////////////////////////////////////
+    PyObject *forPython();
+
+  };
+
+  ///////////////////////////////////////////////////////////
+  /// A wrapper for 1D numpy arrays of data type equaivalent to nupic::Real.
+  ///
+  /// Numpy is a Python extension written in C.
+  /// Accessing numpy's C API directly is tricky but possible.
+  /// Such access can be performed with SWIG typemaps,
+  /// using a slow and feature-poor set of SWIG typemap definitions
+  /// provided as an example with the numpy documentation.
+  /// This class bypasses that method of access, in favor of
+  /// a faster interface that nags (warns) about potential performance
+  /// problems. This wrapper should only be used within Python bindings,
+  /// as numpy data structures will only be passed in from Python code.
+  /// For an example of its use, see the nupic::SparseMatrix Python bindings
+  /// in nupic/python/bindings/math/SparseMatrix.i
+  ///////////////////////////////////////////////////////////
+  template<typename T=nupic::Real>
+  class NumpyVectorT : public NumpyArray
+  {
+
+    NumpyVectorT(const NumpyVectorT<T> &); // Verboten.
+    NumpyVectorT<T> &operator=(const NumpyVectorT<T> &); // Verboten.
+
+  public:
+
+    ///////////////////////////////////////////////////////////
+    /// Create a new 1D numpy array of size n.
+    ///////////////////////////////////////////////////////////
+    NumpyVectorT(int n, const T& val=0)
+      : NumpyArray(1, &n, LookupNumpyDType((const T *) 0))
+    {
+      std::fill(begin(), end(), val);
+    }
+
+    NumpyVectorT(int n, const T *val)
+      : NumpyArray(1, &n, LookupNumpyDType((const T *) 0))
+    {
+      if(val) std::copy(val, val+n, begin());
+    }
+
+    ///////////////////////////////////////////////////////////
+    /// Reference an existing 1D numpy array, or copy it if
+    /// it differs in type.
+    ///
+    /// Produces a really annoying warning if this will do a slow copy.
+    /// Do not use in this case. Make sure the data coming in is in
+    /// the appropriate format (1D contiguous numpy array of type
+    /// equivalent to nupic::Real). If nupic::Real is float,
+    /// the incoming array should have been created with dtype=numpy.float32
+    ///
+    /// @note I do not believe the data is copied unless necessary.
+    ///       This has not been confirmed.
+    ///       This means that ownership has two very different semantics:
+    ///       if the data is not copied, then any modifications to this
+    ///       vector affect the original.
+    ///       If the data is copied (slow), then any modifications do not
+    ///       affect the original.
+    ///////////////////////////////////////////////////////////
+    NumpyVectorT(PyObject *p)
+      : NumpyArray(p, LookupNumpyDType((const T *) 0), 1)
+    {}
+
+    virtual ~NumpyVectorT() {}
+
+    T* begin() { return addressOf(0); }
+    T* end() { return begin() + size(); }
+    const T* begin() const { return addressOf(0); }
+    const T* end() const { return begin() + size(); }
+
+    ///////////////////////////////////////////////////////////
+    /// Get a pointer to element i.
+    ///
+    /// Does not check the validity of the index.
+    ///////////////////////////////////////////////////////////
+    const T *addressOf(int i) const
+    { return (const T *) (addressOf0() + i*stride(0)); }
+
+    ///////////////////////////////////////////////////////////
+    /// Get a non-const pointer to element i.
+    ///
+    /// Does not check the validity of the index.
+    ///////////////////////////////////////////////////////////
+    T *addressOf(int i)
+    { return (T *) (addressOf0() + i*stride(0)); }
+
+    ///////////////////////////////////////////////////////////
+    /// Get the increment (in number of Reals) from one element
+    /// to the next.
+    ///////////////////////////////////////////////////////////
+    int incr() const { return int(addressOf(1) - addressOf(0)); }
+
+    inline T& get(int i) { return *addressOf(i); }
+    inline T get(int i) const { return *addressOf(i); }
+    inline void set(int i, const T& val) { *addressOf(i) = val; }
+  };
+
+  //--------------------------------------------------------------------------------
+  template<typename T=nupic::Real>
+  class NumpyMatrixT : public NumpyArray
+  {
+    NumpyMatrixT(const NumpyMatrixT &); // Verboten.
+    NumpyMatrixT &operator=(const NumpyMatrixT &); // Verboten.
+
+  public:
+
+    typedef int size_type;
+
+    ///////////////////////////////////////////////////////////
+    /// Create a new 2D numpy array of size n.
+    ///////////////////////////////////////////////////////////
+    NumpyMatrixT(const int nRowsCols[2])
+      : NumpyArray(2, nRowsCols, LookupNumpyDType((const T *) 0))
+    {}
+
+    NumpyMatrixT(PyObject *p)
+      : NumpyArray(p, LookupNumpyDType((const T *) 0), 2)
+    {}
+
+    ///////////////////////////////////////////////////////////
+    /// Destructor.
+    ///
+    /// Releases the reference to the internal numpy array.
+    ///////////////////////////////////////////////////////////
+    virtual ~NumpyMatrixT() {}
+
+    int rows() const { return dimension(0); }
+    int columns() const { return dimension(1); }
+    int nRows() const { return dimension(0); }
+    int nCols() const { return dimension(1); }
+
+    inline const T *addressOf(int row, int col) const
+    { return (const T *) (addressOf0() + row*stride(0) + col*stride(1)); }
+
+    inline T *addressOf(int row, int col)
+    { return (T *) (addressOf0() + row*stride(0) + col*stride(1)); }
+
+    inline const T* begin(int row) const
+    { return (const T*)(addressOf0() + row*stride(0)); }
+
+    inline const T* end(int row) const
+    { return (const T*)(addressOf0() + row*stride(0) + nCols()*stride(1)); }
+
+    inline T* begin(int row)
+    { return (T*)(addressOf0() + row*stride(0)); }
+
+    inline T* end(int row)
+    { return (T*)(addressOf0() + row*stride(0) + nCols()*stride(1)); }
+
+    inline T& get(int i, int j) { return *addressOf(i,j); }
+    inline T get(int i, int j) const { return *addressOf(i,j); }
+    inline void set(int i, int j, const T& val) { *addressOf(i,j) = val; }
+  };
+
+  template<typename T=nupic::Real>
+  class NumpyNDArrayT : public NumpyArray
+  {
+    NumpyNDArrayT(const NumpyNDArrayT &); // Verboten.
+    NumpyNDArrayT &operator=(const NumpyNDArrayT &); // Verboten.
+
+  public:
+    NumpyNDArrayT(PyObject *p)
+      : NumpyArray(p, LookupNumpyDType((const T *) 0))
+    {}
+    NumpyNDArrayT(int rank, const int *dims)
+      : NumpyArray(rank, dims, LookupNumpyDType((const T *) 0))
+    {}
+    virtual ~NumpyNDArrayT() {}
+
+    const T *getData() const { return (const T *) addressOf0(); }
+    T *getData() { return (T *) addressOf0(); }
+  };
+
+  //--------------------------------------------------------------------------------
+  typedef NumpyVectorT<> NumpyVector;
+  typedef NumpyMatrixT<> NumpyMatrix;
+  typedef NumpyNDArrayT<> NumpyNDArray;
+
+  //--------------------------------------------------------------------------------
+  template <typename T>
+  inline T convertToValueType(PyObject *val)
+  {
+    return * nupic::NumpyNDArrayT<T>(val).getData();
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename T>
+  inline PyObject* convertFromValueType(const T& value) {
+    nupic::NumpyNDArrayT<T> ret(0, NULL);
+    *ret.getData() = value;
+    return ret.forPython();
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename I, typename T>
+  inline PyObject* convertToPairOfLists(I i_begin, I i_end, T val)
+  {
+    const size_t n = (size_t) (i_end - i_begin);
+
+    PyObject *indOut = PyTuple_New(n);
+    // Steals the new references.
+    for (size_t i = 0; i != n; ++i, ++i_begin)
+      PyTuple_SET_ITEM(indOut, i, PyInt_FromLong(*i_begin));
+
+    PyObject *valOut = PyTuple_New(n);
+    // Steals the new references.
+    for (size_t i = 0; i != n; ++i, ++val)
+      PyTuple_SET_ITEM(valOut, i, PyFloat_FromDouble(*val));
+
+    PyObject *toReturn = PyTuple_New(2);
+    // Steals the index tuple reference.
+    PyTuple_SET_ITEM(toReturn, 0, indOut);
+    // Steals the index tuple reference.
+    PyTuple_SET_ITEM(toReturn, 1, valOut);
+
+    // Returns a single new reference.
+    return toReturn;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename I, typename T>
+  inline PyObject* createPair32(I i, T v)
+  {
+    PyObject *result = PyTuple_New(2);
+    PyTuple_SET_ITEM(result, 0, PyInt_FromLong(i));
+    PyTuple_SET_ITEM(result, 1, PyFloat_FromDouble(v));
+    return result;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename I, typename T>
+  inline PyObject* createPair64(I i, T v)
+  {
+    PyObject *result = PyTuple_New(2);
+    PyTuple_SET_ITEM(result, 0, PyLong_FromLongLong(i));
+    PyTuple_SET_ITEM(result, 1, PyFloat_FromDouble(v));
+    return result;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename I, typename T>
+  inline PyObject* createTriplet32(I i1, I i2, T v1)
+  {
+    PyObject *result = PyTuple_New(3);
+    PyTuple_SET_ITEM(result, 0, PyInt_FromLong(i1));
+    PyTuple_SET_ITEM(result, 1, PyInt_FromLong(i2));
+    PyTuple_SET_ITEM(result, 2, PyFloat_FromDouble(v1));
+    return result;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename I, typename T>
+  inline PyObject* createTriplet64(I i1, I i2, T v1)
+  {
+    PyObject *result = PyTuple_New(3);
+    PyTuple_SET_ITEM(result, 0, PyLong_FromLongLong(i1));
+    PyTuple_SET_ITEM(result, 1, PyLong_FromLongLong(i2));
+    PyTuple_SET_ITEM(result, 2, PyFloat_FromDouble(v1));
+    return result;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename TIter>
+  PyObject* PyInt32Vector(TIter begin, TIter end)
+  {
+    Py_ssize_t n = end - begin;
+    PyObject *p = PyTuple_New(n);
+    Py_ssize_t i = 0;
+    for (TIter cur=begin; cur!=end; ++cur, ++i) {
+      PyTuple_SET_ITEM(p, i, PyInt_FromLong(*cur));
+    }
+
+    return p;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename TIter>
+  PyObject* PyInt64Vector(TIter begin, TIter end)
+  {
+    Py_ssize_t n = end - begin;
+    PyObject *p = PyTuple_New(n);
+    Py_ssize_t i = 0;
+    for (TIter cur=begin; cur!=end; ++cur, ++i) {
+      PyTuple_SET_ITEM(p, i, PyLong_FromLongLong(*cur));
+    }
+
+    return p;
+  }
+
+  //--------------------------------------------------------------------------------
+  template <typename TIter>
+  PyObject* PyFloatVector(TIter begin, TIter end)
+  {
+    Py_ssize_t n = end - begin;
+    PyObject *p = PyTuple_New(n);
+    Py_ssize_t i = 0;
+    for (TIter cur=begin; cur!=end; ++cur, ++i) {
+      PyTuple_SET_ITEM(p, i, PyFloat_FromDouble(*cur));
+    }
+
+    return p;
+  }
+
+  //--------------------------------------------------------------------------------
+
+} // End namespace nupic.
+
+#endif // NTA_PYTHON_SUPPORT
+
+#endif
+

--- a/src/python_support/PyArray.cpp
+++ b/src/python_support/PyArray.cpp
@@ -1,0 +1,348 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+// The Python.h #include MUST always be #included first in every
+// compilation unit (.c or .cpp file). That means that PyHelpers.hpp
+// must be #included first and transitively every .hpp file that 
+// #includes directly or indirectly PyHelpers.hpp must be #included
+// first.
+#include <Python.h>
+
+#include "PyArray.hpp"
+#include <nupic/utils/Log.hpp>
+
+#include <numpy/arrayobject.h>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+namespace nupic
+{    
+  // -------------------------------------
+  //
+  //  G E T   B A S I C   T Y P E
+  //
+  // -------------------------------------
+
+  NTA_BasicType getBasicType(NTA_Byte) { return NTA_BasicType_Byte; }
+  NTA_BasicType getBasicType(NTA_Int16) { return NTA_BasicType_Int16; }
+  NTA_BasicType getBasicType(NTA_UInt16) { return NTA_BasicType_UInt16; }
+  NTA_BasicType getBasicType(NTA_Int32) { return NTA_BasicType_Int32; }
+  NTA_BasicType getBasicType(NTA_UInt32) { return NTA_BasicType_UInt32; }
+  NTA_BasicType getBasicType(NTA_Int64) { return NTA_BasicType_Int64; }
+  NTA_BasicType getBasicType(NTA_UInt64) { return NTA_BasicType_UInt64; }
+  NTA_BasicType getBasicType(NTA_Real32) { return NTA_BasicType_Real32; }
+  NTA_BasicType getBasicType(NTA_Real64) { return NTA_BasicType_Real64; }
+
+  // -------------------------------------
+  //
+  //  A R R A Y    2   N U M P Y
+  //
+  // -------------------------------------
+  // Wrap an Array object with a numpy array PyObject
+
+  static void initNumpy()
+  {
+    import_array();
+  }
+
+  PyObject * array2numpy(const ArrayBase & a)
+  {
+    initNumpy();
+
+    npy_intp dims[1];
+    dims[0] = npy_intp(a.getCount());
+
+    NTA_BasicType t = a.getType();
+    int dtype;
+    switch (t)
+    {
+    case NTA_BasicType_Byte: 
+      dtype = PyArray_INT8; 
+      break;      
+    case NTA_BasicType_Int16: 
+      dtype = PyArray_INT16; 
+      break;      
+    case NTA_BasicType_UInt16: 
+      dtype = PyArray_UINT16; 
+      break;      
+    case NTA_BasicType_Int32: 
+      dtype = PyArray_INT32; 
+      break;      
+    case NTA_BasicType_UInt32: 
+      dtype = PyArray_UINT32; 
+      break;      
+    case NTA_BasicType_Int64: 
+      dtype = PyArray_INT64; 
+      break;      
+    case NTA_BasicType_UInt64: 
+      dtype = PyArray_UINT64; 
+      break;      
+    case NTA_BasicType_Real32: 
+      dtype = PyArray_FLOAT32; 
+      break;      
+    case NTA_BasicType_Real64: 
+      dtype = PyArray_FLOAT64; 
+      break;      
+    default:
+      NTA_THROW << "Unknown basic type: " << t;
+    };
+
+    return (PyObject *)PyArray_SimpleNewFromData(1,
+                                                 dims,
+                                                 dtype,
+                                                 a.getBuffer());
+  }
+
+//// -------------------------------------
+////
+////  P Y   A R R A Y   B A S E
+////
+//// -------------------------------------  
+//  template <typename T, typename A>
+//  PyArrayBase<T, A>::PyArrayBase() : A(getType())
+//  {
+//  }
+//
+//  //template <typename T, typename A>
+//  //PyArrayBase<T, A>::PyArrayBase(ArrayBase * a) : A(*(static_cast<A *>(a)))
+//  //{
+//  //}
+//
+//  //template <typename T, typename A>
+//  //PyArrayBase<T, A>::PyArrayBase(A * a) : A(*a)
+//  //{
+//  //}
+//    
+//  template <typename T, typename A>
+//  NTA_BasicType PyArrayBase<T, A>::getType()
+//  {
+//    T t = 0;
+//    return getBasicType(t);
+//  }
+//  
+//  template <typename T, typename A>
+//  T PyArrayBase<T, A>::__getitem__(int i) const
+//  { 
+//    return ((T *)(A::getBuffer()))[i];
+//  }
+//
+//  template <typename T, typename A>
+//  void PyArrayBase<T, A>::__setitem__(int i, T x)
+//  { 
+//    ((T *)(A::getBuffer()))[i] = x;
+//  }
+//
+//  template <typename T, typename A>
+//  size_t PyArrayBase<T, A>::__len__() const
+//  {
+//    return A::getCount();
+//  }
+//
+//  template <typename T, typename A>
+//  std::string PyArrayBase<T, A>::__repr__() const
+//  {
+//    std::stringstream ss;
+//    ss << "[ ";
+//    for (size_t i = 0; i < __len__(); ++i)
+//      ss << __getitem__(i) << " ";
+//    ss << "]";
+//    return ss.str();
+//  }
+//
+//  template <typename T, typename A>
+//  std::string PyArrayBase<T, A>::__str__() const
+//  {
+//    return __repr__();
+//  }
+//
+//  template <typename T, typename A>
+//  PyObject * PyArrayBase<T, A>::asNumpyArray() const
+//  {
+//    return array2numpy(*this);
+//  }  
+
+// -------------------------------------
+//
+//  P Y   A R R A Y
+//
+// -------------------------------------
+  template <typename T>
+  PyArray<T>::PyArray() : Array(getType())
+  //PyArray<T>::PyArray() : PyArrayBase<T, Array>()
+  {
+  }
+  
+  template <typename T>
+  //PyArray<T>::PyArray(size_t count) : PyArrayBase<T, Array>()
+  PyArray<T>::PyArray(size_t count) : Array(getType())
+  {
+    allocateBuffer(count);
+  }
+
+  template <typename T>
+  NTA_BasicType PyArray<T>::getType()
+  {
+    T t = 0;
+    return getBasicType(t);
+  }
+
+  template <typename T>
+  T PyArray<T>::__getitem__(int i) const
+  { 
+    return ((T *)(getBuffer()))[i];
+    //return PyArrayBase<T, Array>::__getitem__(i);
+  }
+
+  template <typename T>
+  void PyArray<T>::__setitem__(int i, T x)
+  {
+    ((T *)(getBuffer()))[i] = x;
+    //PyArrayBase<T, Array>::__setitem__(i, x);
+  }
+
+  template <typename T>
+  size_t PyArray<T>::__len__() const
+  {
+    return getCount();
+    //return PyArrayBase<T, Array>::__len__();
+  }
+
+  template <typename T>
+  std::string PyArray<T>::__repr__() const
+  {
+    std::stringstream ss;
+    ss << "[ ";
+    for (size_t i = 0; i < __len__(); ++i)
+      ss << __getitem__(i) << " ";
+    ss << "]";
+    return ss.str();
+
+    //return PyArrayBase<T, Array>::__repr__();
+  }
+
+  template <typename T>
+  std::string PyArray<T>::__str__() const
+  {
+    return __repr__();
+    //return PyArrayBase<T, Array>::__str__();
+  }
+
+  template <typename T>
+  PyObject * PyArray<T>::asNumpyArray() const
+  {
+    return array2numpy(*this);
+    //return PyArrayBase<T, Array>::asNumpyArray();
+  }
+
+// -------------------------------------
+//
+//  P Y   A R R A Y   R E F
+//
+// -------------------------------------
+  template <typename T>
+  PyArrayRef<T>::PyArrayRef() : ArrayRef(getType())
+  {
+  }
+
+  template <typename T>
+  PyArrayRef<T>::PyArrayRef(const ArrayRef & a) : ArrayRef(a)
+  {
+  }
+
+  template <typename T>
+  NTA_BasicType PyArrayRef<T>::getType()
+  {
+    T t = 0;
+    return getBasicType(t);
+  }
+
+  template <typename T>
+  T PyArrayRef<T>::__getitem__(int i) const
+  { 
+    return ((T *)(getBuffer()))[i];
+    //return PyArrayBase<T, Array>::__getitem__(i);
+  }
+
+  template <typename T>
+  void PyArrayRef<T>::__setitem__(int i, T x)
+  {
+    ((T *)(getBuffer()))[i] = x;
+    //PyArrayBase<T, Array>::__setitem__(i, x);
+  }
+
+  template <typename T>
+  size_t PyArrayRef<T>::__len__() const
+  {
+    return getCount();
+    //return PyArrayBase<T, Array>::__len__();
+  }
+
+  template <typename T>
+  std::string PyArrayRef<T>::__repr__() const
+  {
+    std::stringstream ss;
+    ss << "[ ";
+    for (size_t i = 0; i < __len__(); ++i)
+      ss << __getitem__(i) << " ";
+    ss << "]";
+    return ss.str();
+
+    //return PyArrayBase<T, Array>::__repr__();
+  }
+
+  template <typename T>
+  std::string PyArrayRef<T>::__str__() const
+  {
+    return __repr__();
+    //return PyArrayBase<T, Array>::__str__();
+  }
+
+  template <typename T>
+  PyObject * PyArrayRef<T>::asNumpyArray() const
+  {
+    return array2numpy(*this);
+    //return PyArrayBase<T, Array>::asNumpyArray();
+  }
+
+
+  template class PyArray<NTA_Byte>;
+  template class PyArray<NTA_Int16>;
+  template class PyArray<NTA_UInt16>;
+  template class PyArray<NTA_Int32>;
+  template class PyArray<NTA_UInt32>;
+  template class PyArray<NTA_Int64>;
+  template class PyArray<NTA_UInt64>;
+  template class PyArray<NTA_Real32>;
+  template class PyArray<NTA_Real64>;
+  
+  template class PyArrayRef<NTA_Byte>;
+  template class PyArrayRef<NTA_Int16>;
+  template class PyArrayRef<NTA_UInt16>;
+  template class PyArrayRef<NTA_Int32>;
+  template class PyArrayRef<NTA_UInt32>;
+  template class PyArrayRef<NTA_Int64>;
+  template class PyArrayRef<NTA_UInt64>;
+  template class PyArrayRef<NTA_Real32>;
+  template class PyArrayRef<NTA_Real64>;  
+}
+

--- a/src/python_support/PyArray.hpp
+++ b/src/python_support/PyArray.hpp
@@ -1,0 +1,141 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file 
+ * Definitions for the PyArrayBase class
+  * 
+  * A PyArrayBase object is a Python compatible wrapper around an nupic::Array object
+  * 
+  * It delegates everything to its Array and exposes a Python facade that
+  * includes: indexed access with operator[], len() support, An Array contains:
+  * - a pointer to a buffer
+  * - a length
+  * - a type
+  * - a flag indicating whether or not the object owns the buffer. 
+  */
+
+#ifndef NTA_PY_ARRAY_HPP
+#define NTA_PY_ARRAY_HPP
+
+#include <python_support/PyHelpers.hpp>
+#include <nupic/types/Types.h>
+#include <nupic/ntypes/Array.hpp>
+#include <nupic/ntypes/ArrayRef.hpp>
+
+namespace nupic
+{
+// -------------------------------------
+//
+//  G E T   B A S I C   T Y P E
+//
+// -------------------------------------
+
+NTA_BasicType getBasicType(NTA_Byte);
+NTA_BasicType getBasicType(NTA_Int16);
+NTA_BasicType getBasicType(NTA_UInt16);
+NTA_BasicType getBasicType(NTA_Int32);
+NTA_BasicType getBasicType(NTA_UInt32);
+NTA_BasicType getBasicType(NTA_Int64);
+NTA_BasicType getBasicType(NTA_UInt64);
+NTA_BasicType getBasicType(NTA_Real32);
+NTA_BasicType getBasicType(NTA_Real64);
+
+// -------------------------------------
+//
+//  A R R A Y    2   N U M P Y
+//
+// -------------------------------------
+// Wrap an Array object with a numpy array PyObject
+PyObject * array2numpy(const ArrayBase & a);
+
+// -------------------------------------
+//
+//  P Y   A R R A Y   B A S E
+//
+// -------------------------------------
+//template<typename T, typename A>
+//class PyArrayBase : public A
+//{
+//public:
+//  PyArrayBase();
+//  //PyArrayBase(A * a);
+//  //PyArrayBase(ArrayBase * a);
+//    
+//  NTA_BasicType getType();
+//  T __getitem__(int i) const;
+//  void __setitem__(int i, T x);
+//  size_t __len__() const;
+//  std::string __repr__() const;
+//  std::string __str__() const;
+//  PyObject * asNumpyArray() const;
+//};
+
+// -------------------------------------
+//
+//  P Y   A R R A Y
+//
+// -------------------------------------
+template<typename T>
+class PyArray : public Array //public PyArrayBase<T, Array>
+{
+public:
+  PyArray();
+  PyArray(size_t count);
+  //PyArray(Array * a);    
+  //PyArray(ArrayBase * a);    
+
+  NTA_BasicType getType();
+  T __getitem__(int i) const;
+  void __setitem__(int i, T x);
+  size_t __len__() const;
+  std::string __repr__() const;
+  std::string __str__() const;
+  PyObject * asNumpyArray() const;
+};
+
+
+// -------------------------------------
+//
+//  P Y   A R R A Y   R E F
+//
+// -------------------------------------
+template<typename T>
+class PyArrayRef : public ArrayRef
+{
+public:
+  PyArrayRef();
+  PyArrayRef(const ArrayRef & a);
+  
+  NTA_BasicType getType();
+  T __getitem__(int i) const;
+  void __setitem__(int i, T x);
+  size_t __len__() const;
+  std::string __repr__() const;
+  std::string __str__() const;
+  PyObject * asNumpyArray() const;
+};
+
+
+}
+
+#endif
+

--- a/src/python_support/PyHelpers.cpp
+++ b/src/python_support/PyHelpers.cpp
@@ -1,0 +1,769 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+
+#include "PyHelpers.hpp"
+
+// Nested namespace nupic::py
+namespace nupic { namespace py
+{
+  static bool runningUnderPython = false;
+  
+  void setRunningUnderPython()
+  {
+    runningUnderPython = true;
+  }
+  
+  // ---
+  // Get the stack trace from a Python tracebak object
+  // ---
+  static std::string getTraceback(PyObject * p)
+  {
+    if (!p)
+      return "";
+
+    std::stringstream ss;
+
+    PyTracebackObject * tb = (PyTracebackObject *)p;
+    NTA_CHECK(PyTraceBack_Check(tb));
+
+    while (tb)
+    {
+      PyCodeObject * c = tb->tb_frame->f_code;
+      std::string filename(PyString_AsString(c->co_filename));
+      std::string function(PyString_AsString(c->co_name));
+      int lineno = tb->tb_lineno;
+      // Read source line from the file (assumes line is shorter than 256)
+      char line[256];
+      std::ifstream f(filename.c_str());
+      for (int i = 0; i < lineno; ++i)
+      {
+        f.getline(line, 256);
+      }
+
+      ss << "  File \" " 
+         << filename
+         << ", line " << lineno << ", in " 
+         << function
+         << std::endl
+         << std::string(line)
+         << std::endl;
+      
+      tb = tb->tb_next;
+    }
+
+    return ss.str();
+  }
+
+  void checkPyError(int lineno)
+  {
+    if (!PyErr_Occurred())
+      return;
+
+    PyObject * exceptionClass = NULL; 
+    PyObject * exceptionValue = NULL; 
+    PyObject * exceptionTraceback = NULL; 
+
+    // Get the Python exception info
+    PyErr_Fetch(&exceptionClass,
+                &exceptionValue,
+                &exceptionTraceback);
+
+    if (!exceptionValue)
+    {
+      NTA_THROW << "Python exception raised. Unable to extract info";
+    }
+
+    // Normalize the exception value to make sure
+    // it is an instance of the exception class
+    // (Python often goes crazy with exception values)
+    PyErr_NormalizeException(&exceptionClass,
+                             &exceptionValue,
+                             &exceptionTraceback);
+    
+    std::string exception;
+    std::string traceback;
+    if (exceptionValue)
+    {
+      // Extract the exception message as a string
+      PyObject * sExcValue = PyObject_Str(exceptionValue);
+      exception = std::string(PyString_AsString(sExcValue));
+      traceback = getTraceback(exceptionTraceback);
+
+      Py_XDECREF(sExcValue);
+    }
+
+    // If running under Python restore the fetched exception so it can
+    // be handled at the Python interpreter level
+    
+    if (runningUnderPython)
+    {
+      PyErr_Restore(exceptionClass, exceptionValue, exceptionTraceback);
+    }
+    else 
+    {
+      //PyErr_Clear();
+      Py_XDECREF(exceptionClass);
+      Py_XDECREF(exceptionTraceback);
+      Py_XDECREF(exceptionValue);
+    }
+
+    // Throw a correponding C++ exception
+    throw nupic::Exception(__FILE__, lineno, exception, traceback);
+  }
+
+  // ---
+  // Implementation of Ptr class
+  // ---
+  Ptr::Ptr(PyObject * p, bool allowNULL) : p_(p), allowNULL_(allowNULL)
+  {
+    if (!p && !allowNULL)
+      NTA_THROW << "The PyObject * is NULL";
+  }
+
+  Ptr::~Ptr()
+  {
+    Py_XDECREF(p_);
+  }
+
+  PyObject * Ptr::release()
+  {
+    PyObject * result = p_;
+    p_ = NULL;
+    return result;
+  }
+
+  std::string Ptr::getTypeName()
+  {
+    if (!p_)
+      return "(NULL)";
+
+    // Do not wrap t in a Ptr object because it will break
+    // the tracing macros (with recursive calls)
+    PyObject * t = PyObject_Type(p_);
+    std::string result(((PyTypeObject *)t)->tp_name);
+    Py_DECREF(t);
+
+    if (PyString_Check(p_)) 
+    {
+      result += "\"" + std::string(PyString_AsString(p_)) + "\"";
+    }
+    return result;
+  }
+
+  void Ptr::assign(PyObject * p)
+  {
+    // Identity check
+    if (p == p_)
+      return;
+
+    // Check for NULL and allow NULL
+    NTA_CHECK(p || allowNULL_);
+    
+    // Verify that the new object type matches the current type
+    // unless one of them is NULL
+    if (p && p_)
+    {        
+      NTA_CHECK(PyObject_Type(p_) == PyObject_Type(p));
+    }
+
+    // decrease ref count of the existing pointer if not NULL
+    Py_XDECREF(p_);
+    
+    // Assign the new pointer
+    p_ = p;
+    
+    // increment the ref count of the new pointer if not NULL
+    Py_XINCREF(p_);
+  }
+
+  Ptr::operator PyObject *() 
+  {
+    return p_; 
+  }
+
+  Ptr::operator const PyObject *() const 
+  { 
+    return p_; 
+  }
+
+  bool Ptr::isNULL()
+  {
+    return p_ == NULL;
+  }
+
+
+  // ---
+  // Implementation of String class
+  // ---
+  String::String(const std::string & s, bool allowNULL) : 
+        Ptr(createString_(s.c_str(), s.size()), allowNULL)
+  {
+  }
+    
+  String::String(const char * s, size_t size, bool allowNULL) :
+      Ptr(createString_(s, size), allowNULL)
+  {
+  }
+
+  String::String(const char * s, bool allowNULL) :
+    Ptr(createString_(s), allowNULL)
+  {
+  }
+
+  String::String(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyString_Check(p));
+  }
+
+  String::operator const char * ()
+  {
+    if (!p_)
+      return NULL;
+
+    return PyString_AsString(p_);
+  }
+
+  PyObject * String::createString_(const char * s, size_t size)
+  {
+    NTA_CHECK(size >= 0) << "String length must not be negative";
+    if (size == 0)
+    {
+      NTA_CHECK(s) << "The input string must not be NULL when size == 0";
+      size = ::strlen(s);
+    }
+    return PyString_FromStringAndSize(s, size);
+  }
+
+  // --- 
+  // Implementation of Int class
+  // ---
+  Int::Int(long n) : Ptr(PyInt_FromLong(n))
+  {
+  }
+  
+  Int::Int(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyInt_Check(p));
+  }
+
+  Int::operator long()
+  {
+    NTA_CHECK(p_);
+    return PyInt_AsLong(p_);
+  }
+
+
+  // --- 
+  // Implementation of Long class
+  // ---
+  Long::Long(long n) : Ptr(PyInt_FromLong(n))
+  {
+  }
+  
+  Long::Long(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyLong_Check(p) || PyInt_Check(p));
+  }
+
+  Long::operator long()
+  {
+    NTA_CHECK(p_);
+    return PyInt_AsLong(p_);
+  }
+
+  // --- 
+  // Implementation of UnsignedLong class
+  // ---
+  UnsignedLong::UnsignedLong(unsigned long n) : Ptr(PyInt_FromLong((long)n))
+  {
+  }
+  
+  UnsignedLong::UnsignedLong(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyLong_Check(p) || PyInt_Check(p));
+  }
+
+  UnsignedLong::operator unsigned long()
+  {
+    NTA_CHECK(p_);
+    return (unsigned long)PyInt_AsLong(p_);
+  }
+
+  // --- 
+  // Implementation of LongLong class
+  // ---
+  LongLong::LongLong(long long n) : Ptr(PyLong_FromLongLong(n))
+  {
+  }
+  
+  LongLong::LongLong(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyLong_Check(p) || PyInt_Check(p));
+  }
+
+  LongLong::operator long long()
+  {
+    NTA_CHECK(p_);
+    return PyLong_AsLongLong(p_);
+  }
+
+
+  // --- 
+  // Implementation of UnsignedLongLong class
+  // ---
+  UnsignedLongLong::UnsignedLongLong(unsigned long long n) : 
+    Ptr(PyLong_FromUnsignedLongLong(n))
+  {
+  }
+  
+  UnsignedLongLong::UnsignedLongLong(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyLong_Check(p) || PyInt_Check(p));
+  }
+
+  UnsignedLongLong::operator unsigned long long()
+  {
+    NTA_CHECK(p_);
+    return PyLong_AsUnsignedLongLong(p_);
+  }
+
+  // --- 
+  // Implementation of Float class
+  // ---
+  Float::Float(const char * n) : Ptr(PyFloat_FromString(String(n), NULL))
+  {
+  }
+
+  Float::Float(double n) : Ptr(PyFloat_FromDouble(n))
+  {
+  }
+  
+  Float::Float(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyFloat_Check(p));
+  }
+
+  Float::operator double()
+  {
+    NTA_CHECK(p_);
+
+    return PyFloat_AsDouble(p_);
+  }
+
+  double Float::getMax()
+  {
+    return PyFloat_GetMax();
+  }
+
+  double Float::getMin()
+  {
+    return PyFloat_GetMin();
+  }
+
+  // --- 
+  // Implementation of Tuple class
+  // ---
+  Tuple::Tuple(PyObject * p) :
+    Ptr(p),
+    size_(PyTuple_Size(p))
+  {
+  }
+  
+  Tuple::Tuple(Py_ssize_t size) :
+    Ptr(PyTuple_New(size)),
+    size_(size)
+  {
+  }
+
+  void Tuple::assign(PyObject * p)
+  {
+    Ptr::assign(p);
+    size_ = PyTuple_Size(p);
+  }
+
+  PyObject * Tuple::getItem(Py_ssize_t index)
+  {
+    NTA_CHECK(index < size_);
+    PyObject * p = PyTuple_GetItem(p_, index);
+    NTA_CHECK(p);
+    // Increment refcount of borrowed item (caller must DECREF)
+    Py_INCREF(p);
+    return p;
+  }
+
+  PyObject * Tuple::fastGetItem(Py_ssize_t index)
+  {
+    NTA_ASSERT(index < getCount());
+    PyObject * p = PyTuple_GET_ITEM(p_, index);
+    NTA_ASSERT(p);
+    return p;
+  }
+
+  void Tuple::setItem(Py_ssize_t index, PyObject * item)
+  {
+    NTA_CHECK(item);
+    NTA_CHECK(index < getCount());
+
+    // Increment refcount, so caller still needs to DECREF the item
+    // eventhough PyTuple_SetItem steals the reference
+    Py_INCREF(item);
+
+    //! item reference is stolen here
+    int res = PyTuple_SetItem(p_, index, item);
+    NTA_CHECK(res == 0);
+  }
+
+  Py_ssize_t Tuple::getCount()
+  {
+    return PyTuple_Size(p_);
+  }
+
+  // --- 
+  // Implementation of List class
+  // ---
+  List::List(PyObject * p) : Ptr(p)
+  {
+  }
+
+
+  List::List() : Ptr(PyList_New(0))
+  {
+  }
+
+  PyObject * List::getItem(Py_ssize_t index)
+  {
+    NTA_CHECK(index < getCount());
+    PyObject * p = PyList_GetItem(p_, index);
+    NTA_CHECK(p);
+    // Increment refcount of borrowed item (caller must DECREF)
+    Py_INCREF(p);
+    return p;
+  }
+
+  PyObject * List::fastGetItem(Py_ssize_t index)
+  {
+    NTA_ASSERT(index < getCount());
+    PyObject * p = PyList_GET_ITEM(p_, index);
+    NTA_ASSERT(p);
+    return p;
+  }
+
+  void List::setItem(Py_ssize_t index, PyObject * item)
+  {
+    NTA_CHECK(item);
+    NTA_CHECK(index < getCount());
+
+    // Increment refcount, so caller still needs to DECREF the item
+    // eventhough PyList_SetItem steals the reference
+    Py_INCREF(item);
+
+    //! item reference is stolen here
+    int res = PyList_SetItem(p_, index, item);
+    NTA_CHECK(res == 0);
+  }
+
+  void List::append(PyObject * item)
+  {
+    NTA_CHECK(item);
+
+    int res = PyList_Append(p_, item);
+    NTA_CHECK(res == 0);
+  }
+
+  Py_ssize_t List::getCount()
+  {
+    return PyList_Size(p_);
+  }
+
+  // --- 
+  // Implementation of Dict class
+  // ---
+  Dict::Dict() : Ptr(PyDict_New())
+  {
+  }
+
+  Dict::Dict(PyObject * dict) : Ptr(dict)
+  {
+    NTA_CHECK(PyDict_Check(dict));
+  }
+
+  PyObject * Dict::getItem(const std::string & name, PyObject * defaultItem)
+  {
+    // PyDict_GetItem() returns a borrowed reference
+    PyObject * pItem = PyDict_GetItem(p_, String(name));
+    if (!pItem)
+      return defaultItem;
+
+    // Increment ref count, so the caller has to call DECREF
+    Py_INCREF(pItem);
+
+    return pItem;
+  }
+
+  void Dict::setItem(const std::string & name, PyObject * pItem)
+  {
+    int res = PyDict_SetItem(p_, String(name), pItem);
+    NTA_CHECK(res == 0);
+  }
+
+
+  // --- 
+  // Implementation of Module class
+  // ---
+  Module::Module(const std::string & moduleName) :
+      Ptr(createModule_(moduleName))
+  {
+  }
+  
+  // Invoke a module method. Equivalent to:
+  // return module.method(*args, **kwargs)
+  // This code is identical to Instance::invoke
+  PyObject * Module::invoke(std::string method, 
+                    PyObject * args,
+                    PyObject * kwargs)
+  {
+    NTA_CHECK(p_);
+    PyObject * pMethod = getAttr(method);
+    NTA_CHECK(PyCallable_Check(pMethod));
+
+    Ptr m(pMethod);
+    PyObject * result = PyObject_Call(m, args, kwargs);
+    checkPyError(__LINE__);
+    NTA_CHECK(result);
+    return result;
+  }
+
+  // Get an module attribute. Equivalent to:
+  //
+  // return module.name
+  // This code is identical to Instance::getAttr
+  PyObject * Module::getAttr(std::string name)
+  {
+    NTA_CHECK(p_);
+    PyObject * attr = PyObject_GetAttrString(p_, name.c_str());
+    checkPyError(__LINE__);
+    NTA_CHECK(attr);
+    return attr;
+  }
+
+  PyObject * Module::createModule_(const std::string & moduleName)
+  {
+    String name(moduleName);
+    // Import the module
+    PyObject * pModule = PyImport_Import(name);
+    checkPyError(__LINE__);
+
+    if (pModule == NULL || !(PyModule_Check(pModule)))
+    {
+      NTA_THROW << "Unable to import module: " << moduleName;
+    }
+    return pModule;
+  }
+
+  // --- 
+  // Implementation of Class class
+  // ---
+  // Wraps a Python class object and allows invoking class methods
+  // The constructor is equivalent the following Python code:
+  //
+  // from moduleName import className
+  Class::Class(const std::string & moduleName, const std::string & className) :
+      Ptr(createClass_(Module(moduleName), className))
+  {
+  }
+  
+  Class::Class(PyObject * pModule, const std::string & className) :
+    Ptr(createClass_(pModule, className))
+  {
+  }
+
+  // The invoke() method is equivalent the following Python code
+  // which invokes a class method:
+  //
+  // return className.method(*args, **kwargs)
+  PyObject * Class::invoke(std::string method, 
+                    PyObject * args,
+                    PyObject * kwargs)
+  {
+    NTA_CHECK(p_);
+    PyObject * pMethod = PyObject_GetAttrString(p_, method.c_str());
+    //printPythonError();      
+    NTA_CHECK(pMethod);
+    NTA_CHECK(PyCallable_Check(pMethod));
+
+    Ptr m(pMethod);
+    PyObject * result = PyObject_Call(m, args, kwargs);
+    checkPyError(__LINE__);
+
+    return result;
+  }
+
+  PyObject * Class::createClass_(PyObject * pModule, const std::string & className)
+  {
+    // Get the node class from the module (as a new reference)
+    PyObject * pClass = PyObject_GetAttrString(pModule, className.c_str());
+    NTA_CHECK(pClass && PyType_Check(pClass));
+
+    return pClass;
+  }
+
+  // --- 
+  // Implementation of Instance class
+  // ---
+  // Wraps an instance of a Python object
+  
+  // A constructor that takes an existing PyObject * (can be NULL too)
+  Instance::Instance(PyObject * p) : Ptr(p, p == NULL)
+  {
+  }
+
+  // A constructor that instantiates an instance of the requested
+  // class from the requested module. Equivalent to the follwoing:
+  //
+  // from moduleName import className
+  // instance = className(*args, **kwargs)
+  Instance::Instance(const std::string & moduleName, 
+             const std::string & className,
+             PyObject * args,
+             PyObject * kwargs) :
+      Ptr(createInstance_(Class(moduleName, className),
+                            args,
+                            kwargs))
+  {
+  }
+  
+  Instance::Instance(PyObject * pClass,                
+             PyObject * args,
+             PyObject * kwargs) :
+    Ptr(createInstance_(pClass, args, kwargs))
+  {
+  }
+
+  // Return true if the instance has attribute 'name' and false otherwise
+  bool Instance::hasAttr(std::string name)
+  {
+    checkPyError(__LINE__);
+    NTA_CHECK(p_);
+    return PyObject_HasAttrString(p_, name.c_str()) != 0;
+  }
+
+  // Get an instance attribute. Equivalent to:
+  //
+  // return instance.name
+  PyObject * Instance::getAttr(std::string name)
+  {
+    NTA_CHECK(p_);
+    PyObject * attr = PyObject_GetAttrString(p_, name.c_str());
+    checkPyError(__LINE__);
+    NTA_CHECK(attr);
+
+    return attr;
+  }
+
+  // Set an instance attribute. Equivalent to:
+  //
+  // return instance.name = value
+  void Instance::setAttr(std::string name, PyObject * value)
+  {
+    NTA_CHECK(p_);
+    int rc = PyObject_SetAttrString(p_, name.c_str(), value);
+    checkPyError(__LINE__);
+    NTA_CHECK(rc != -1);
+  }
+
+
+  // Return a string representation of an instance. Equivalent to:
+  //
+  // return str(instance)
+  PyObject * Instance::toString()
+  {
+    NTA_CHECK(p_);
+    PyObject * s = PyObject_Str(p_);
+    checkPyError(__LINE__);
+    NTA_CHECK(s);
+
+    return s;
+  }
+
+  // Invoke an instance method. Equivalent to:
+  //
+  // return instance.method(*args, **kwargs)
+  PyObject * Instance::invoke(std::string method, 
+                    PyObject * args,
+                    PyObject * kwargs)
+  {
+    NTA_CHECK(p_);
+    PyObject * pMethod = getAttr(method);
+    NTA_CHECK(PyCallable_Check(pMethod));
+
+    Ptr m(pMethod);
+    PyObject * result = PyObject_Call(m, args, kwargs);
+    checkPyError(__LINE__);
+    NTA_CHECK(result);
+    return result;
+  }
+
+  PyObject * Instance::createInstance_(PyObject * pClass,
+                             PyObject * args,
+                             PyObject * kwargs)
+  {
+    NTA_CHECK(pClass && PyCallable_Check(pClass));
+    NTA_CHECK(args && PyTuple_Check(args));
+    NTA_CHECK(!kwargs || PyDict_Check(kwargs));
+    
+    PyObject * pInstance = PyObject_Call(pClass, args, kwargs);
+    checkPyError(__LINE__);
+    NTA_CHECK(pInstance);
+
+    return pInstance;
+  }
+
+  //// ---
+  //// Raise a Python RuntimeError exception from C++ with
+  //// an error message and an optional stack trace. The 
+  //// stack trace will be added as a custom attribute of the
+  //// exception object. 
+  //// ---
+  //void setPyError(const char * message, const char * stackTrace = NULL)
+  //{
+  //  // Create a RuntimeError Python exception object
+  //  Tuple args(1);
+  //  args.setItem(0, py::String(message));
+  //  Instance e(PyExc_RuntimeError, args);
+
+  //  // Add a new attribute "stackTrace" if available
+  //  if (stackTrace)
+  //  {
+  //    e.setAttr("stackTrace", py::String(stackTrace));
+  //  }
+
+  //  // Set the Python error. Equivalent to: "raise e"
+  //  PyErr_SetObject(PyExc_RuntimeError, e);
+  //}
+
+
+
+} } // end of nupic::py namespace
+
+
+

--- a/src/python_support/PyHelpers.hpp
+++ b/src/python_support/PyHelpers.hpp
@@ -1,0 +1,405 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef NTA_PY_HELPERS_HPP
+#define NTA_PY_HELPERS_HPP
+
+// The Python.h #include MUST always be #included first in every
+// compilation unit (.c or .cpp file). That means that PyHelpers.hpp
+// must be #included first and transitively every .hpp file that 
+// #includes directly or indirectly PyHelpers.hpp must be #included
+// first.
+#include <Python.h>
+#include <frameobject.h>
+
+#include <nupic/utils/Log.hpp>
+#include <iostream>
+#include <fstream>
+
+// ===
+// ---------------------------------
+//
+//   P Y   H E L P E R S
+//
+// ---------------------------------
+//
+// The PyHelpers module contain C++ classes that wrap Python C-API
+// objects and allows working with Python C-API in a safe and user 
+// friendly manner. Please refer to the Python C-API docs for general
+// background: http://docs.python.org/c-api/
+//
+// The purpose of this module is to support internally the C++ PyNode
+// class and it implements exactly the classes needed by PyNode. 
+// It is not a comprehensive wrapper around the Python C-API.
+// 
+//The follwoing classes are implemented in the
+// namespac nupic::py
+//
+// Ptr:
+//   A class that manages a PyObject pointer and serves as base class
+//   for all other helper objects
+// 
+// Int, Long, LongLong, UnsignedLong, UnsignedLongLong: 
+//   Integral types that match the corresponding C integral types and
+//   map to either the Python int or Python long types. They provide
+//   constructors and conversion operators that were chosen to reflect
+//   the underlying Python C API functions (e.g. PyInt_FromLong() and
+//   PyInt_AsLong()).
+//
+// Float:
+//   A floating point number class that maps a double precision C double
+//   to a Python float. It provides a constructor and conversion operator.
+//   Python has just one floating point type (not including numpy and 
+//   the complex type).
+// 
+// String: 
+//   A string type that maps to the Python string and provides
+//   a constractor and conversion operator for the C char * type.
+//
+// Tuple, Dict:
+//   Sequence types that map to the Python tuple and dict. They provide
+//   a safe getItem() and setItem() that don't borrow or steal references.
+//
+// Module, Class, Instance:
+//   Types for working with the Python object system. Module is for importing
+//   modules. Class is for invoking class methods and Instance is for 
+//   instantiating objects and invoking their methods.
+// ===
+
+// Nested namespace nupic::py
+namespace nupic { namespace py
+{
+  void setRunningUnderPython();
+  
+  
+  void checkPyError(int lineno);
+
+  // A RAII class to hold a PyObject *
+  // It decrements the refCount when it 
+  // is destroyed.
+  //
+  // Ptr objects can be passed directly to Python C API calls.
+  // Most functions just use the object and when the function 
+  // returns the refCount stays the same. Some functions take
+  // ownership of the PyObject pointer. In this case you should
+  // call release().
+  //
+  // The Ptr class also serves as the base class for all the other helper
+  // classes that rely on it to manage the underlying PyObject * and
+  // just add type checks and type-specific constructors, conversion
+  // operator and special methods.
+  //
+  // In general, the specific sub-classes should be used to store Python
+  // objects (e.g use PyDict to store a dict object). You should use PyPtr
+  // directly only when storing Python objects that don't have a 
+  // corresponding PyHelpers sub-class.
+  class Ptr
+  {
+  public:
+    // Constructor of the Ptr class
+    //
+    // PyObject * p   - the managed pointer (ref count not incremented)
+    // bool allowNULL - If false (default) p must not be NULL
+    //
+    Ptr(PyObject * p, bool allowNULL = false);
+
+    virtual ~Ptr();
+
+    // Relinquish ownership of this object. Call release()
+    // if you pass the Ptr to a function that takes ownership
+    // like PyTuple_SetItem()
+    PyObject * release();
+    std::string getTypeName();
+    void assign(PyObject * p);
+    operator PyObject *();
+    operator const PyObject *() const;
+    bool isNULL();
+  private:
+    // This constructors MUST never be implemented to maintain 
+    // the integrity of the Ptr class. As a RAII class you don't
+    // want copies sharing (and later releasing) the same pointer.
+    Ptr();
+    Ptr(const Ptr &);
+
+  protected:  
+    PyObject * p_;
+    bool allowNULL_;
+  };
+
+
+  // String 
+  class String : public Ptr
+  {
+  public:
+    explicit String(const std::string & s, bool allowNULL = false);
+    explicit String(const char * s, size_t size, bool allowNULL = false);
+    explicit String(const char * s, bool allowNULL = false);
+    explicit String(PyObject * p);
+
+    operator const char * ();
+
+  private:
+    PyObject * createString_(const char * s, size_t size = 0);
+  };
+
+  // Int 
+  class Int : public Ptr
+  {
+  public:
+    Int(long n);
+    Int(PyObject * p);
+    operator long();
+  };
+
+  // Long 
+  class Long : public Ptr
+  {
+  public:
+    Long(long n);
+    Long(PyObject * p);
+    operator long();
+  };
+
+  // UnsignedLong 
+  class UnsignedLong : public Ptr
+  {
+  public:
+    UnsignedLong(unsigned long n);
+    UnsignedLong(PyObject * p);
+    operator unsigned long();
+  };
+
+  // LongLong 
+  class LongLong : public Ptr
+  {
+  public:
+    LongLong(long long n);
+    LongLong(PyObject * p);
+    operator long long();
+  };
+
+  // UnsignedLongLong 
+  class UnsignedLongLong : public Ptr
+  {
+  public:
+    UnsignedLongLong(unsigned long long n);
+    UnsignedLongLong(PyObject * p);
+    operator unsigned long long();
+  };
+
+
+  // Float 
+  class Float : public Ptr
+  {
+  public:
+    Float(const char * n);
+    Float(double n);
+    Float(PyObject * p);
+    operator double();
+    static double getMax();
+    static double getMin();
+  };
+
+  // Tuple
+  class Tuple : public Ptr
+  {
+  public:
+    Tuple(Py_ssize_t size = 0);
+    Tuple(PyObject * p);
+    void assign(PyObject *);
+    
+    PyObject * getItem(Py_ssize_t index);
+    
+    // The fast version of getItem() doesn't do bounds checking
+    // and doesn't increment the ref count of returned item. The original
+    // tuple still owns the item. If you try to access out of bounds item
+    // you will crash (or worse). If you assign the returned item to a py::Ptr
+    // or a sub-class you MUST call release() to prevent the py::Ptr from
+    // decrementing the ref count
+    PyObject * fastGetItem(Py_ssize_t index);
+    void setItem(Py_ssize_t index, PyObject * item);
+    Py_ssize_t getCount();
+  private:
+    Py_ssize_t size_;
+  };
+
+  // List
+  class List : public Ptr
+  {
+  public:
+    List();
+    List(PyObject *);
+    PyObject * getItem(Py_ssize_t index);
+
+    // The fast version of getItem() doesn't do bounds checking
+    // and doesn't increment the ref count of returned item. The original
+    // list still owns the item. If you try to access out of bounds item
+    // you will crash (or worse). If you assign the returned item to a py::Ptr
+    // or a sub-class you MUST call release() to prevent the py::Ptr from
+    // decrementing the ref count
+    PyObject * fastGetItem(Py_ssize_t index);
+    void setItem(Py_ssize_t index, PyObject * item);
+    void append(PyObject * item);
+    Py_ssize_t getCount();
+  };
+
+  // Dict
+  class Dict : public Ptr
+  {
+  public:
+    Dict();
+    Dict(PyObject * dict);
+    PyObject * getItem(const std::string & name, PyObject * defaultItem = NULL);
+    void setItem(const std::string & name, PyObject * pItem);
+  };
+
+  // Module 
+  //
+  // Wraps a Python module object and can import by name
+  // The Python interpreter sys.path must contain the
+  // requested module.
+  class Module : public Ptr
+  {
+  public:
+    Module(const std::string & moduleName);
+    
+    // Invoke a module method. Equivalent to:
+    // return module.method(*args, **kwargs)
+    // This code is identical to Instance::invoke
+    PyObject * invoke(std::string method, 
+                      PyObject * args,
+                      PyObject * kwargs = NULL);
+    // Get an module attribute. Equivalent to:
+    //
+    // return module.name
+    // This code is identical to Instance::getAttr
+    PyObject * getAttr(std::string name);
+  private:
+    PyObject * createModule_(const std::string & moduleName);
+  };
+
+  // Class 
+  //
+  // Wraps a Python class object and allows invoking class methods
+  class Class : public Ptr
+  {
+  public:
+    // The constructor is equivalent the following Python code:
+    //
+    // from moduleName import className
+    Class(const std::string & moduleName, const std::string & className);
+    Class(PyObject * pModule, const std::string & className);
+
+    // The invoke() method is equivalent the following Python code
+    // which invokes a class method:
+    //
+    // return className.method(*args, **kwargs)
+    PyObject * invoke(std::string method, 
+                      PyObject * args,
+                      PyObject * kwargs = NULL);
+  private:
+    PyObject * createClass_(PyObject * pModule, const std::string & className);
+  };
+
+
+  // Instance 
+  //
+  // Wraps an instance of a Python object
+  class Instance : public Ptr
+  {
+  public:
+    // A constructor that takes an existing PyObject * (can be NULL too)
+    Instance(PyObject * p = NULL);
+
+    // A constructor that instantiates an instance of the requested
+    // class from the requested module. Equivalent to the follwoing:
+    //
+    // from moduleName import className
+    // instance = className(*args, **kwargs)
+    Instance(const std::string & moduleName, 
+               const std::string & className,
+               PyObject * args,
+               PyObject * kwargs = NULL);
+
+    Instance(PyObject * pClass,                
+               PyObject * args,
+               PyObject * kwargs = NULL);
+
+    // Return true if the instance has attribute 'name' and false otherwise
+    bool hasAttr(std::string name);
+
+    // Get an instance attribute. Equivalent to:
+    //
+    // return instance.name
+    PyObject * getAttr(std::string name);
+
+    // Set an instance attribute. Equivalent to:
+    //
+    // return instance.name = value
+    void setAttr(std::string name, PyObject * value);
+
+    // Return a string representation of an instance. Equivalent to:
+    //
+    // return str(instance)
+    PyObject * toString();
+
+    // Invoke an instance method. Equivalent to:
+    //
+    // return instance.method(*args, **kwargs)
+    PyObject * invoke(std::string method, 
+                      PyObject * args,
+                      PyObject * kwargs = NULL);
+  private:
+    PyObject * createInstance_(PyObject * pClass,
+                               PyObject * args,
+                               PyObject * kwargs);
+  };
+
+  //// ---
+  //// Raise a Python RuntimeError exception from C++ with
+  //// an error message and an optional stack trace. The 
+  //// stack trace will be added as a custom attribute of the
+  //// exception object. 
+  //// ---
+  //void setPyError(const char * message, const char * stackTrace = NULL)
+  //{
+  //  // Create a RuntimeError Python exception object
+  //  Tuple args(1);
+  //  args.setItem(0, py::String(message));
+  //  Instance e(PyExc_RuntimeError, args);
+
+  //  // Add a new attribute "stackTrace" if available
+  //  if (stackTrace)
+  //  {
+  //    e.setAttr("stackTrace", py::String(stackTrace));
+  //  }
+
+  //  // Set the Python error. Equivalent to: "raise e"
+  //  PyErr_SetObject(PyExc_RuntimeError, e);
+  //}
+
+
+
+} } // end of nupic::py namespace
+
+#endif // NTA_PY_HELPERS_HPP
+

--- a/src/python_support/PythonStream.cpp
+++ b/src/python_support/PythonStream.cpp
@@ -1,0 +1,65 @@
+#ifdef NTA_PYTHON_SUPPORT
+
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#include <python_support/PythonStream.hpp>
+#include <nupic/utils/Log.hpp>
+
+/**
+ * Bumps up size to a nicely aligned larger size.
+ * Taken for NuPIC2 from PythonUtils.hpp
+ */
+static size_t NextPythonSize(size_t n)
+{
+  n += 1;
+  n += 8 - (n % 8);
+  return n;
+}
+
+// -------------------------------------------------------------
+SharedPythonOStream::SharedPythonOStream(size_t maxSize) :
+	target_size_(NextPythonSize(maxSize)),
+	ss_(std::ios_base::out)
+{
+}
+
+// -------------------------------------------------------------
+std::ostream &SharedPythonOStream::getStream()
+{
+	return ss_;
+}
+
+// -------------------------------------------------------------
+PyObject * SharedPythonOStream::close()
+{
+	ss_.flush();
+
+	if (ss_.str().length() > target_size_)
+    throw std::runtime_error("Stream output larger than allocated buffer.");
+
+  return PyString_FromStringAndSize(ss_.str().c_str(), ss_.str().length());
+}
+
+#endif // NTA_PYTHON_SUPPORT
+
+

--- a/src/python_support/PythonStream.hpp
+++ b/src/python_support/PythonStream.hpp
@@ -1,0 +1,70 @@
+#ifndef NTA_PYTHON_STREAM_HPP
+#define NTA_PYTHON_STREAM_HPP
+
+#ifdef NTA_PYTHON_SUPPORT
+
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#include <python_support/PyHelpers.hpp>
+#include <iosfwd>
+#include <sstream>
+
+///////////////////////////////////////////////////////////////////
+/// Provides a stream that outputs a PyString on class close()
+///
+/// @b Responsibility
+/// Must make a PyString object that contains the same string as
+/// was passed to the ostream returned by getStream()
+///
+/// @b Description
+/// After instantiation, a call to getStream() returns an ostream
+/// that collects the characters fed to it. Any subsequent call
+/// to close() will return a PyObject * to a PyString that 
+/// contains the current contents of the ostream.
+/// 
+/// @note
+/// A close() before a getStream() will return an empty PyString.
+/// 
+///////////////////////////////////////////////////////////////////
+class SharedPythonOStream
+{
+public:
+  SharedPythonOStream(size_t maxSize);
+  std::ostream &getStream();
+  PyObject *close();
+
+private:
+	size_t target_size_;
+	std::stringstream ss_;
+};
+
+//------------------------------------------------------------------
+
+#endif // NTA_PYTHON_SUPPORT
+
+#endif // NTA_PYTHON_STREAM_HPP
+
+
+
+
+

--- a/src/python_support/WrappedVector.hpp
+++ b/src/python_support/WrappedVector.hpp
@@ -1,0 +1,413 @@
+#ifndef NTA_WRAPPED_VECTOR_HPP
+#define NTA_WRAPPED_VECTOR_HPP
+
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file 
+ */
+ 
+#include <nupic/types/Types.hpp>
+
+#include <algorithm>
+#include <vector>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <iterator>
+
+namespace nupic {
+
+template<typename T>
+inline std::string tts(const T x) {
+  std::ostringstream s;
+  s << x;
+  return s.str();
+}
+
+template<typename T>
+class WrappedVectorIter //: public random_access_iterator<T, int> 
+{
+public:
+  int n_;
+  int incr_;
+  T *p_;
+
+  typedef T value_type;
+//  typedef int size_type;
+//  typedef ptrdiff_t difference_type;
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef int difference_type;
+  typedef T *pointer;
+//  typedef const T *const_pointer;
+  typedef T &reference;
+//  typedef const T &const_reference;
+
+  WrappedVectorIter(int n, int incr, T *p) : n_(n), incr_(incr), p_(p) {}
+
+  int size() const { return n_; }
+  T operator[](int i) const { return *(p_ + (i*incr_)); }
+  T &operator[](int i) { return *(p_ + (i*incr_)); }
+
+  /// Slices without bounds-checking.
+  WrappedVectorIter<T> slice(int i, int j) const {
+    if(j >= i) return WrappedVectorIter(j - i, incr_, p_ + i*incr_);
+    else return WrappedVectorIter(i - j, -incr_, p_ + i*incr_);
+  }
+
+  WrappedVectorIter<T> slice(int start, int /*stop*/, int step, int length) const {
+    return WrappedVectorIter(length, incr_*step, p_ + start*incr_);
+  }
+
+  WrappedVectorIter<T> end() const { return slice(n_, n_); }
+
+  WrappedVectorIter<T> reversed() const {
+    return WrappedVectorIter(n_, -incr_, p_ + (n_-1)*incr_);
+  }
+
+  /// Advance
+  WrappedVectorIter<T> operator+(int n) const { return slice(n, n_-n); }
+  WrappedVectorIter<T> operator+(size_t n) const { return slice(int(n), n_-int(n)); }
+  /// Advance in-place
+  WrappedVectorIter<T> &operator+=(int n) { *this = slice(n, n_-n); return *this; }
+  WrappedVectorIter<T> &operator+=(size_t n) { *this = slice(int(n), n_-int(n)); return *this; }
+  /// Prefix increment
+  WrappedVectorIter<T> &operator++() { *this = slice(1, n_-1); return *this; }
+  /// Postfix increment
+  WrappedVectorIter<T> operator++(int) { WrappedVectorIter<T> a = *this; *this = slice(1, n_-1); return a; }
+  /// Move back
+  WrappedVectorIter<T> operator-(int n) const { return slice(-n, n_+n); }
+  WrappedVectorIter<T> operator-(size_t n) const { return slice(-int(n), n_+int(n)); }
+  /// Move back in-place
+  WrappedVectorIter<T> &operator-=(int n) { *this = slice(-n, n_+n); return *this; }
+  WrappedVectorIter<T> &operator-=(size_t n) { *this = slice(-int(n), n_+int(n)); return *this; }
+  /// Prefix decrement
+  WrappedVectorIter<T> &operator--() { *this = slice(-1, n_+1); return *this; }
+  /// Postfix decrement
+  WrappedVectorIter<T> operator--(int) { WrappedVectorIter<T> a = slice(-1, n_+1); *this = slice(-1, n_+1); return a; }
+  /// Difference between two iterators
+  int operator-(const WrappedVectorIter<T> &i) const { return int((p_ - i.p_) / incr_); }
+
+  /// Dereference
+  T operator*() const { return *p_; }
+  /// Dereference, non-const
+  T &operator*() { return *p_; }
+  /// Cast to pointer
+  operator const T *() const { return p_; }
+  /// Cast to pointer, non-const
+  operator T *() { return p_; }
+  /// Access as pointer
+  const T *operator->() const { return p_; }
+  /// Access as pointer, non-const
+  T *operator->() { return p_; }
+  
+  /// Not-equal comparison
+  bool neq(const T *p) const { return p_ != p; }
+  /// Equal comparison
+  bool eq(const T *p) const { return p_ == p; }
+  /// Less-than, considering increment direction
+  bool le(const T *p) const { return (incr_ >= 0) ? (p_ < p) : (p < p_); }
+  /// LEQ, considering increment direction
+  bool leq(const T *p) const { return (incr_ >= 0) ? (p_ <= p) : (p <= p_); }
+  /// Greater-than, considering increment direction
+  bool ge(const T *p) const { return (incr_ >= 0) ? (p_ > p) : (p > p_); }
+  /// GEQ, considering increment direction
+  bool geq(const T *p) const { return (incr_ >= 0) ? (p_ >= p) : (p >= p_); }
+
+  bool operator!=(const WrappedVectorIter<T> &x) const { return neq(x.p_); }
+  bool operator==(const WrappedVectorIter<T> &x) const { return eq(x.p_); }
+  bool operator<(const WrappedVectorIter<T> &x) const { return le(x.p_); }
+  bool operator<=(const WrappedVectorIter<T> &x) const { return leq(x.p_); }
+  bool operator>(const WrappedVectorIter<T> &x) const { return ge(x.p_); }
+  bool operator>=(const WrappedVectorIter<T> &x) const { return geq(x.p_); }
+
+  template<typename T2>
+  void copyFrom(int dim, int incr, const T2 *in) {
+    const int n = n_, inc1 = incr_, inc2 = incr;
+    T *p1 = p_;
+    const T2 *p2 = in;
+    for(int i=0; i<n; ++i) { *p1 = *p2; p1 += inc1; p2 += inc2; }
+  }
+
+  template<typename T2>
+  void into(int dim, int incr, T2 *out) const {
+    const int n = n_, inc1 = incr_, inc2 = incr;
+    const T *p1 = p_;
+    T2 *p2 = out;
+    for(int i=0; i<n; ++i) { *p2 = *p1; p1 += inc1; p2 += inc2; }
+  }
+};
+
+/// Simple, namespace-less wrapper for Vector.
+/// Designed to mirror Python functionality and to be 
+/// very easy to wrap using SWIG.
+/// Most operations should disappear through inlining.
+/// Does not own its pointer or guarantee its safety in 
+/// any way (similar to the way Vector references 
+/// memory managed elsewhere).
+class WrappedVector {
+  WrappedVectorIter<nupic::Real> p_;
+  nupic::Real *own_;
+  void free() { if(own_) { delete own_; own_ = 0; } }
+
+public:
+  /// Extremely dangerous constructor! Only use for unit testing!
+  WrappedVector(int n) : p_(n, 1, new nupic::Real[n]), own_(0) { own_ = p_.p_; }
+
+public:
+  void checkIndex(int i) const {
+    if(!((i >= 0) && (i < p_.n_)))
+      throw std::invalid_argument("Index " + tts(i) + " out of bounds.");
+  }
+
+  void checkBeginEnd(int begin, int end) const {
+    if(end > begin) {
+      if(!(begin >= 0)) 
+        throw std::invalid_argument("Begin " + tts(begin) + " out of bounds.");
+      if(!(end <= p_.n_)) 
+        throw std::invalid_argument("End " + tts(end) + " out of bounds.");
+    }
+    else if(end == begin) {
+      if(!((begin >= 0) && (end <= p_.n_)))
+        throw std::invalid_argument("Out of bounds.");
+    }
+    else if(end < begin) {
+      if(!(end >= (-1))) 
+        throw std::invalid_argument("End " + tts(end) + " out of bounds.");
+      if(!(begin < p_.n_)) 
+        throw std::invalid_argument("Begin " + tts(begin) + " out of bounds.");
+    }
+  }
+
+public:
+  typedef WrappedVectorIter<nupic::Real> iterator;
+
+  WrappedVector() : p_(0, 1, 0), own_(0) {}
+  WrappedVector(const WrappedVectorIter<nupic::Real> &p) : p_(p), own_(0) {}
+  WrappedVector(int size, nupic::Real *p) : p_(size, 1, p), own_(0) {}
+  
+//  WrappedVector(const nupic::Belief &b) : p_(b.size(), 1, const_cast<nupic::Real *>(b.ptr())), own_(0) {}
+  WrappedVector(const std::vector<nupic::Real> &v) : p_(int(v.size()), 1, const_cast<nupic::Real *>(&(v[0]))), own_(0) {}
+  WrappedVector(const WrappedVector &v) : p_(v.p_), own_(0) {}
+  WrappedVector &operator=(const WrappedVector &v) { this->free(); p_ = v.p_; own_ = 0; return *this; }
+  
+  ~WrappedVector() { this->free(); }
+  
+  WrappedVector wvector(size_t lag=0) const { return *this; }
+
+  void clear() { this->free(); p_.n_ = 0; p_.incr_ = 1; p_.p_ = 0; }
+  void setPointer(int n, int incr, nupic::Real *p) { this->free(); p_.n_ = n; p_.incr_ = incr; p_.p_ = p; }
+  void setPointer(int n, nupic::Real *p) { this->free(); p_.n_ = n; p_.incr_ = 1; p_.p_ = p; }
+
+  // Returns the beginning address of the underlying
+  // data buffer as an integer.
+  int getBufPtrAsInt(void) { return (int)(long)(p_.p_); }
+
+  iterator begin() { return p_; }
+  iterator end() { return p_.end(); }
+
+  nupic::Size __len__() const { return p_.size(); }
+
+  template<typename T>
+  void adjust(T &endPoint) const {
+    T n = (T) p_.size();
+    if(endPoint < 0) endPoint += n;
+    else if(endPoint > n) endPoint = n;
+  }
+
+  nupic::Real __getitem__(int i) const {
+    adjust(i); 
+    checkIndex(i); 
+    return p_[i]; 
+  }
+
+  void __setitem__(int i, nupic::Real x) {
+    adjust(i);
+    checkIndex(i); 
+    p_[i] = x; 
+  }
+
+  std::string __repr__() const {
+    std::ostringstream s;
+    s << "[";
+    const nupic::Real *p = p_.p_;
+    int nm1 = p_.n_-1;
+    for(int i=0; i<nm1; ++i) {
+      s << (*p) << ", ";
+      p += p_.incr_;
+    }
+    if(p_.n_) s << (*p);
+    s << "]";
+    return s.str();
+  }
+
+  std::string __str__() const { return __repr__(); }
+
+  WrappedVector slice(int i, int j) const {
+    return p_.slice(i, j);
+  }
+
+  /// These are meant to come from PySlice_GetIndicesEx.
+  WrappedVector slice(int start, int stop, int step, int length) const {
+    return p_.slice(start, stop, step, length);
+  }
+
+  /// Copied reference is reversed.
+  WrappedVector __reversed__() const { return p_.reversed(); }
+
+  /// Reverse in-place.
+  void reverse() { p_ = p_.reversed(); }
+
+  /// Sort the elements in place.
+  void sort(bool descending=false) {
+    std::sort(begin(), end());
+    if(descending) reverse();
+  }
+
+//  WrappedVector &
+  void __iadd__(const WrappedVector &v) {
+    if(!(p_.n_ == v.p_.n_)) 
+      throw std::invalid_argument("Sizes must match: " +
+        tts(p_.n_) + " " + tts(v.p_.n_));
+    const int n = p_.n_, inc1 = p_.incr_, inc2 = v.p_.incr_;
+    nupic::Real *p1 = p_.p_;
+    const nupic::Real *p2 = v.p_.p_;
+    for(int i=0; i<n; ++i) { *p1 += *p2; p1 += inc1; p2 += inc2; }
+//    return *this;
+  }
+
+//  WrappedVector &
+  void __imul__(const WrappedVector &v) {
+    if(!(p_.n_ == v.p_.n_)) 
+      throw std::invalid_argument("Sizes must match: " +
+        tts(p_.n_) + " " + tts(v.p_.n_));
+    const int n = p_.n_, inc1 = p_.incr_, inc2 = v.p_.incr_;
+    nupic::Real *p1 = p_.p_;
+    const nupic::Real *p2 = v.p_.p_;
+    for(int i=0; i<n; ++i) { *p1 *= *p2; p1 += inc1; p2 += inc2; }
+//    return *this;
+  }
+
+  /// Copy the elements of v into this vector.
+  /// Sizes must match exactly.
+  void copyFrom(const WrappedVector &v) {
+    int n = v.p_.n_;
+    if(!(p_.n_ == n)) 
+      throw std::invalid_argument("Sizes must match: " +
+        tts(p_.n_) + " " + tts(n));
+    p_.copyFrom(n, v.p_.incr_, v.p_.p_);
+  }
+
+  template<typename T2>
+  void copyFromT(int n, int incr, const T2 *p) {
+    if(!(p_.n_ == n)) 
+      throw std::invalid_argument("Sizes must match: " +
+        tts(p_.n_) + " " + tts(n));
+    p_.copyFrom(n, incr, p);
+  }
+
+  template<typename T2>
+  void copyIntoT(int n, int incr, T2 *p) const {
+    p_.into(n, incr, p);
+  }
+
+  void setSlice(int i, int j, const WrappedVector &v) {
+    checkBeginEnd(i, j);
+    int n = v.p_.n_;
+    if(!(n == abs(j-i))) throw std::invalid_argument("Sizes must match.");
+    p_.slice(i, j).copyFrom(n, v.p_.incr_, v.p_.p_);
+  }
+
+  /// Can function as its own iterator.
+  WrappedVector __iter__() const { return *this; }
+
+  /// Iterator functionality.
+  WrappedVector next() const { return p_ + 1; }
+
+  void fill(nupic::Real x) {
+    const int n = p_.n_, inc1 = p_.incr_;
+    nupic::Real *p1 = p_.p_;
+    for(int i=0; i<n; ++i) { *p1 = x; p1 += inc1; }
+  }
+
+  int argmax() const {
+    const int n = p_.n_, inc1 = p_.incr_;
+    if(!(n >= 1))
+      throw std::runtime_error("Cannot call argmax on a 0-length vector.");
+    const nupic::Real *p1 = p_.p_;
+    int mi = 0;
+    nupic::Real mv = *p1; p1 += inc1;
+    for(int i=1; i<n; ++i) { 
+      nupic::Real x = *p1; p1 += inc1;
+      if(x > mv) { mi = i; mv = x; }
+    }
+    return mi;
+  }
+
+  nupic::Real sum() const {
+    const int n = p_.n_, inc1 = p_.incr_;
+    const nupic::Real *p1 = p_.p_;
+    nupic::Real sum = 0;
+    for(int i=0; i<n; ++i) { 
+      nupic::Real x = *p1; p1 += inc1;
+      sum += x;
+    }
+    return sum;
+  }
+
+  nupic::Real sumSq() const {
+    const int n = p_.n_, inc1 = p_.incr_;
+    const nupic::Real *p1 = p_.p_;
+    nupic::Real sum = 0;
+    for(int i=0; i<n; ++i) { 
+      nupic::Real x = *p1; p1 += inc1;
+      sum += x*x;
+    }
+    return sum;
+  }
+    
+  bool any() const {
+    const int n = p_.n_, inc1 = p_.incr_;
+    const nupic::Real *p1 = p_.p_;
+    for(int i=0; i<n; ++i) { 
+      nupic::Real x = *p1; p1 += inc1;
+      if(x) return true;
+    }
+    return false;
+  }
+
+  nupic::Real all() const {
+    const int n = p_.n_, inc1 = p_.incr_;
+    const nupic::Real *p1 = p_.p_;
+    for(int i=0; i<n; ++i) { 
+      nupic::Real x = *p1; p1 += inc1;
+      if(!x) return false;
+    }
+    return true;
+  }
+};
+
+} // End namespace nupic.
+
+#endif
+
+


### PR DESCRIPTION
Solves: https://github.com/numenta/nupic.core/issues/256

To be sincere, I didn't like the changes brought by this PR. I had to bring the python scripts (to get prefix and version of python) into CMake file and still we will have to use a flag to say if CMake should build python stuff or not (in order to users specify when want a stand-alone c++ library). These changes gave me a feeling that we are going backwards. Maybe this is only an impression of mine. By the way I would like some feedback. If you think it is fine, then I'll keep working on this...  if not, we will have to change the strategy..
