### PR TITLE
Capnp RegionImpl serialization

### DIFF
--- a/src/nupic/engine/RegionImpl.cpp
+++ b/src/nupic/engine/RegionImpl.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/engine/RegionImpl.cpp
+++ b/src/nupic/engine/RegionImpl.cpp
@@ -20,23 +20,22 @@
  * ---------------------------------------------------------------------
  */
 
-
 #include <iostream>
 
-#include <nupic/engine/RegionImpl.hpp>
-#include <nupic/ntypes/Buffer.hpp>
-#include <nupic/ntypes/Array.hpp>
-#include <nupic/types/BasicType.hpp>
 #include <nupic/engine/Region.hpp>
+#include <nupic/engine/RegionImpl.hpp>
 #include <nupic/engine/Spec.hpp>
-#include <nupic/ntypes/Dimensions.hpp>
+#include <nupic/ntypes/Array.hpp>
+#include <nupic/ntypes/Buffer.hpp>
 #include <nupic/ntypes/BundleIO.hpp>
+#include <nupic/ntypes/Dimensions.hpp>
 #include <nupic/os/FStream.hpp>
+#include <nupic/types/BasicType.hpp>
 
 namespace nupic
 {
 
-RegionImpl::RegionImpl(Region *region) : 
+RegionImpl::RegionImpl(Region *region) :
   region_(region)
 {
 }
@@ -52,7 +51,7 @@ const std::string& RegionImpl::getType() const
 }
 
 const std::string& RegionImpl::getName() const
