### PR TITLE
Allow registering custom Python regions

### DIFF
--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -980,6 +980,11 @@ void Network::resetProfiling()
     regions_.getByIndex(i).second->resetProfiling();
 }
 
+void Network::addCustomRegionPackage(const char * path)
+{
+  Region::addCustomRegionPackage(path);
+}
+
 
 
 } // namespace nupic

--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -980,9 +980,9 @@ void Network::resetProfiling()
     regions_.getByIndex(i).second->resetProfiling();
 }
 
-void Network::addCustomRegionPackage(const char * path)
+void Network::registerRegionPackage(const char * path)
 {
-  Region::addCustomRegionPackage(path);
+  Region::registerRegionPackage(path);
 }
 
 

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -374,7 +374,7 @@ namespace nupic
      * Add user built regions to package path
      */
     static void
-    addCustomRegionPackage(const char * path);
+    registerRegionPackage(const char * path);
 
   private:
 

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -370,6 +370,12 @@ namespace nupic
      * @}
      */
 
+    /**
+     * Add user built regions to package path
+     */
+    void
+    addCustomRegionPackage(const char * path);
+
   private:
 
 

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -373,7 +373,7 @@ namespace nupic
     /**
      * Add user built regions to package path
      */
-    void
+    static void
     addCustomRegionPackage(const char * path);
 
   private:

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -223,6 +223,12 @@ Region::getSpecFromType(const std::string& nodeType)
   return factory.getSpec(nodeType);
 }
 
+void
+Region::addCustomRegionPackage(const char * path)
+{
+  RegionImplFactory::addPackage(path);
+}
+
 const Dimensions&
 Region::getDimensions() const
 {

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -224,9 +224,9 @@ Region::getSpecFromType(const std::string& nodeType)
 }
 
 void
