### PR TITLE
(WIP) Add ability to unregister regions. Throws error if registering existing region name

### DIFF
--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -1132,5 +1132,15 @@ void Network::registerCPPRegion(const std::string name, GenericRegisteredRegionI
   Region::registerCPPRegion(name, wrapper);
 }
 
+void Network::unregisterPyRegion(const std::string className)
+{
+  Region::unregisterPyRegion(className);
+}
+
+void Network::unregisterCPPRegion(const std::string name)
+{
+  Region::unregisterCPPRegion(name);
+}
+
 
 } // namespace nupic

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -407,6 +407,16 @@ namespace nupic
     static void registerCPPRegion(const std::string name,
                                   GenericRegisteredRegionImpl* wrapper);
 
+    /*
+     * Removes a region from RegionImplFactory's packages
+     */
+    static void unregisterPyRegion(const std::string className);
+
+    /*
+     * Removes a c++ region from RegionImplFactory's packages
+     */
+    static void unregisterCPPRegion(const std::string name);
+
   private:
 
 

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -248,6 +248,18 @@ namespace nupic
     RegionImplFactory::registerCPPRegion(name, wrapper);
   }
 
+  void
+  Region::unregisterPyRegion(const std::string className)
+  {
+    RegionImplFactory::unregisterPyRegion(className);
+  }
+
+  void
+  Region::unregisterCPPRegion(const std::string name)
+  {
+    RegionImplFactory::unregisterCPPRegion(name);
+  }
+
   const Dimensions&
   Region::getDimensions() const
   {

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -160,6 +160,16 @@ namespace nupic
      */
     static void registerCPPRegion(const std::string name, GenericRegisteredRegionImpl* wrapper);
 
+    /*
+     * Removes a Python module and class from the RegionImplFactory's regions
+     */
+    static void unregisterPyRegion(const std::string className);
+
+    /*
+     * Removes a cpp region from the RegionImplFactory's packages
+     */
+    static void unregisterCPPRegion(const std::string name);
+
 
     /**
      * @}

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -420,13 +420,6 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
   std::string className(nodeType.c_str() + 3);
-  NTA_DEBUG << "getPySpec - className = '" << className << "'";
-
-  for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
-  {
-    NTA_DEBUG << "     region: '" << pyr->first << "'";
-  }
-
   for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
   {
     const std::string module = pyr->first;
@@ -434,17 +427,11 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
 
     // This module contains the class
     if (classes.find(className) != classes.end())
-    { 
-      NTA_DEBUG << "     found spec! - module = '" << module << "'";
-
-      for(std::set<std::string>::iterator it=classes.begin(); it!=classes.end(); ++it)
-        NTA_DEBUG << "                     - class = '" << *it << "'";
-
+    {
       void * exception = nullptr;
       void * ns = pyLib->createSpec(module, &exception, className);
       if (ns)
-      { 
-        NTA_DEBUG << "returning spec from module = '" << module << "'";
+      {
         return (Spec *)ns;
       }
     }
@@ -466,17 +453,14 @@ Spec * RegionImplFactory::getSpec(const std::string nodeType)
   Spec * ns = nullptr;
   if (cppRegions.find(nodeType) != cppRegions.end())
   {
-    NTA_DEBUG << "Using cpp region of type '" << nodeType << "'";
     ns = cppRegions[nodeType]->createSpec();
   }
   else if (nodeType.find(std::string("py.")) == 0)
   {
-    NTA_DEBUG << "Using py region of type '" << nodeType << "'";
     if (!pyLib_)
       pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
 
     ns = getPySpec(pyLib_.get(), nodeType);
-    NTA_DEBUG << "Nodespec = '" << ns << "'";
   }
   else
   {

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -59,6 +59,12 @@ namespace nupic
   // Allows the user to add custom regions
   void RegionImplFactory::registerPyRegion(const std::string module, const std::string className)
   {
+    // Verify that no regions exist with the same className
+    for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
+      if (pyr->second.find(className) != pyr->second.end())
+        NTA_THROW << "A pyRegion with name '" << className << "' already exists. " <<
+        "Unregister the existing region or register the new region using a different name.";
+
     // Module hasn't been added yet
     if (pyRegions.find(module) == pyRegions.end())
     {
@@ -70,6 +76,8 @@ namespace nupic
 
   void RegionImplFactory::registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper)
   {
+    if (cppRegions.find(name) != cppRegions.end())
+      NTA_WARN << "A CPPRegion already exists with the name '" << name << "'. Overwriting it...";
     cppRegions[name] = wrapper;
   }
 

--- a/src/nupic/engine/RegionImplFactory.hpp
+++ b/src/nupic/engine/RegionImplFactory.hpp
@@ -90,6 +90,12 @@ namespace nupic
     // Allows the user to load custom C++ regions
     static void registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper);
 
+    // Allows the user to unregister Python regions
+    static void unregisterPyRegion(const std::string className);
+
+    // Allows the user to unregister C++ regions
+    static void unregisterCPPRegion(const std::string name);
+
   private:
     RegionImplFactory() {};
     RegionImplFactory(const RegionImplFactory &);


### PR DESCRIPTION
- Adds functionality to nupic.core to unregister regions. Needed in the case of name conflicts or overriding regions. 
- Error is now thrown on registering an existing pyregion. 
- Warning is now thrown on registering an existing cppregion. 

Todo:
- [ ] Write unit/integration tests 