-{ 
+{
   return region_->getName();
 }
 
@@ -66,10 +65,10 @@ const NodeSet& RegionImpl::getEnabledNodes() const
 // By default, all typed getParameter calls forward to the
 // untyped getParameter that serializes to a buffer
 
-// Use macros to implement these methods. 
+// Use macros to implement these methods.
 // This is similar to a template + explicit instantiation, but
 // templated methods can't be virtual and thus can't be
-// overridden by subclasses. 
+// overridden by subclasses.
 
 #define getParameterT(Type) \
 Type RegionImpl::getParameter##Type(const std::string& name, Int64 index) \
@@ -117,7 +116,7 @@ setParameterT(UInt64)
 setParameterT(Real32);
 setParameterT(Real64);
 
-// buffer mechanism can't handle Handles. RegionImpl must override these methods. 
+// buffer mechanism can't handle Handles. RegionImpl must override these methods.
 Handle RegionImpl::getParameterHandle(const std::string& name, Int64 index)
 {
   NTA_THROW << "Unknown parameter '"  << name << "' of type Handle.";
@@ -126,7 +125,7 @@ Handle RegionImpl::getParameterHandle(const std::string& name, Int64 index)
 void RegionImpl::setParameterHandle(const std::string& name, Int64 index, Handle h)
 {
   NTA_THROW << "Unknown parameter '"  << name << "' of type Handle.";
-}  
+}
 
 
 
@@ -139,7 +138,7 @@ void RegionImpl::getParameterArray(const std::string& name, Int64 index, Array &
   void *buffer = array.getBuffer();
 
   for (size_t i = 0; i < count; i++)
-  { 
+  {
     int rc;
     switch (array.getType())
     {
@@ -170,7 +169,7 @@ void RegionImpl::getParameterArray(const std::string& name, Int64 index, Array &
                 << " in getParameterArray for parameter " << name;
       break;
     }
-    
+
     if (rc != 0)
     {
       NTA_THROW << "getParameterArray -- failure to get parameter '"
@@ -187,7 +186,7 @@ void RegionImpl::setParameterArray(const std::string& name, Int64 index,const Ar
   size_t count = array.getCount();
   void *buffer = array.getBuffer();
   for (size_t i = 0; i < count; i++)
-  { 
+  {
     int rc;
     switch (array.getType())
     {
@@ -247,14 +246,14 @@ bool RegionImpl::isParameterShared(const std::string& name)
   NTA_THROW << "RegionImpl::isParameterShared was not overridden in node type " << getType();
 }
 
-void RegionImpl::getParameterFromBuffer(const std::string& name, 
-                             Int64 index, 
+void RegionImpl::getParameterFromBuffer(const std::string& name,
+                             Int64 index,
                              IWriteBuffer& value)
 {
   NTA_THROW << "RegionImpl::getParameterFromBuffer must be overridden by subclasses";
 }
 
-void RegionImpl::setParameterFromBuffer(const std::string& name, 
+void RegionImpl::setParameterFromBuffer(const std::string& name,
                           Int64 index,
                           IReadBuffer& value)
 {
@@ -266,14 +265,14 @@ void RegionImpl::setParameterFromBuffer(const std::string& name,
 size_t RegionImpl::getParameterArrayCount(const std::string& name, Int64 index)
 {
   // Default implementation for RegionImpls with no array parameters
-  // that have a dynamic length. 
+  // that have a dynamic length.
   //std::map<std::string, ParameterSpec*>::iterator i = nodespec_->parameters.find(name);
   //if (i == nodespec_->parameters.end())
 
-  
+
   if (!region_->getSpec()->parameters.contains(name))
   {
-    NTA_THROW << "getParameterArrayCount -- no parameter named '" 
+    NTA_THROW << "getParameterArrayCount -- no parameter named '"
               << name << "' in node of type " << getType();
   }
   UInt32 count = region_->getSpec()->parameters.getByName(name).count;
@@ -306,4 +305,3 @@ const Dimensions& RegionImpl::getDimensions()
 }
 
 }
-

--- a/src/nupic/engine/RegionImpl.cpp
+++ b/src/nupic/engine/RegionImpl.cpp
@@ -22,6 +22,11 @@
 
 #include <iostream>
 
+#include <capnp/any.h>
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+#include <kj/std/iostream.h>
+
 #include <nupic/engine/Region.hpp>
 #include <nupic/engine/RegionImpl.hpp>
 #include <nupic/engine/Spec.hpp>
@@ -302,6 +307,25 @@ const Output* RegionImpl::getOutput(const std::string& name)
 const Dimensions& RegionImpl::getDimensions()
 {
   return region_->getDimensions();
+}
+
+void RegionImpl::writeToStream(std::ostream& stream) const
+{
+  capnp::MallocMessageBuilder message;
+  capnp::AnyPointer::Builder proto = message.initRoot<capnp::AnyPointer>();
+  this->write(proto);
+
+  kj::std::StdOutputStream out(stream);
+  capnp::writeMessage(out, message);
+}
+
+void RegionImpl::readFromStream(std::istream& stream)
+{
+  kj::std::StdInputStream in(stream);
+
+  capnp::InputStreamMessageReader message(in);
+  capnp::AnyPointer::Reader proto = message.getRoot<capnp::AnyPointer>();
+  this->read(proto);
 }
 
 }

--- a/src/nupic/engine/RegionImpl.hpp
+++ b/src/nupic/engine/RegionImpl.hpp
@@ -20,11 +20,11 @@
  * ---------------------------------------------------------------------
  */
 
-/** @file 
+/** @file
  * Definition of the RegionImpl API
  *
- * A RegionImpl is a node "plugin" that provides most of the 
- * implementation of a Region, including algorithms. 
+ * A RegionImpl is a node "plugin" that provides most of the
+ * implementation of a Region, including algorithms.
  *
  * The RegionImpl class is expected to be subclassed for particular
  * node types (e.g. FDRNode, PyNode, etc) and RegionImpls are created
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+
 #include <nupic/ntypes/ObjectModel.hpp> // IWriteBuffer
 
 namespace nupic
@@ -58,7 +59,7 @@ namespace nupic
 
     // All subclasses must call this constructor from their regular constructor
     RegionImpl(Region* region);
-    
+
     virtual ~RegionImpl();
 
 
@@ -66,15 +67,15 @@ namespace nupic
     /* ------- Convenience methods  that access region data -------- */
 
     const std::string& getType() const;
-    
+
     const std::string& getName() const;
 
     const NodeSet& getEnabledNodes() const;
 
     /* ------- Parameter support in the base class. ---------*/
-    // The default implementation of all of these methods goes through 
-    // set/getParameterFromBuffer, which is compatible with NuPIC 1. 
-    // RegionImpl subclasses may override for higher performance. 
+    // The default implementation of all of these methods goes through
+    // set/getParameterFromBuffer, which is compatible with NuPIC 1.
+    // RegionImpl subclasses may override for higher performance.
 
     virtual Int32 getParameterInt32(const std::string& name, Int64 index);
     virtual UInt32 getParameterUInt32(const std::string& name, Int64 index);
@@ -91,7 +92,7 @@ namespace nupic
     virtual void setParameterReal32(const std::string& name, Int64 index, Real32 value);
     virtual void setParameterReal64(const std::string& name, Int64 index, Real64 value);
     virtual void setParameterHandle(const std::string& name, Int64 index, Handle value);
-    
+
     virtual void getParameterArray(const std::string& name, Int64 index, Array & array);
     virtual void setParameterArray(const std::string& name, Int64 index, const Array & array);
 
@@ -103,12 +104,12 @@ namespace nupic
 
     /**
      * Can't declare a static method in an interface. But RegionFactory
-     * expects to find this method. Caller gets ownership. 
+     * expects to find this method. Caller gets ownership.
      */
 
     //static Spec* createSpec();
 
-    // Serialize state. 
+    // Serialize state.
     virtual void serialize(BundleIO& bundle) = 0;
 
     // De-serialize state. Must be called from deserializing constructor
@@ -130,24 +131,24 @@ namespace nupic
     virtual std::string executeCommand(const std::vector<std::string>& args, Int64 index) = 0;
 
 
-    // Per-node size (in elements) of the given output. 
+    // Per-node size (in elements) of the given output.
     // For per-region outputs, it is the total element count.
     // This method is called only for outputs whose size is not
-    // specified in the nodespec. 
+    // specified in the nodespec.
     virtual size_t getNodeOutputElementCount(const std::string& outputName) = 0;
 
     /**
-     * Get a parameter from a write buffer. 
+     * Get a parameter from a write buffer.
      * This method is called only by the typed getParameter*
      * methods in the RegionImpl base class
-     * 
+     *
      * Must be implemented by all subclasses.
      *
      * @param index A node index. (-1) indicates a region-level parameter
      *
      */
-    virtual void getParameterFromBuffer(const std::string& name, 
-                                        Int64 index, 
+    virtual void getParameterFromBuffer(const std::string& name,
+                                        Int64 index,
                                         IWriteBuffer& value) = 0;
 
     /**
@@ -158,7 +159,7 @@ namespace nupic
      *
      * @param index A node index. (-1) indicates a region-level parameter
      */
-    virtual void setParameterFromBuffer(const std::string& name, 
+    virtual void setParameterFromBuffer(const std::string& name,
                               Int64 index,
                               IReadBuffer& value) = 0;
 
@@ -168,11 +169,11 @@ namespace nupic
 
 
     /**
-     * Array-valued parameters may have a size determined at runtime. 
-     * This method returns the number of elements in the named parameter. 
+     * Array-valued parameters may have a size determined at runtime.
+     * This method returns the number of elements in the named parameter.
      * If parameter is not an array type, may throw an exception or return 1.
      *
-     * Must be implemented only if the node has one or more array 
+     * Must be implemented only if the node has one or more array
      * parameters with a dynamically-determined length.
      */
     virtual size_t getParameterArrayCount(const std::string& name, Int64 index);
@@ -187,27 +188,27 @@ namespace nupic
 
 
 
-  protected: 
+  protected:
     Region* region_;
 
     /* -------- Methods provided by the base class for use by subclasses -------- */
-    
+
     // ---
-    /// Callback for subclasses to get an output stream during serialize() 
+    /// Callback for subclasses to get an output stream during serialize()
     /// (for output) and the deserializing constructor (for input)
-    /// It is invalid to call this method except inside serialize() in a subclass. 
-    /// 
+    /// It is invalid to call this method except inside serialize() in a subclass.
+    ///
     /// Only one serialization stream may be open at a time. Calling
-    /// getSerializationXStream a second time automatically closes the 
-    /// first stream. Any open stream is closed when serialize() returns. 
+    /// getSerializationXStream a second time automatically closes the
+    /// first stream. Any open stream is closed when serialize() returns.
     // ---
     std::ostream& getSerializationOutputStream(const std::string& name);
     std::istream& getSerializationInputStream(const std::string& name);
     std::string getSerializationPath(const std::string& name);
 
     // These methods provide access to inputs and outputs
-    // They raise an exception if the named input or output is 
-    // not found. 
+    // They raise an exception if the named input or output is
+    // not found.
     const Input* getInput(const std::string& name);
     const Output* getOutput(const std::string& name);
 
@@ -216,6 +217,5 @@ namespace nupic
   };
 
 }
-
 
 #endif // NTA_REGION_IMPL_HPP

--- a/src/nupic/engine/RegionImpl.hpp
+++ b/src/nupic/engine/RegionImpl.hpp
@@ -34,8 +34,11 @@
 #ifndef NTA_REGION_IMPL_HPP
 #define NTA_REGION_IMPL_HPP
 
+#include <iostream>
 #include <string>
 #include <vector>
+
+#include <capnp/any.h>
 
 #include <nupic/ntypes/ObjectModel.hpp> // IWriteBuffer
 
@@ -115,6 +118,14 @@ namespace nupic
     // De-serialize state. Must be called from deserializing constructor
     virtual void deserialize(BundleIO& bundle) = 0;
 
+    // Serialize state with capnp
+    void writeToStream(std::ostream& stream) const;
+    virtual void write(capnp::AnyPointer::Builder& anyProto) const = 0;
+
+    // Deserialize state from capnp. Must be called from deserializing
+    // constructor.
+    void readFromStream(std::istream& stream);
+    virtual void read(capnp::AnyPointer::Reader& anyProto) = 0;
 
     /**
      * Inputs/Outputs are made available in initialize()

--- a/src/nupic/engine/RegionImpl.hpp
+++ b/src/nupic/engine/RegionImpl.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *
@@ -20,8 +20,10 @@
  * ---------------------------------------------------------------------
  */
 
-
 #include <stdexcept>
+
+#include <capnp/any.h>
+
 #include <nupic/engine/RegionImplFactory.hpp>
 #include <nupic/engine/RegionImpl.hpp>
 #include <nupic/engine/Region.hpp>
@@ -62,7 +64,7 @@ namespace nupic
     {
       pyRegions[module] = std::set<std::string>();
     }
-        
+
     pyRegions[module].insert(className);
   }
 
@@ -97,8 +99,8 @@ namespace nupic
       rootDir_ = OS::executeCommand(command);
       if (!Path::exists(rootDir_))
         NTA_THROW << "Unable to find NuPIC library in '" << rootDir_ << "'";
-      
-      
+
+
 #if defined(NTA_OS_WINDOWS)
       const char * filename = "cpp_region.dll";
 #else
@@ -111,20 +113,20 @@ namespace nupic
         NTA_THROW << "Unable to find library '" << libName << "'";
 
       std::string errorString;
-      DynamicLibrary * p = 
-        DynamicLibrary::load(libName, 
+      DynamicLibrary * p =
+        DynamicLibrary::load(libName,
                              // export as LOCAL because we don't want
-                             // the symbols to be globally visible; 
+                             // the symbols to be globally visible;
                              // But the python module that we load
                              // has to be able to access symbols from
                              // libpython.so; Since libpython.so is linked
                              // to the pynode shared library, it appears
                              // we have to make the pynode shared library
                              // symbols global. TODO: investigate
-                             DynamicLibrary::GLOBAL| 
-                             // Evaluate them NOW instead of LAZY to catch 
+                             DynamicLibrary::GLOBAL|
+                             // Evaluate them NOW instead of LAZY to catch
                              // errors up front, even though this takes
-                             // a little longer to load the library. 
+                             // a little longer to load the library.
                              // However -- the current dependency chain
                              // PyNode->Region->RegionImplFactory apparently
                              // creates never-used dependencies on YAML
@@ -161,7 +163,7 @@ namespace nupic
       //NTA_DEBUG << "In DynamicPythonLibrary Destructor";
       if (finalizePython_)
         finalizePython_();
-    } 
+    }
 
     void * createSpec(std::string nodeType, void ** exception, std::string className)
     {
@@ -175,7 +177,7 @@ namespace nupic
       return (*destroySpec_)(nodeType.c_str(), className.c_str());
     }
 
-    void * createPyNode(const std::string& nodeType, 
+    void * createPyNode(const std::string& nodeType,
                         ValueMap * nodeParams,
                         Region * region,
                         void ** exception,
@@ -190,16 +192,16 @@ namespace nupic
 
     }
 
-    void * deserializePyNode(const std::string& nodeType, 
+    void * deserializePyNode(const std::string& nodeType,
                              BundleIO* bundle,
-                             Region * region, 
+                             Region * region,
                              void ** exception,
                              const std::string& className)
     {
       //NTA_DEBUG << "RegionImplFactory::deserializePyNode(" << nodeType << ")";
-      return (*deserializePyNode_)(nodeType.c_str(), 
+      return (*deserializePyNode_)(nodeType.c_str(),
                                    reinterpret_cast<void*>(bundle),
-                                   reinterpret_cast<void*>(region), 
+                                   reinterpret_cast<void*>(region),
                                    exception,
                                    className.c_str());
     }
@@ -238,8 +240,8 @@ RegionImplFactory & RegionImplFactory::getInstance()
   return instance;
 }
 
-// This function creates either a NuPIC 2 or NuPIC 1 Python node 
-static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib, 
+// This function creates either a NuPIC 2 or NuPIC 1 Python node
+static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib,
                                  const std::string & nodeType,
                                  ValueMap * nodeParams,
                                  Region * region)
@@ -266,8 +268,8 @@ static RegionImpl * createPyNode(DynamicPythonLibrary * pyLib,
   return nullptr;
 }
 
-// This function deserializes either a NuPIC 2 or NuPIC 1 Python node 
-static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib, 
+// This function deserializes either a NuPIC 2 or NuPIC 1 Python node
+static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
                                       const std::string & nodeType,
                                       BundleIO & bundle,
                                       Region * region)
@@ -297,64 +299,90 @@ static RegionImpl * deserializePyNode(DynamicPythonLibrary * pyLib,
 
 }
 
-RegionImpl* RegionImplFactory::createRegionImpl(const std::string nodeType, 
+RegionImpl* RegionImplFactory::createRegionImpl(const std::string nodeType,
                                                 const std::string nodeParams,
                                                 Region* region)
 {
 
-  RegionImpl *mn = nullptr;
+  RegionImpl *impl = nullptr;
   Spec *ns = getSpec(nodeType);
   ValueMap vm = YAMLUtils::toValueMap(
-    nodeParams.c_str(), 
-    ns->parameters, 
-    nodeType, 
+    nodeParams.c_str(),
+    ns->parameters,
+    nodeType,
     region->getName());
-    
+
   if (cppRegions.find(nodeType) != cppRegions.end())
   {
-    mn = cppRegions[nodeType]->createRegionImpl(vm, region);
+    impl = cppRegions[nodeType]->createRegionImpl(vm, region);
   }
   else if ((nodeType.find(std::string("py.")) == 0))
   {
     if (!pyLib_)
       pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
-    
-    mn = createPyNode(pyLib_.get(), nodeType, &vm, region);
+
+    impl = createPyNode(pyLib_.get(), nodeType, &vm, region);
   } else
   {
     NTA_THROW << "Unsupported node type '" << nodeType << "'";
   }
 
-  return mn;
+  return impl;
 
 }
 
-RegionImpl* RegionImplFactory::deserializeRegionImpl(const std::string nodeType, 
+RegionImpl* RegionImplFactory::deserializeRegionImpl(const std::string nodeType,
                                                      BundleIO& bundle,
                                                      Region* region)
 {
 
-  RegionImpl *mn = nullptr;
+  RegionImpl *impl = nullptr;
 
   if (cppRegions.find(nodeType) != cppRegions.end())
   {
-    mn = cppRegions[nodeType]->deserializeRegionImpl(bundle, region);
+    impl = cppRegions[nodeType]->deserializeRegionImpl(bundle, region);
   }
   else if (StringUtils::startsWith(nodeType, "py."))
   {
     if (!pyLib_)
       pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
-    
-    mn = deserializePyNode(pyLib_.get(), nodeType, bundle, region);
+
+    impl = deserializePyNode(pyLib_.get(), nodeType, bundle, region);
   } else
   {
     NTA_THROW << "Unsupported node type '" << nodeType << "'";
   }
-  return mn;
+  return impl;
 
 }
 
-// This function returns the node spec of a NuPIC 2 or NuPIC 1 Python node 
+RegionImpl* RegionImplFactory::deserializeRegionImpl(
+    const std::string nodeType,
+    capnp::AnyPointer::Reader& proto,
+    Region* region)
+{
+  RegionImpl *impl = nullptr;
+
+  if (cppRegions.find(nodeType) != cppRegions.end())
+  {
+    impl = cppRegions[nodeType]->deserializeRegionImpl(proto, region);
+  }
+  else if (StringUtils::startsWith(nodeType, "py."))
+  {
+    NTA_THROW << "Python regions not yet supported for Cap'n Proto "
+      << "deserialization.";
+    //if (!pyLib_)
+    //  pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
+
+    //impl = deserializePyNode(pyLib_.get(), nodeType, proto, region);
+  } else
+  {
+    NTA_THROW << "Unsupported node type '" << nodeType << "'";
+  }
+  return impl;
+}
+
+// This function returns the node spec of a NuPIC 2 or NuPIC 1 Python node
 static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
@@ -400,8 +428,8 @@ Spec * RegionImplFactory::getSpec(const std::string nodeType)
       pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
 
     ns = getPySpec(pyLib_.get(), nodeType);
-  } 
-  else 
+  }
+  else
   {
     NTA_THROW << "getSpec() -- Unsupported node type '" << nodeType << "'";
   }
@@ -412,7 +440,7 @@ Spec * RegionImplFactory::getSpec(const std::string nodeType)
   nodespecCache_[nodeType] = ns;
   return ns;
 }
-    
+
 void RegionImplFactory::cleanup()
 {
   std::map<std::string, Spec*>::iterator ns;
@@ -454,4 +482,3 @@ void RegionImplFactory::cleanup()
 }
 
 }
-

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -371,11 +371,14 @@ RegionImpl* RegionImplFactory::deserializeRegionImpl(
   {
     NTA_THROW << "Python regions not yet supported for Cap'n Proto "
       << "deserialization.";
+    // Temporarily disabled for Cap'n Proto serialization until PyRegion in
+    // nupic defines the new RegionImpl functions.
     //if (!pyLib_)
     //  pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
 
     //impl = deserializePyNode(pyLib_.get(), nodeType, proto, region);
-  } else
+  }
+  else
   {
     NTA_THROW << "Unsupported node type '" << nodeType << "'";
   }

--- a/src/nupic/engine/RegionImplFactory.hpp
+++ b/src/nupic/engine/RegionImplFactory.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *
@@ -20,22 +20,24 @@
  * ---------------------------------------------------------------------
  */
 
-/** @file 
+/** @file
  * Definition of the RegionImpl Factory API
  *
- * A RegionImplFactory creates RegionImpls upon request. 
- * Pynode creation is delegated to another class (TBD). 
- * Because all C++ RegionImpls are compiled in to NuPIC, 
- * the RegionImpl factory knows about them explicitly. 
- * 
+ * A RegionImplFactory creates RegionImpls upon request.
+ * Pynode creation is delegated to another class (TBD).
+ * Because all C++ RegionImpls are compiled in to NuPIC,
+ * the RegionImpl factory knows about them explicitly.
+ *
  */
 
 #ifndef NTA_REGION_IMPL_FACTORY_HPP
 #define NTA_REGION_IMPL_FACTORY_HPP
 
-#include <string>
 #include <map>
+#include <string>
+
 #include <boost/shared_ptr.hpp>
+#include <capnp/any.h>
 
 namespace nupic
 {
@@ -57,24 +59,27 @@ namespace nupic
     ~RegionImplFactory() {};
 
     // Create a RegionImpl of a specific type; caller gets ownership.
-    RegionImpl* createRegionImpl(const std::string nodeType, 
+    RegionImpl* createRegionImpl(const std::string nodeType,
                                  const std::string nodeParams,
                                  Region* region);
 
-    // Create a RegionImpl from serialized state; caller gets ownership. 
+    // Create a RegionImpl from serialized state; caller gets ownership.
     RegionImpl* deserializeRegionImpl(const std::string nodeType,
                                       BundleIO& bundle,
                                       Region* region);
 
+    // Create a RegionImpl from capnp proto; caller gets ownership.
+    RegionImpl* deserializeRegionImpl(const std::string nodeType,
+                                      capnp::AnyPointer::Reader& proto,
+                                      Region* region);
 
-
-    // Returns nodespec for a specific node type; Factory retains ownership. 
+    // Returns nodespec for a specific node type; Factory retains ownership.
     Spec* getSpec(const std::string nodeType);
 
     // RegionImplFactory caches nodespecs and the dynamic library reference
     // This frees up the cached information.
     // Should be called only if there are no outstanding
-    // nodespec references (e.g. in NuPIC shutdown) or pynodes. 
+    // nodespec references (e.g. in NuPIC shutdown) or pynodes.
     void cleanup();
 
     static void registerPyRegionPackage(const char * path);
@@ -89,21 +94,18 @@ namespace nupic
     RegionImplFactory() {};
     RegionImplFactory(const RegionImplFactory &);
 
-  private:
-
     // TODO: implement locking for thread safety for this global data structure
     // TODO: implement cleanup
 
-    // getSpec returns references to nodespecs in this cache. 
-    // should not be cleaned up until those references have disappeared. 
+    // getSpec returns references to nodespecs in this cache.
+    // should not be cleaned up until those references have disappeared.
     std::map<std::string, Spec*> nodespecCache_;
 
     // Using shared_ptr here to ensure the dynamic python library object
     // is deleted when the factory goes away. Can't use scoped_ptr
     // because it is not initialized in the constructor.
-    boost::shared_ptr<DynamicPythonLibrary> pyLib_; 
+    boost::shared_ptr<DynamicPythonLibrary> pyLib_;
   };
 }
-
 
 #endif // NTA_REGION_IMPL_FACTORY_HPP

--- a/src/nupic/engine/RegisteredRegionImpl.hpp
+++ b/src/nupic/engine/RegisteredRegionImpl.hpp
@@ -42,40 +42,53 @@ namespace nupic
 
   class GenericRegisteredRegionImpl {
     public:
-      GenericRegisteredRegionImpl() {
-      }
-      virtual ~GenericRegisteredRegionImpl() {
-      }
-      virtual RegionImpl* createRegionImpl(const ValueMap& params, Region *region) {
-        return nullptr;
-      }
-      virtual RegionImpl* deserializeRegionImpl(BundleIO& params, Region *region) {
-        return nullptr;
-      }
-      virtual Spec* createSpec() {
-        return nullptr;
-      }
+      GenericRegisteredRegionImpl() {}
+
+      virtual ~GenericRegisteredRegionImpl() {}
+
+      virtual RegionImpl* createRegionImpl(
+          const ValueMap& params, Region *region) = 0;
+
+      virtual RegionImpl* deserializeRegionImpl(
+          BundleIO& params, Region *region) = 0;
+
+      virtual RegionImpl* deserializeRegionImpl(
+          capnp::AnyPointer::Reader& proto, Region *region) = 0;
+
+      virtual Spec* createSpec() = 0;
   };
 
   template <class T>
   class RegisteredRegionImpl: public GenericRegisteredRegionImpl {
     public:
-      RegisteredRegionImpl() {
-      }
-      ~RegisteredRegionImpl() {
-      }
-      T* createRegionImpl(const ValueMap& params, Region *region) {
+      RegisteredRegionImpl() {}
+
+      ~RegisteredRegionImpl() {}
+
+      virtual RegionImpl* createRegionImpl(
+          const ValueMap& params, Region *region) override
+      {
         return new T(params, region);
       }
-      T* deserializeRegionImpl(BundleIO& params, Region *region) {
+
+      virtual RegionImpl* deserializeRegionImpl(
+          BundleIO& params, Region *region) override
+      {
         return new T(params, region);
       }
-      Spec* createSpec()
+
+      virtual RegionImpl* deserializeRegionImpl(
+          capnp::AnyPointer::Reader& proto, Region *region) override
+      {
+        return new T(proto, region);
+      }
+
+      virtual Spec* createSpec() override
       {
         return T::createSpec();
       }
   };
-}
 
+}
 
 #endif // NTA_REGISTERED_REGION_IMPL_HPP

--- a/src/nupic/engine/TestNode.hpp
+++ b/src/nupic/engine/TestNode.hpp
@@ -89,8 +89,8 @@ namespace nupic
     void serialize(BundleIO& bundle) override;
     void deserialize(BundleIO& bundle) override;
 
-    virtual void write(capnp::AnyPointer::Builder& anyProto) const;
-    virtual void read(capnp::AnyPointer::Reader& anyProto);
+    virtual void write(capnp::AnyPointer::Builder& anyProto) const override;
+    virtual void read(capnp::AnyPointer::Reader& anyProto) override;
 
     /* -----------  Optional RegionImpl Interface methods ------- */
 

--- a/src/nupic/regions/VectorFileEffector.hpp
+++ b/src/nupic/regions/VectorFileEffector.hpp
@@ -97,8 +97,8 @@ namespace nupic
     // ---
     virtual void deserialize(BundleIO& bundle) override;
 
-    virtual void write(capnp::AnyPointer::Builder& anyProto) const;
-    virtual void read(capnp::AnyPointer::Reader& anyProto);
+    virtual void write(capnp::AnyPointer::Builder& anyProto) const override;
+    virtual void read(capnp::AnyPointer::Reader& anyProto) override;
 
     void compute() override;
 

--- a/src/nupic/regions/VectorFileSensor.hpp
+++ b/src/nupic/regions/VectorFileSensor.hpp
@@ -301,8 +301,8 @@ namespace nupic
     // ---
     virtual void deserialize(BundleIO& bundle) override;
 
-    virtual void write(capnp::AnyPointer::Builder& anyProto) const;
-    virtual void read(capnp::AnyPointer::Reader& anyProto);
+    virtual void write(capnp::AnyPointer::Builder& anyProto) const override;
+    virtual void read(capnp::AnyPointer::Reader& anyProto) override;
 
     void compute() override;
     virtual std::string executeCommand(const std::vector<std::string>& args, Int64 index) override;


### PR DESCRIPTION
This adds serialization logic to the RegionImpl base class so that the Region class can serialize the various RegionImpl subclasses. It also provides read from / write to stream functions for each RegionImpl subclass.

fixes #477

@chetan51 please review