### PR TITLE
Revert "disable temp. optimization flags"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,10 +142,6 @@ endif()
 set(OPTIMIZATION_FLAGS_CC "-pipe ${OPTIMIZATION_FLAGS_CC}") #TODO use -Ofast instead of -O3
 
 
-# disable optimizations temporarily #FIXME
-set(OPTIMIZATION_FLAGS_CC "")
-set(OPTIMIZATION_FLAGS_LT "")
-
 set(COMMON_LINK_FLAGS "${COMMON_LINK_FLAGS} ${OPTIMIZATION_FLAGS_LT}")
 set(COMPILE_FLAGS "-fPIC -std=c++11 -m${BITNESS} ${STDLIB} -fvisibility=hidden -Werror -Wall -Wextra -Wreturn-type -Wunused -Wno-unused-parameter -Wno-missing-field-initializers  ${OPTIMIZATION_FLAGS_CC}")
 


### PR DESCRIPTION
Reverts numenta/nupic.core#295

that would disable all optimization (was only fallback) ..is not needed now. Tested in nupic #1695 SHA