### PR TITLE
Implements capnp serialization for Network class

### DIFF
--- a/src/examples/regions/HelloRegions.cpp
+++ b/src/examples/regions/HelloRegions.cpp
@@ -21,11 +21,14 @@
  */
 
 #include <iostream>
+#include <sstream>
+
 #include <nupic/engine/Network.hpp>
 #include <nupic/engine/Region.hpp>
 #include <nupic/ntypes/Dimensions.hpp>
 #include <nupic/ntypes/ArrayRef.hpp>
 #include <nupic/os/Path.hpp>
+#include <nupic/utils/Log.hpp>
 
 
 
@@ -77,6 +80,30 @@ int main(int argc, const char * argv[])
     for (size_t i = 0; i < outputArray.getCount(); i++)
     {
         std::cout << "  " << i << "    " << buffer[i] << "" << std::endl;
+    }
+
+    // Serialize
+    Network net2;
+    {
+      std::stringstream ss;
+      net.write(ss);
+      net2.read(ss);
+    }
+    net2.initialize();
+
+    Region* region2 = net2.getRegions().getByName("region");
+    region2->executeCommand(loadFileArgs);
+    ArrayRef outputArray2 = region2->getOutputData("dataOut");
+    Real64 *buffer2 = (Real64*)outputArray2.getBuffer();
+
+    net.run(1);
+    net2.run(1);
+
+    NTA_ASSERT(outputArray2.getCount() == outputArray.getCount());
+    for (size_t i = 0; i < outputArray.getCount(); i++)
+    {
+        std::cout << "  " << i << "    " << buffer[i] << "   " << buffer2[i]
+                  << std::endl;
     }
 
     return 0;

--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -1022,7 +1022,7 @@ void Network::write(NetworkProto::Builder& proto) const
     auto entry = entriesProto[i];
     auto regionPair = regions_.getByIndex(i);
     auto regionProto = entry.initValue();
-    entry.setKey(regionPair.first);
+    entry.setKey(regionPair.first.c_str());
     regionPair.second->write(regionProto);
 
     // Aggregate this regions links in a vector to store at end
