### PR TITLE
Change paramter name in temporal memory proto

### DIFF
--- a/src/nupic/proto/TemporalMemoryProto.capnp
+++ b/src/nupic/proto/TemporalMemoryProto.capnp
@@ -28,5 +28,5 @@ struct TemporalMemoryProto {
   winnerCells @15 :List(UInt32);
   matchingSegments @16 :List(UInt32);
   matchingCells @17 :List(UInt32);
-  permanenceOrphanDecrement @18 :Float32;
+  predictedSegmentDecrement @18 :Float32;
 }


### PR DESCRIPTION
@scottpurdy 

I changed a parameter name in the temporal memory proto to be more descriptive. Please review and merge.