-Region::addCustomRegionPackage(const char * path)
+Region::registerRegionPackage(const char * path)
 {
-  RegionImplFactory::addPackage(path);
+  RegionImplFactory::registerRegionPackage(path);
 }
 
 const Dimensions&

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -68,6 +68,7 @@ namespace nupic
   class Region 
   {
   public:
+
     /**
      * @name Region information
      *

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -68,7 +68,6 @@ namespace nupic
   class Region 
   {
   public:
-
     /**
      * @name Region information
      *
@@ -146,6 +145,13 @@ namespace nupic
      */
     static const Spec* 
     getSpecFromType(const std::string& nodeType);
+
+
+    /*
+     * Adds a package to the RegionImplFactory's packages
+     */
+    static void addCustomRegionPackage(const char * path);
+
 
     /**
      * @}

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -151,7 +151,7 @@ namespace nupic
     /*
      * Adds a package to the RegionImplFactory's packages
      */
-    static void addCustomRegionPackage(const char * path);
+    static void registerRegionPackage(const char * path);
 
 
     /**

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -339,7 +339,6 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
     if (!fullNodeType.empty()) // Not in current directory
       fullNodeType += std::string(".");
     fullNodeType += std::string(nodeType.c_str() + 3);
-    std::cout << fullNodeType << std::endl;
 
     void * exception = nullptr;
     void * ns = pyLib->createSpec(fullNodeType, &exception);

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -50,7 +50,7 @@ namespace nupic
 {
 
   // Allows the user to add custom regions to the package list
-  void RegionImplFactory::addPackage(const char * path)
+  void RegionImplFactory::registerRegionPackage(const char * path)
   {
     packages.push_back(path);
   }
@@ -217,8 +217,10 @@ static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib,
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") +
-                               std::string(nodeType.c_str() + 3);
+    std::string fullNodeType = std::string(package);
+    if (!fullNodeType.empty()) // Not in current directory
+      fullNodeType += std::string(".");
+    fullNodeType += std::string(nodeType.c_str() + 3);
 
     void * exception = nullptr;
     void * node = pyLib->createPyNode(fullNodeType, nodeParams, region, &exception);
@@ -241,8 +243,10 @@ static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") +
-                               std::string(nodeType.c_str() + 3);
+    std::string fullNodeType = std::string(package);
+    if (!fullNodeType.empty()) // Not in current directory
+      fullNodeType += std::string(".");
+    fullNodeType += std::string(nodeType.c_str() + 3);
 
     void *exception = nullptr;
     void * node = pyLib->deserializePyNode(fullNodeType, &bundle, region, &exception);
@@ -331,8 +335,11 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
     
 
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") + 
-                               std::string(nodeType.c_str() + 3);
+    std::string fullNodeType = std::string(package);
+    if (!fullNodeType.empty()) // Not in current directory
+      fullNodeType += std::string(".");
+    fullNodeType += std::string(nodeType.c_str() + 3);
+    std::cout << fullNodeType << std::endl;
 
     void * exception = nullptr;
     void * ns = pyLib->createSpec(fullNodeType, &exception);

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -213,11 +213,11 @@ static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib,
                                  ValueMap * nodeParams,
                                  Region * region)
 {
-  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(* package) + std::string(".") +
+    std::string fullNodeType = std::string(package) + std::string(".") +
                                std::string(nodeType.c_str() + 3);
 
     void * exception = nullptr;
@@ -237,11 +237,11 @@ static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
                                       Region * region)
 {
   // We need to find the module so that we know if it is NuPIC 1 or NuPIC 2
-  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(* package) + std::string(".") +
+    std::string fullNodeType = std::string(package) + std::string(".") +
                                std::string(nodeType.c_str() + 3);
 
     void *exception = nullptr;
@@ -326,12 +326,12 @@ RegionImpl* RegionImplFactory::deserializeRegionImpl(const std::string nodeType,
 static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
-  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  for (auto package : packages)
   {
     
 
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(* package) + std::string(".") + 
+    std::string fullNodeType = std::string(package) + std::string(".") + 
                                std::string(nodeType.c_str() + 3);
 
     void * exception = nullptr;

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -44,10 +44,17 @@
 #define expand_and_stringify(x) stringify(x)
 
 // Path from site-packages to packages that contain NuPIC Python regions
-const char * packages[] = { "nupic.regions", "nupic.regions.extra" };
+static std::vector<const char *> packages { "nupic.regions", "nupic.regions.extra" };
 
 namespace nupic
 {
+
+  // Allows the user to add custom regions to the package list
+  void RegionImplFactory::addPackage(const char * path)
+  {
+    packages.push_back(path);
+  }
+
   class DynamicPythonLibrary
   {
     typedef void (*initPythonFunc)();
@@ -200,49 +207,24 @@ RegionImplFactory & RegionImplFactory::getInstance()
   return instance;
 }
 
-static std::string getPackageDir(const std::string& rootDir, const std::string & package)
-{
-  
-  std::string p(package);
-  p.replace(p.find("."), 1, "/");
-  size_t pos = p.find(".");
-  if (pos != std::string::npos)
-    p.replace(p.find("."), 1, "/");
-
-  return Path::join(rootDir, p);
-}
-
 // This function creates either a NuPIC 2 or NuPIC 1 Python node 
 static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib, 
                                  const std::string & nodeType,
                                  ValueMap * nodeParams,
                                  Region * region)
 {
-  for (auto package : packages)
+  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  //for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") +
+    std::string fullNodeType = std::string(* package) + std::string(".") +
                                std::string(nodeType.c_str() + 3);
-
-    // Check if node exists and continue if not
-    std::string nodePath = Path::join(getPackageDir(pyLib->getRootDir(), package), 
-      std::string(nodeType.c_str() + 3) + std::string(".py"));
-
-      if (!Path::exists(nodePath))
-        continue;
 
     void * exception = nullptr;
     void * node = pyLib->createPyNode(fullNodeType, nodeParams, region, &exception);
     if (node)
       return static_cast<RegionImpl*>(node);
-
-    if (exception)
-    {
-      nupic::Exception * e = (nupic::Exception *)exception;
-      throw nupic::Exception(*e);
-      delete e;
-    }
   }
 
   NTA_THROW << "Unable to create region " << region->getName() << " of type " << nodeType;
@@ -256,33 +238,18 @@ static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
                                       Region * region)
 {
   // We need to find the module so that we know if it is NuPIC 1 or NuPIC 2
-  for (auto package : packages)
+  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  //for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") +
+    std::string fullNodeType = std::string(* package) + std::string(".") +
                                std::string(nodeType.c_str() + 3);
-
-    // Check if node exists and continue if not
-    std::string nodePath = Path::join(getPackageDir(pyLib->getRootDir(), package), 
-           std::string(nodeType.c_str() + 3) + std::string(".py"));
-
-    if (!Path::exists(nodePath))
-      continue;
-
-
 
     void *exception = nullptr;
     void * node = pyLib->deserializePyNode(fullNodeType, &bundle, region, &exception);
     if (node)
       return static_cast<RegionImpl*>(node);
-    
-    if (exception)
-    {
-      nupic::Exception * e = (nupic::Exception *)exception;
-      throw nupic::Exception(*e);
-      delete e;
-    }
   }
   NTA_THROW << "Unable to deserialize region " << region->getName() << " of type " << nodeType;
   return nullptr;
@@ -361,31 +328,19 @@ RegionImpl* RegionImplFactory::deserializeRegionImpl(const std::string nodeType,
 static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
-  for (auto package : packages)
+  for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
+  //for (auto package : packages)
   {
     
 
     // Construct the full module path to the requested node
-    std::string fullNodeType = std::string(package) + std::string(".") + 
+    std::string fullNodeType = std::string(* package) + std::string(".") + 
                                std::string(nodeType.c_str() + 3);
 
-    // Check if node exists and continue if not
-    std::string nodePath = Path::join(getPackageDir(pyLib->getRootDir(), package), 
-      std::string(nodeType.c_str() + 3) + std::string(".py"));
-
-      if (!Path::exists(nodePath))
-        continue;
     void * exception = nullptr;
     void * ns = pyLib->createSpec(fullNodeType, &exception);
     if (ns) {
       return (Spec *)ns;
-    }
-
-    if (exception)
-    {
-      nupic::Exception * e = (nupic::Exception *)exception;
-      delete e;
-      NTA_THROW << "Could not get valid spec for Region: " << nodeType;
     }
   }
 

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -214,7 +214,6 @@ static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib,
                                  Region * region)
 {
   for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
-  //for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
@@ -239,7 +238,6 @@ static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
 {
   // We need to find the module so that we know if it is NuPIC 1 or NuPIC 2
   for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
-  //for (auto package : packages)
   {
     
     // Construct the full module path to the requested node
@@ -329,7 +327,6 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
   for (std::vector<const char *>::iterator package = packages.begin(); package !=packages.end();package++)
-  //for (auto package : packages)
   {
     
 

--- a/src/nupic/engine/RegionImplFactory.hpp
+++ b/src/nupic/engine/RegionImplFactory.hpp
@@ -76,7 +76,7 @@ namespace nupic
     void cleanup();
 
     // Allows the user to load custom packages
-    static void addPackage(const char * path);
+    static void registerRegionPackage(const char * path);
 
   private:
     RegionImplFactory() {};

--- a/src/nupic/engine/RegionImplFactory.hpp
+++ b/src/nupic/engine/RegionImplFactory.hpp
@@ -75,6 +75,9 @@ namespace nupic
     // nodespec references (e.g. in NuPIC shutdown) or pynodes. 
     void cleanup();
 
+    // Allows the user to load custom packages
+    static void addPackage(const char * path);
+
   private:
     RegionImplFactory() {};
     RegionImplFactory(const RegionImplFactory &);


### PR DESCRIPTION
These modifications allow a user to create custom regions in Python. They just need to add the module to the network and then they can create their custom region.  There are changes for nupic as well.

Fixes https://github.com/numenta/nupic/issues/2057

@scottpurdy - please review