@@ -1056,7 +1056,7 @@ void Network::read(NetworkProto::Reader& proto)
   for (auto entry : proto.getRegions().getEntries())
   {
     auto regionProto = entry.getValue();
-    auto region = addRegionFromProto(entry.getKey(), regionProto);
+    auto region = addRegionFromProto(entry.getKey().cStr(), regionProto);
     // Initialize the phases for the region
     std::set<UInt32> phases;
     for (auto phase : regionProto.getPhases())
@@ -1070,26 +1070,26 @@ void Network::read(NetworkProto::Reader& proto)
   // because the linked input and output need references to the new link.
   for (auto linkProto : proto.getLinks())
   {
-    if (!regions_.contains(linkProto.getSrcRegion()))
+    if (!regions_.contains(linkProto.getSrcRegion().cStr()))
     {
       NTA_THROW << "Link references unknown region: "
                 << linkProto.getSrcRegion().cStr();
     }
-    Region* srcRegion = regions_.getByName(linkProto.getSrcRegion());
-    Output* srcOutput = srcRegion->getOutput(linkProto.getSrcOutput());
+    Region* srcRegion = regions_.getByName(linkProto.getSrcRegion().cStr());
+    Output* srcOutput = srcRegion->getOutput(linkProto.getSrcOutput().cStr());
     if (srcOutput == nullptr)
     {
       NTA_THROW << "Link references unknown source output: "
                 << linkProto.getSrcOutput().cStr();
     }
 
-    if (!regions_.contains(linkProto.getDestRegion()))
+    if (!regions_.contains(linkProto.getDestRegion().cStr()))
     {
       NTA_THROW << "Link references unknown region: "
                 << linkProto.getDestRegion().cStr();
     }
-    Region* destRegion = regions_.getByName(linkProto.getDestRegion());
-    Input* destInput = destRegion->getInput(linkProto.getDestInput());
+    Region* destRegion = regions_.getByName(linkProto.getDestRegion().cStr());
+    Input* destInput = destRegion->getInput(linkProto.getDestInput().cStr());
     if (destInput == nullptr)
     {
       NTA_THROW << "Link references unknown destination input: "
@@ -1097,7 +1097,8 @@ void Network::read(NetworkProto::Reader& proto)
     }
 
     // Actually create the link
-    destInput->addLink(linkProto.getType(), linkProto.getParams(), srcOutput);
+    destInput->addLink(
+        linkProto.getType().cStr(), linkProto.getParams().cStr(), srcOutput);
   }
 
   initialized_ = false;

--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -20,7 +20,7 @@
  * ---------------------------------------------------------------------
  */
 
-/** @file 
+/** @file
 Implementation of the Network class
 */
 
@@ -45,6 +45,7 @@ Implementation of the Network class
 
 namespace nupic
 {
+
 class GenericRegisteredRegionImpl;
 
 Network::Network()
@@ -80,7 +81,7 @@ Network::~Network()
    * Teardown choreography:
    * - unitialize all regions because otherwise we won't be able to disconnect them
    * - remove all links, because we can't delete connected regions
-   * - delete the regions themselves. 
+   * - delete the regions themselves.
    */
 
   // 1. uninitialize
@@ -107,8 +108,8 @@ Network::~Network()
 }
 
 
-Region* Network::addRegion(const std::string& name, 
-                           const std::string& nodeType, 
+Region* Network::addRegion(const std::string& name,
+                           const std::string& nodeType,
                            const std::string& nodeParams)
 {
   if (regions_.contains(name))
@@ -117,7 +118,7 @@ Region* Network::addRegion(const std::string& name,
   auto r = new Region(name, nodeType, nodeParams, this);
   regions_.add(name, r);
   initialized_ = false;
-    
+
   setDefaultPhase_(r);
   return r;
 }
@@ -133,24 +134,24 @@ void Network::setDefaultPhase_(Region* region)
 
 
 
-Region* Network::addRegionFromBundle(const std::string& name, 
-                                     const std::string& nodeType, 
-                                     const Dimensions& dimensions, 
-                                     const std::string& bundlePath, 
+Region* Network::addRegionFromBundle(const std::string& name,
+                                     const std::string& nodeType,
+                                     const Dimensions& dimensions,
+                                     const std::string& bundlePath,
                                      const std::string& label)
 {
   if (regions_.contains(name))
     NTA_THROW << "Invalid saved network: two or more instance of region '" << name << "'";
 
   if (! Path::exists(bundlePath))
-    NTA_THROW << "addRegionFromBundle -- bundle '" << bundlePath 
+    NTA_THROW << "addRegionFromBundle -- bundle '" << bundlePath
               << " does not exist";
-  
+
   BundleIO bundle(bundlePath, label, name, /* isInput: */ true );
   auto r = new Region(name, nodeType, dimensions, bundle, this);
   regions_.add(name, r);
   initialized_ = false;
-    
+
   // In the normal use case (deserializing a network from a bundle)
   // this default phase will immediately be overridden with the
   // saved phases. Having it here makes it possible for user code
@@ -160,7 +161,7 @@ Region* Network::addRegionFromBundle(const std::string& name,
 }
 
 
-void 
+void
 Network::setPhases_(Region *r, std::set<UInt32>& phases)
 {
   if (phases.empty())
@@ -172,8 +173,8 @@ Network::setPhases_(Region *r, std::set<UInt32>& phases)
   {
     // It is very unlikely that someone would add a region
     // with a phase much greater than the phase of any other
-    // region. This sanity check catches such problems, 
-    // though it should arguably be legal to set any phase. 
+    // region. This sanity check catches such problems,
+    // though it should arguably be legal to set any phase.
     if (maxNewPhase - nextPhase > 3)
       NTA_THROW << "Attempt to set phase of " << maxNewPhase
                 << " when expected next phase is " << nextPhase
@@ -193,7 +194,7 @@ Network::setPhases_(Region *r, std::set<UInt32>& phases)
     if (item != phaseInfo_[i].end() && !insertPhase)
     {
       phaseInfo_[i].erase(item);
-    } else if (insertPhase) 
+    } else if (insertPhase)
     {
       phaseInfo_[i].insert(r);
     }
@@ -230,7 +231,7 @@ Network::getPhases(const std::string& name) const
 {
   if (! regions_.contains(name))
     NTA_THROW << "setPhases -- no region exists with name '" << name << "'";
-  
+
   Region *r = regions_.getByName(name);
 
   std::set<UInt32> phases;
@@ -256,9 +257,9 @@ Network::removeRegion(const std::string& name)
   if (r->hasOutgoingLinks())
     NTA_THROW << "Unable to remove region '" << name << "' because it has one or more outgoing links";
 
-  // Network does not have to be uninitialized -- removing a region 
-  // has no effect on the network as long as it has no outgoing links, 
-  // which we have already checked. 
+  // Network does not have to be uninitialized -- removing a region
+  // has no effect on the network as long as it has no outgoing links,
+  // which we have already checked.
   // initialized_ = false;
 
   // Must uninitialize the region prior to removing incoming links
@@ -272,7 +273,7 @@ Network::removeRegion(const std::string& name)
     if (toremove != phase->end())
       phase->erase(toremove);
   }
-  
+
   // Trim phaseinfo as we may have no more regions at the highest phase(s)
   for (size_t i = phaseInfo_.size() - 1; i > 0; i--)
   {
@@ -288,19 +289,19 @@ Network::removeRegion(const std::string& name)
 
   return;
 }
-  
+
 
 void
-Network::link(const std::string& srcRegionName, const std::string& destRegionName, 
-              const std::string& linkType, const std::string& linkParams, 
+Network::link(const std::string& srcRegionName, const std::string& destRegionName,
+              const std::string& linkType, const std::string& linkParams,
               const std::string& srcOutputName, const std::string& destInputName)
 {
-  
+
   // Find the regions
   if (! regions_.contains(srcRegionName))
     NTA_THROW << "Network::link -- source region '" << srcRegionName << "' does not exist";
   Region* srcRegion = regions_.getByName(srcRegionName);
-  
+
   if (! regions_.contains(destRegionName))
     NTA_THROW << "Network::link -- dest region '" << destRegionName << "' does not exist";
   Region* destRegion = regions_.getByName(destRegionName);
@@ -310,10 +311,10 @@ Network::link(const std::string& srcRegionName, const std::string& destRegionNam
   std::string outputName = srcOutputName;
   if (outputName == "")
     outputName = srcSpec->getDefaultOutputName();
-  
+
   Output* srcOutput = srcRegion->getOutput(outputName);
   if (srcOutput == nullptr)
-    NTA_THROW << "Network::link -- output " << outputName 
+    NTA_THROW << "Network::link -- output " << outputName
               << " does not exist on region " << srcRegionName;
 
 
@@ -327,7 +328,7 @@ Network::link(const std::string& srcRegionName, const std::string& destRegionNam
   Input* destInput = destRegion->getInput(inputName);
   if (destInput == nullptr)
   {
-    NTA_THROW << "Network::link -- input '" << inputName 
+    NTA_THROW << "Network::link -- input '" << inputName
               << " does not exist on region " << destRegionName;
   }
 
@@ -338,14 +339,14 @@ Network::link(const std::string& srcRegionName, const std::string& destRegionNam
 
 
 void
-Network::removeLink(const std::string& srcRegionName, const std::string& destRegionName, 
+Network::removeLink(const std::string& srcRegionName, const std::string& destRegionName,
                     const std::string& srcOutputName, const std::string& destInputName)
 {
   // Find the regions
   if (! regions_.contains(srcRegionName))
     NTA_THROW << "Network::unlink -- source region '" << srcRegionName << "' does not exist";
   Region* srcRegion =  regions_.getByName(srcRegionName);
-  
+
   if (! regions_.contains(destRegionName))
     NTA_THROW << "Network::unlink -- dest region '" << destRegionName << "' does not exist";
   Region* destRegion = regions_.getByName(destRegionName);
@@ -362,25 +363,25 @@ Network::removeLink(const std::string& srcRegionName, const std::string& destReg
   Input* destInput = destRegion->getInput(inputName);
   if (destInput == nullptr)
   {
-    NTA_THROW << "Network::unlink -- input '" << inputName 
+    NTA_THROW << "Network::unlink -- input '" << inputName
               << " does not exist on region " << destRegionName;
   }
-  
+
   std::string outputName = srcOutputName;
   if (outputName == "")
     outputName = srcSpec->getDefaultOutputName();
   Link* link = destInput->findLink(srcRegionName, outputName);
 
   if (link == nullptr)
-    NTA_THROW << "Network::unlink -- no link exists from region " << srcRegionName 
-              << " output " << outputName << " to region " << destRegionName 
+    NTA_THROW << "Network::unlink -- no link exists from region " << srcRegionName
+              << " output " << outputName << " to region " << destRegionName
               << " input " << destInput->getName();
 
   // Finally, remove the link
   destInput->removeLink(link);
 
 }
-  
+
 void
 Network::run(int n)
 {
@@ -403,7 +404,7 @@ Network::run(int n)
     {
       for (auto r : phaseInfo_[phase])
       {
-        
+
         r->prepareInputs();
         r->compute();
       }
@@ -414,7 +415,7 @@ Network::run(int n)
       std::pair<std::string, callbackItem>& callback = callbacks_.getByIndex(i);
       callback.second.first(this, iteration_, callback.second.second);
     }
-    
+
   }
 
   return;
@@ -425,32 +426,32 @@ void
 Network::initialize()
 {
 
-  /* 
-   * Do not reinitialize if already initialized. 
+  /*
+   * Do not reinitialize if already initialized.
    * Mostly, this is harmless, but it has a side
-   * effect of resetting the max/min enabled phases, 
-   * which causes havoc if we are in the middle of 
-   * a computation. 
+   * effect of resetting the max/min enabled phases,
+   * which causes havoc if we are in the middle of
+   * a computation.
    */
   if (initialized_)
     return;
 
   /*
-   * 1. Calculate all region dimensions by 
+   * 1. Calculate all region dimensions by
    * iteratively evaluating links to induce
    * region dimensions.
    */
 
-  
+
   // Iterate until all regions have finished
   // evaluating their links. If network is
-  // incompletely specified, we'll never finish, 
-  // so make sure we make progress each time 
-  // through the network. 
+  // incompletely specified, we'll never finish,
+  // so make sure we make progress each time
+  // through the network.
 
   size_t nLinksRemainingPrev = std::numeric_limits<size_t>::max();
   size_t nLinksRemaining = nLinksRemainingPrev - 1;
-    
+
   std::vector<Region*>::iterator r;
   while(nLinksRemaining > 0 && nLinksRemainingPrev > nLinksRemaining)
   {
@@ -460,8 +461,8 @@ Network::initialize()
     for (size_t i = 0; i < regions_.getCount(); i++)
     {
       // evaluateLinks returns the number
-      // of links which still need to be 
-      // evaluated. 
+      // of links which still need to be
+      // evaluated.
       Region *r = regions_.getByIndex(i).second;
       nLinksRemaining += r->evaluateLinks();
     }
@@ -483,7 +484,7 @@ Network::initialize()
     }
     NTA_THROW << ss.str();
   }
-      
+
 
   // Make sure all regions now have dimensions
   for (size_t i = 0; i < regions_.getCount(); i++)
@@ -499,7 +500,7 @@ Network::initialize()
     }
     if (!d.isValid())
     {
-      NTA_THROW << "Network::initialize() -- invalid dimensions " << d.toString() 
+      NTA_THROW << "Network::initialize() -- invalid dimensions " << d.toString()
                 << " for Region " << r->getName();
     }
 
@@ -509,7 +510,7 @@ Network::initialize()
   /*
    * 2. initialize outputs:
    *   - . Delegated to regions
-   */ 
+   */
   for (size_t i = 0; i < regions_.getCount(); i++)
   {
     Region *r = regions_.getByIndex(i).second;
@@ -542,7 +543,7 @@ Network::initialize()
 
 
   /*
-   * Mark network as initialized. 
+   * Mark network as initialized.
    */
   initialized_ = true;
 
@@ -578,7 +579,7 @@ UInt32
 Network::getMaxPhase() const
 {
   /*
-   * phaseInfo_ is always trimmed, so the max phase is 
+   * phaseInfo_ is always trimmed, so the max phase is
    * phaseInfo_.size()-1
    */
 
@@ -616,7 +617,7 @@ Network::getMinEnabledPhase() const
 }
 
 
-UInt32 
+UInt32
 Network::getMaxEnabledPhase() const
 {
   return maxEnabledPhase_;
@@ -633,13 +634,13 @@ void Network::save(const std::string& name)
   {
     saveToBundle(name);
   } else {
-    NTA_THROW << "Network::save -- unknown file extension for '" << name 
+    NTA_THROW << "Network::save -- unknown file extension for '" << name
               << "'. Supported extensions are .tgz and .nta";
   }
 }
 
 // A Region "name" is the name specified by the user in addRegion
-// This name may not be usable as part of a filesystem path, so 
+// This name may not be usable as part of a filesystem path, so
 // bundle files associated with a region use the region "label"
 // that can always be stored in the filesystem
 static std::string getLabel(size_t index)
@@ -662,7 +663,7 @@ void Network::saveToBundle(const std::string& name)
   {
     if (! Path::isDirectory(fullPath) || ! Path::exists(networkStructureFilename))
     {
-      NTA_THROW << "Existing filesystem entry " << fullPath 
+      NTA_THROW << "Existing filesystem entry " << fullPath
                 << " is not a network bundle -- refusing to delete";
     }
     Directory::removeTree(fullPath);
@@ -672,7 +673,7 @@ void Network::saveToBundle(const std::string& name)
 
   {
     YAML::Emitter out;
-    
+
     out << YAML::BeginMap;
     out << YAML::Key << "Version" << YAML::Value << 2;
     out << YAML::Key << "Regions" << YAML::Value << YAML::BeginSeq;
@@ -681,14 +682,14 @@ void Network::saveToBundle(const std::string& name)
       std::pair<std::string, Region*>& info = regions_.getByIndex(regionIndex);
       Region *r = info.second;
       // Network serializes the region directly because it is actually easier
-      // to do here than inside the region, and we don't have the RegionImpl data yet. 
+      // to do here than inside the region, and we don't have the RegionImpl data yet.
       out << YAML::BeginMap;
       out << YAML::Key << "name" << YAML::Value << info.first;
       out << YAML::Key << "nodeType" << YAML::Value << r->getType();
       out << YAML::Key << "dimensions" << YAML::Value << r->getDimensions();
 
-      // yaml-cpp doesn't come with a default emitter for std::set, so 
-      // implement as a sequence by hand. 
+      // yaml-cpp doesn't come with a default emitter for std::set, so
+      // implement as a sequence by hand.
       out << YAML::Key << "phases" << YAML::Value << YAML::BeginSeq;
       std::set<UInt32> phases = r->getPhases();
       for (const auto & phases_phase : phases)
@@ -702,7 +703,7 @@ void Network::saveToBundle(const std::string& name)
       out << YAML::EndMap;
     }
     out << YAML::EndSeq; // end of regions
-  
+
     out << YAML::Key << "Links" << YAML::Value << YAML::BeginSeq;
 
     for (size_t regionIndex = 0; regionIndex < regions_.getCount(); regionIndex++)
@@ -726,7 +727,7 @@ void Network::saveToBundle(const std::string& name)
         }
 
       }
-    }      
+    }
     out << YAML::EndSeq; // end of links
 
     out << YAML::EndMap; // end of network
@@ -757,7 +758,7 @@ void Network::load(const std::string& path)
   {
     loadFromBundle(path);
   } else {
-    NTA_THROW << "Network::save -- unknown file extension for '" << path 
+    NTA_THROW << "Network::save -- unknown file extension for '" << path
               << "'. Supported extensions are  .tgz and .nta";
   }
 
@@ -779,7 +780,7 @@ void Network::loadFromBundle(const std::string& name)
   YAML::Node doc;
   bool success = parser.GetNextDocument(doc);
   if (!success)
-    NTA_THROW << "Unable to find YAML document in network structure file " 
+    NTA_THROW << "Unable to find YAML document in network structure file "
               << networkStructureFilename;
 
   if (doc.Type() != YAML::NodeType::Map)
@@ -787,19 +788,19 @@ void Network::loadFromBundle(const std::string& name)
 
   // Should contain Version, Regions, Links
   if (doc.size() != 3)
-    NTA_THROW << "Invalid network structure file -- contains " 
+    NTA_THROW << "Invalid network structure file -- contains "
               << doc.size() << " elements";
 
   // Extra version
   const YAML::Node *node = doc.FindValue("Version");
   if (node == nullptr)
     NTA_THROW << "Invalid network structure file -- no version";
-  
+
   int version;
   *node >> version;
   if (version != 2)
     NTA_THROW << "Invalid network structure file -- only version 2 supported";
-  
+
   // Regions
   const YAML::Node *regions = doc.FindValue("Regions");
   if (regions == nullptr)
@@ -807,16 +808,16 @@ void Network::loadFromBundle(const std::string& name)
 
   if (regions->Type() != YAML::NodeType::Sequence)
     NTA_THROW << "Invalid network structure file -- regions element is not a list";
-  
+
   for (YAML::Iterator region = regions->begin(); region != regions->end(); region++)
   {
     // Each region is a map -- extract the 5 values in the map
     if ((*region).Type() != YAML::NodeType::Map)
       NTA_THROW << "Invalid network structure file -- bad region (not a map)";
-    
+
     if ((*region).size() != 5)
       NTA_THROW << "Invalid network structure file -- bad region (wrong size)";
-    
+
     // 1. name
     node = (*region).FindValue("name");
     if (node == nullptr)
@@ -827,7 +828,7 @@ void Network::loadFromBundle(const std::string& name)
     // 2. nodeType
     node = (*region).FindValue("nodeType");
     if (node == nullptr)
-      NTA_THROW << "Invalid network structure file -- region " 
+      NTA_THROW << "Invalid network structure file -- region "
                 << name << " has no node type";
     std::string nodeType;
     *node >> nodeType;
@@ -864,7 +865,7 @@ void Network::loadFromBundle(const std::string& name)
       (*valiter) >> val;
       phases.insert(val);
     }
-    
+
     // 5. label
     node = (*region).FindValue("label");
     if (node == nullptr)
@@ -872,7 +873,7 @@ void Network::loadFromBundle(const std::string& name)
                 << name << "has no label";
     std::string label;
     *node >> label;
-    
+
     Region *r = addRegionFromBundle(name, nodeType, dimensions, fullPath, label);
     setPhases_(r, phases);
 
@@ -891,10 +892,10 @@ void Network::loadFromBundle(const std::string& name)
     // Each link is a map -- extract the 5 values in the map
     if ((*link).Type() != YAML::NodeType::Map)
       NTA_THROW << "Invalid network structure file -- bad link (not a map)";
-    
+
     if ((*link).size() != 6)
       NTA_THROW << "Invalid network structure file -- bad link (wrong size)";
-    
+
     // 1. type
     node = (*link).FindValue("type");
     if (node == nullptr)
@@ -990,7 +991,6 @@ void Network::registerCPPRegion(const std::string name, GenericRegisteredRegionI
 {
   Region::registerCPPRegion(name, wrapper);
 }
-
 
 
 } // namespace nupic

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -20,7 +20,7 @@
  * ---------------------------------------------------------------------
  */
 
-/** @file 
+/** @file
  * Interface for the Network class
  */
 
@@ -61,7 +61,7 @@ namespace nupic
      *
      * Create an new Network and register it to NuPIC.
      *
-     * @note Creating a Network will auto-initialize NuPIC. 
+     * @note Creating a Network will auto-initialize NuPIC.
      */
     Network();
 
@@ -69,14 +69,14 @@ namespace nupic
      * Create a Network by loading previously saved bundle,
      * and register it to NuPIC.
      *
-     * @param path The path to the previously saved bundle file, currently only 
+     * @param path The path to the previously saved bundle file, currently only
      * support files with `.nta` extension.
      *
-     * @note Creating a Network will auto-initialize NuPIC. 
+     * @note Creating a Network will auto-initialize NuPIC.
      */
     Network(const std::string& path);
 
-    /** 
+    /**
      * Destructor.
      *
      * Destruct the network and unregister it from NuPIC:
@@ -90,10 +90,10 @@ namespace nupic
     ~Network();
 
     /**
-     * Initialize all elements of a network so that it can run. 
-     * 
-     * @note This can be called after the Network structure has been set and 
-     * before Network.run(). However, if you don't call it, Network.run() will 
+     * Initialize all elements of a network so that it can run.
+     *
+     * @note This can be called after the Network structure has been set and
+     * before Network.run(). However, if you don't call it, Network.run() will
      * call it for you. Also sets up various memory buffers etc. once the Network
      *  structure has been finalized.
      */
@@ -107,18 +107,18 @@ namespace nupic
      *
      * @{
      */
-    
+
     /**
      * Save the network to a network bundle (extension `.nta`).
-     * 
+     *
      * @param name
      *        Name of the bundle
      */
     void save(const std::string& name);
-    
+
     /**
      * @}
-     * 
+     *
      * @name Region and Link operations
      *
      * @{
@@ -126,24 +126,24 @@ namespace nupic
 
     /**
      * Create a new region in a network.
-     * 
+     *
      * @param name
      *        Name of the region, Must be unique in the network
      * @param nodeType
      *        Type of node in the region, e.g. "FDRNode"
      * @param nodeParams
      *        A JSON-encoded string specifying writable params
-     * 
+     *
      * @returns A pointer to the newly created Region
      */
     Region*
-    addRegion(const std::string& name, 
-              const std::string& nodeType, 
+    addRegion(const std::string& name,
+              const std::string& nodeType,
               const std::string& nodeParams);
 
     /**
      * Create a new region from saved state.
-     * 
+     *
      * @param name
      *        Name of the region, Must be unique in the network
      * @param nodeType
@@ -155,21 +155,21 @@ namespace nupic
      * @param label
      *        The label of the bundle
      *
-     * @todo @a label is the prefix of filename of the saved bundle, should this 
+     * @todo @a label is the prefix of filename of the saved bundle, should this
      * be documented?
-     * 
+     *
      * @returns A pointer to the newly created Region
      */
     Region*
-    addRegionFromBundle(const std::string& name, 
-                        const std::string& nodeType, 
-                        const Dimensions& dimensions, 
-                        const std::string& bundlePath, 
+    addRegionFromBundle(const std::string& name,
+                        const std::string& nodeType,
+                        const Dimensions& dimensions,
+                        const std::string& bundlePath,
                         const std::string& label);
 
     /**
      * Removes an existing region from the network.
-     * 
+     *
      * @param name
      *        Name of the Region
      */
@@ -178,7 +178,7 @@ namespace nupic
 
     /**
      * Create a link and add it to the network.
-     * 
+     *
      * @param srcName
      *        Name of the source region
      * @param destName
@@ -193,14 +193,14 @@ namespace nupic
      *        Name of the destination input
      */
     void
-    link(const std::string& srcName, const std::string& destName, 
-         const std::string& linkType, const std::string& linkParams, 
+    link(const std::string& srcName, const std::string& destName,
+         const std::string& linkType, const std::string& linkParams,
          const std::string& srcOutput="", const std::string& destInput="");
 
 
     /**
      * Removes a link.
-     * 
+     *
      * @param srcName
      *        Name of the source region
      * @param destName
@@ -211,8 +211,8 @@ namespace nupic
      *        Name of the destination input
      */
     void
-    removeLink(const std::string& srcName, const std::string& destName, 
-               const std::string& srcOutputName="", const std::string& destInputName=""); 
+    removeLink(const std::string& srcName, const std::string& destName,
+               const std::string& srcOutputName="", const std::string& destInputName="");
 
     /**
      * @}
@@ -224,15 +224,15 @@ namespace nupic
 
     /**
      * Get all regions.
-     * 
+     *
      * @returns A Collection of Region objects in the network
      */
     const Collection<Region*>&
     getRegions() const;
-  
+
     /**
      * Set phases for a region.
-     * 
+     *
      * @param name
      *        Name of the region
      * @param phases
@@ -240,13 +240,13 @@ namespace nupic
      */
     void
     setPhases(const std::string& name, std::set<UInt32>& phases);
-    
+
     /**
      * Get phases for a region.
-     * 
+     *
      * @param name
      *        Name of the region
-     * 
+     *
      * @returns Set of phases for the region
      */
     std::set<UInt32>
@@ -254,21 +254,21 @@ namespace nupic
 
     /**
      * Get minimum phase for regions in this network. If no regions, then min = 0.
-     * 
+     *
      * @returns Minimum phase
      */
     UInt32 getMinPhase() const;
 
     /**
      * Get maximum phase for regions in this network. If no regions, then max = 0.
-     * 
+     *
      * @returns Maximum phase
      */
     UInt32 getMaxPhase() const;
 
     /**
      * Set the minimum enabled phase for this network.
-     * 
+     *
      * @param minPhase Minimum enabled phase
      */
     void
@@ -276,28 +276,28 @@ namespace nupic
 
     /**
      * Set the maximum enabled phase for this network.
-     * 
+     *
      * @param minPhase Maximum enabled phase
      */
     void
     setMaxEnabledPhase(UInt32 minPhase);
-    
+
     /**
      * Get the minimum enabled phase for this network.
-     * 
+     *
      * @returns Minimum enabled phase for this network
      */
     UInt32
     getMinEnabledPhase() const;
-    
+
     /**
      * Get the maximum enabled phase for this network.
-     * 
+     *
      * @returns Maximum enabled phase for this network
      */
     UInt32
     getMaxEnabledPhase() const;
-    
+
     /**
      * @}
      *
@@ -307,11 +307,11 @@ namespace nupic
      */
 
     /**
-     * Run the network for the given number of iterations of compute for each 
-     * Region in the correct order. 
-     * 
+     * Run the network for the given number of iterations of compute for each
+     * Region in the correct order.
+     *
      * For each iteration, Region.compute() is called.
-     * 
+     *
      * @param n Number of iterations
      */
     void
@@ -321,22 +321,22 @@ namespace nupic
      * The type of run callback function.
      *
      * You can attach a callback function to a network, and the callback function
-     *  is called after every iteration of run(). 
-     *  
-     * To attach a callback, just get a reference to the callback 
+     *  is called after every iteration of run().
+     *
+     * To attach a callback, just get a reference to the callback
      * collection with getCallbacks() , and add a callback.
      */
     typedef void (*runCallbackFunction)(Network*, UInt64 iteration, void*);
 
     /**
-     * Type definition for a callback item, combines a @c runCallbackFunction and 
+     * Type definition for a callback item, combines a @c runCallbackFunction and
      * a `void*` pointer to the associated data.
      */
     typedef std::pair<runCallbackFunction, void*> callbackItem;
 
     /**
      * Get reference to callback Collection.
-     * 
+     *
      * @returns Reference to callback Collection
      */
     Collection<callbackItem>& getCallbacks();
@@ -397,12 +397,12 @@ namespace nupic
     void saveToBundle(const std::string& bundleName);
 
     // internal method using region pointer instead of name
-    void 
+    void
     setPhases_(Region *r, std::set<UInt32>& phases);
 
     // default phase assignment for a new region
     void setDefaultPhase_(Region* region);
-    
+
     // whenever we modify a network or change phase
     // information, we set enabled phases to min/max for
     // the network
@@ -413,14 +413,14 @@ namespace nupic
 
     UInt32 minEnabledPhase_;
     UInt32 maxEnabledPhase_;
-    
+
     // This is main data structure used to choreograph
     // network computation
     std::vector< std::set<Region*> > phaseInfo_;
-  
+
     // we invoke these callbacks at every iteration
     Collection<callbackItem> callbacks_;
-    
+
     //number of elapsed iterations
     UInt64 iteration_;
   };

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *
@@ -28,12 +28,16 @@
 #define NTA_NETWORK_HPP
 
 
+#include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
-#include <nupic/types/Types.hpp>
+
 #include <nupic/ntypes/Collection.hpp>
+#include <nupic/proto/NetworkProto.capnp.h>
+#include <nupic/proto/RegionProto.capnp.h>
+#include <nupic/types/Types.hpp>
 
 namespace nupic
 {
@@ -166,6 +170,20 @@ namespace nupic
                         const Dimensions& dimensions,
                         const std::string& bundlePath,
                         const std::string& label);
+
+    /**
+     * Create a new region from saved Cap'n Proto state.
+     *
+     * @param name
+     *        Name of the region, Must be unique in the network
+     * @param proto
+     *        The capnp proto reader
+     *
+     * @returns A pointer to the newly created Region
+     */
+    Region*
+    addRegionFromProto(const std::string& name,
+                        RegionProto::Reader& proto);
 
     /**
      * Removes an existing region from the network.
@@ -367,6 +385,12 @@ namespace nupic
     void
     resetProfiling();
 
+    // Capnp serialization methods
+    void write(std::ostream& stream) const;
+    void read(std::istream& stream);
+    void write(NetworkProto::Builder& proto) const;
+    void read(NetworkProto::Reader& proto);
+
     /**
      * @}
      */
@@ -374,12 +398,14 @@ namespace nupic
     /*
      * Adds user built region to list of regions
      */
-    static void registerPyRegion(const std::string module, const std::string className);
+    static void registerPyRegion(const std::string module,
+                                 const std::string className);
 
     /*
      * Adds a c++ region to the RegionImplFactory's packages
      */
-    static void registerCPPRegion(const std::string name, GenericRegisteredRegionImpl* wrapper);
+    static void registerCPPRegion(const std::string name,
+                                  GenericRegisteredRegionImpl* wrapper);
 
   private:
 

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -119,6 +119,7 @@ namespace nupic
     network_(network)
   {
     read(proto);
+    createInputsAndOutputs_();
   }
 
   Network * Region::getNetwork()
@@ -544,6 +545,7 @@ namespace nupic
 
     auto implProto = proto.getRegionImpl();
     RegionImplFactory& factory = RegionImplFactory::getInstance();
+    spec_ = factory.getSpec(type_);
     impl_ = factory.deserializeRegionImpl(
         proto.getNodeType().cStr(), implProto, this);
   }


### PR DESCRIPTION
This implements the serialization for the Network class. This should enable entire networks to be serialized at once, although PyRegion serialization isn't implemented yet. This is difficult to create an integration test for since there are limited C++ regions available but this PR includes an example that should help validate that the basic paths work.

fixes #449 

@oxtopus  - please review