### PR TITLE
Add ability to unregister regions. Throws an error if registering existing region name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -593,7 +593,6 @@ file(WRITE "${PROJECT_BINARY_DIR}/AddTestHeaders.hpp" "${headers_file_content}")
 #
 add_custom_target(tests_all
                   DEPENDS tests_cpp_region
-                  DEPENDS tests_py_region
                   DEPENDS tests_unit
                   COMMENT "Running all tests"
                   VERBATIM)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,6 +445,11 @@ target_link_libraries(${EXECUTABLE_PYREGIONTEST} ${COMMON_LIBS})
 set_target_properties(${EXECUTABLE_PYREGIONTEST} PROPERTIES COMPILE_FLAGS ${COMMON_COMPILE_FLAGS})
 set_target_properties(${EXECUTABLE_PYREGIONTEST}
                       PROPERTIES LINK_FLAGS "${COMMON_LINK_FLAGS}")
+add_custom_target(tests_py_region
+                  COMMAND ${EXECUTABLE_PYREGIONTEST}
+                  DEPENDS ${EXECUTABLE_PYREGIONTEST}
+                  VERBATIM)
+
 
 #
 # Setup helloregion example
@@ -588,6 +593,7 @@ file(WRITE "${PROJECT_BINARY_DIR}/AddTestHeaders.hpp" "${headers_file_content}")
 #
 add_custom_target(tests_all
                   DEPENDS tests_cpp_region
+                  DEPENDS tests_py_region
                   DEPENDS tests_unit
                   COMMENT "Running all tests"
                   VERBATIM)

--- a/src/nupic/engine/Network.cpp
+++ b/src/nupic/engine/Network.cpp
@@ -1132,5 +1132,15 @@ void Network::registerCPPRegion(const std::string name, GenericRegisteredRegionI
   Region::registerCPPRegion(name, wrapper);
 }
 
+void Network::unregisterPyRegion(const std::string className)
+{
+  Region::unregisterPyRegion(className);
+}
+
+void Network::unregisterCPPRegion(const std::string name)
+{
+  Region::unregisterCPPRegion(name);
+}
+
 
 } // namespace nupic

--- a/src/nupic/engine/Network.hpp
+++ b/src/nupic/engine/Network.hpp
@@ -407,6 +407,16 @@ namespace nupic
     static void registerCPPRegion(const std::string name,
                                   GenericRegisteredRegionImpl* wrapper);
 
+    /*
+     * Removes a region from RegionImplFactory's packages
+     */
+    static void unregisterPyRegion(const std::string className);
+
+    /*
+     * Removes a c++ region from RegionImplFactory's packages
+     */
+    static void unregisterCPPRegion(const std::string name);
+
   private:
 
 

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -248,6 +248,18 @@ namespace nupic
     RegionImplFactory::registerCPPRegion(name, wrapper);
   }
 
+  void
+  Region::unregisterPyRegion(const std::string className)
+  {
+    RegionImplFactory::unregisterPyRegion(className);
+  }
+
+  void
+  Region::unregisterCPPRegion(const std::string name)
+  {
+    RegionImplFactory::unregisterCPPRegion(name);
+  }
+
   const Dimensions&
   Region::getDimensions() const
   {

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -160,6 +160,16 @@ namespace nupic
      */
     static void registerCPPRegion(const std::string name, GenericRegisteredRegionImpl* wrapper);
 
+    /*
+     * Removes a Python module and class from the RegionImplFactory's regions
+     */
+    static void unregisterPyRegion(const std::string className);
+
+    /*
+     * Removes a cpp region from the RegionImplFactory's packages
+     */
+    static void unregisterCPPRegion(const std::string name);
+
 
     /**
      * @}

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -62,8 +62,10 @@ namespace nupic
     // Verify that no regions exist with the same className
     for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
       if (pyr->second.find(className) != pyr->second.end())
+      {
         NTA_THROW << "A pyRegion with name '" << className << "' already exists. " <<
         "Unregister the existing region or register the new region using a different name.";
+      }
 
     // Module hasn't been added yet
     if (pyRegions.find(module) == pyRegions.end())
@@ -77,21 +79,23 @@ namespace nupic
   void RegionImplFactory::registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper)
   {
     if (cppRegions.find(name) != cppRegions.end())
+    {
       NTA_WARN << "A CPPRegion already exists with the name '" << name << "'. Overwriting it...";
+    }
     cppRegions[name] = wrapper;
   }
 
-  // Allows the user do unregister regions
   void RegionImplFactory::unregisterPyRegion(const std::string className)
   {
-    for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
-      if (pyr->second.find(className) != pyr->second.end())
+    for (auto pyRegion : pyRegions)
+      if (pyRegion.second.find(className) != pyRegion.second.end())
       {
-        pyRegions.erase(pyr);
+        pyRegions.erase(pyRegion.first);
         return;
       }
 
-    NTA_WARN << "A pyRegion with name '" << className << "' doesn't exist. Nothing to unregister...";
+    NTA_WARN << "A pyRegion with name '" << className <<
+    "' doesn't exist. Nothing to unregister...";
   }
 
   void RegionImplFactory::unregisterCPPRegion(const std::string name)

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -63,8 +63,9 @@ namespace nupic
     for (auto pyRegion : pyRegions)
       if (pyRegion.second.find(className) != pyRegion.second.end())
       {
-        NTA_THROW << "A pyRegion with name '" << className << "' already exists. " <<
-        "Unregister the existing region or register the new region using a different name.";
+        NTA_THROW << "A pyRegion with name '" << className << "' already exists. "
+                  << "Unregister the existing region or register the new region using a "
+                  << "different name.";
       }
 
     // Module hasn't been added yet
@@ -76,11 +77,13 @@ namespace nupic
     pyRegions[module].insert(className);
   }
 
-  void RegionImplFactory::registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper)
+  void RegionImplFactory::registerCPPRegion(const std::string name,
+                                            GenericRegisteredRegionImpl * wrapper)
   {
     if (cppRegions.find(name) != cppRegions.end())
     {
-      NTA_WARN << "A CPPRegion already exists with the name '" << name << "'. Overwriting it...";
+      NTA_WARN << "A CPPRegion already exists with the name '" 
+               << name << "'. Overwriting it...";
     }
     cppRegions[name] = wrapper;
   }

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -420,13 +420,6 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
                                 const std::string & nodeType)
 {
   std::string className(nodeType.c_str() + 3);
-  NTA_DEBUG << "getPySpec - className = '" << className << "'";
-
-  for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
-  {
-    NTA_DEBUG << "     region: '" << pyr->first << "'";
-  }
-
   for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
   {
     const std::string module = pyr->first;
@@ -434,17 +427,11 @@ static Spec * getPySpec(DynamicPythonLibrary * pyLib,
 
     // This module contains the class
     if (classes.find(className) != classes.end())
-    { 
-      NTA_DEBUG << "     found spec! - module = '" << module << "'";
-
-      for(std::set<std::string>::iterator it=classes.begin(); it!=classes.end(); ++it)
-        NTA_DEBUG << "                     - class = '" << *it << "'";
-
+    {
       void * exception = nullptr;
       void * ns = pyLib->createSpec(module, &exception, className);
       if (ns)
-      { 
-        NTA_DEBUG << "returning spec from module = '" << module << "'";
+      {
         return (Spec *)ns;
       }
     }
@@ -466,17 +453,14 @@ Spec * RegionImplFactory::getSpec(const std::string nodeType)
   Spec * ns = nullptr;
   if (cppRegions.find(nodeType) != cppRegions.end())
   {
-    NTA_DEBUG << "Using cpp region of type '" << nodeType << "'";
     ns = cppRegions[nodeType]->createSpec();
   }
   else if (nodeType.find(std::string("py.")) == 0)
   {
-    NTA_DEBUG << "Using py region of type '" << nodeType << "'";
     if (!pyLib_)
       pyLib_ = boost::shared_ptr<DynamicPythonLibrary>(new DynamicPythonLibrary());
 
     ns = getPySpec(pyLib_.get(), nodeType);
-    NTA_DEBUG << "Nodespec = '" << ns << "'";
   }
   else
   {

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -61,12 +61,14 @@ namespace nupic
   {
     // Verify that no regions exist with the same className
     for (auto pyRegion : pyRegions)
+    {
       if (pyRegion.second.find(className) != pyRegion.second.end())
       {
         NTA_THROW << "A pyRegion with name '" << className << "' already exists. "
                   << "Unregister the existing region or register the new region using a "
                   << "different name.";
       }
+    }
 
     // Module hasn't been added yet
     if (pyRegions.find(module) == pyRegions.end())
@@ -91,12 +93,13 @@ namespace nupic
   void RegionImplFactory::unregisterPyRegion(const std::string className)
   {
     for (auto pyRegion : pyRegions)
+    {
       if (pyRegion.second.find(className) != pyRegion.second.end())
       {
         pyRegions.erase(pyRegion.first);
         return;
       }
-
+    }
     NTA_WARN << "A pyRegion with name '" << className <<
     "' doesn't exist. Nothing to unregister...";
   }

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -59,6 +59,12 @@ namespace nupic
   // Allows the user to add custom regions
   void RegionImplFactory::registerPyRegion(const std::string module, const std::string className)
   {
+    // Verify that no regions exist with the same className
+    for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
+      if (pyr->second.find(className) != pyr->second.end())
+        NTA_THROW << "A pyRegion with name '" << className << "' already exists. " <<
+        "Unregister the existing region or register the new region using a different name.";
+
     // Module hasn't been added yet
     if (pyRegions.find(module) == pyRegions.end())
     {
@@ -70,6 +76,8 @@ namespace nupic
 
   void RegionImplFactory::registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper)
   {
+    if (cppRegions.find(name) != cppRegions.end())
+      NTA_WARN << "A CPPRegion already exists with the name '" << name << "'. Overwriting it...";
     cppRegions[name] = wrapper;
   }
 

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -60,8 +60,8 @@ namespace nupic
   void RegionImplFactory::registerPyRegion(const std::string module, const std::string className)
   {
     // Verify that no regions exist with the same className
-    for (auto pyr=pyRegions.begin(); pyr!=pyRegions.end(); pyr++)
-      if (pyr->second.find(className) != pyr->second.end())
+    for (auto pyRegion : pyRegions)
+      if (pyRegion.second.find(className) != pyRegion.second.end())
       {
         NTA_THROW << "A pyRegion with name '" << className << "' already exists. " <<
         "Unregister the existing region or register the new region using a different name.";

--- a/src/nupic/engine/RegionImplFactory.hpp
+++ b/src/nupic/engine/RegionImplFactory.hpp
@@ -90,6 +90,12 @@ namespace nupic
     // Allows the user to load custom C++ regions
     static void registerCPPRegion(const std::string name, GenericRegisteredRegionImpl * wrapper);
 
+    // Allows the user to unregister Python regions
+    static void unregisterPyRegion(const std::string className);
+
+    // Allows the user to unregister C++ regions
+    static void unregisterCPPRegion(const std::string name);
+
   private:
     RegionImplFactory() {};
     RegionImplFactory(const RegionImplFactory &);

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -114,7 +114,6 @@ struct MemoryMonitor
 void testExceptionBug()
 {
   Network n;
-  Network::registerPyRegion("nupic.regions.TestNode", "TestNode");
   Region *l1 = n.addRegion("l1", "py.TestNode", "");
   //Dimensions d(1);
   Dimensions d(1);
@@ -189,7 +188,6 @@ void testPynodeLinking()
   Network net = Network();
 
   Region * region1 = net.addRegion("region1", "TestNode", "");
-  Network::registerPyRegion("nupic.regions.TestNode", "TestNode");
   Region * region2 = net.addRegion("region2", "py.TestNode", "");
   std::cout << "Linking region 1 to region 2" << std::endl;
   net.link("region1", "region2", "TestFanIn2", "");
@@ -282,7 +280,6 @@ void testPynodeLinking()
 void testSecondTimeLeak()
 {
   Network n;
-  Network::registerPyRegion("nupic.regions.TestNode", "TestNode");
   n.addRegion("r1", "py.TestNode", "");
   n.addRegion("r2", "py.TestNode", "");
 }

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -284,6 +284,49 @@ void testSecondTimeLeak()
   n.addRegion("r2", "py.TestNode", "");
 }
 
+void testFailOnRegisterDuplicateRegion()
+{
+  bool caughtException = false;
+  Network::registerPyRegion("nupic.regions.TestDuplicateNodes", "TestDuplicateNodes");
+  try
+  {
+    Network::registerPyRegion("nupic.regions.TestDuplicateNodes", "TestDuplicateNodes");
+  } catch (std::exception& e) {
+    NTA_DEBUG << "Caught exception as expected: '" << e.what() << "'";
+    caughtException = true;
+  }
+  if (caughtException)
+  {
+    NTA_DEBUG << "testFailOnRegisterDuplicateRegion passed";
+  } else {
+    NTA_THROW << "testFailOnRegisterDuplicateRegion did not throw an exception as expected";
+  }
+}
+
+void testUnregisterRegion()
+{
+  Network n;
+  n.addRegion("test", "py.TestNode", "");
+
+  Network::unregisterPyRegion("TestNode");
+
+  bool caughtException = false;
+  try
+  {
+    n.addRegion("test", "py.TestNode", "");
+  } catch (std::exception& e) {
+    NTA_DEBUG << "Caught exception as expected: '" << e.what() << "'";
+    caughtException = true;
+  }
+  if (caughtException)
+  {
+    NTA_DEBUG << "testUnregisterRegion passed";
+  } else {
+    NTA_THROW << "testUnregisterRegion did not throw an exception as expected";
+  }
+
+}
+
 int realmain(bool leakTest)
 {
   // verbose == true turns on extra output that is useful for
@@ -342,11 +385,16 @@ int realmain(bool leakTest)
   testPynodeInputOutputAccess(level2);
   testPynodeArrayParameters(level2);
   testPynodeLinking();
+  testFailOnRegisterDuplicateRegion();
   if (!leakTest)
   {
     //testNuPIC1x();
     //testPynode1xLinking();
   }
+
+  // testUnregisterRegion needs to be the last test run as it will unregister
+  // the region 'TestNode'.
+  testUnregisterRegion();
 
   std::cout << "Done -- all tests passed" << std::endl;
 

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -287,10 +287,12 @@ void testSecondTimeLeak()
 void testFailOnRegisterDuplicateRegion()
 {
   bool caughtException = false;
-  Network::registerPyRegion("nupic.regions.TestDuplicateNodes", "TestDuplicateNodes");
+  Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
+                            "TestDuplicateNodes");
   try
   {
-    Network::registerPyRegion("nupic.regions.TestDuplicateNodes", "TestDuplicateNodes");
+    Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
+                              "TestDuplicateNodes");
   } catch (std::exception& e) {
     NTA_DEBUG << "Caught exception as expected: '" << e.what() << "'";
     caughtException = true;
@@ -299,7 +301,8 @@ void testFailOnRegisterDuplicateRegion()
   {
     NTA_DEBUG << "testFailOnRegisterDuplicateRegion passed";
   } else {
-    NTA_THROW << "testFailOnRegisterDuplicateRegion did not throw an exception as expected";
+    NTA_THROW << "testFailOnRegisterDuplicateRegion did not "
+              << "throw an exception as expected";
   }
 }
 


### PR DESCRIPTION
Fixes #494

- Adds functionality to nupic.core to unregister regions. Needed in the case of name conflicts or overriding regions.
- Error is now thrown on registering an existing pyregion.
- Warning is now thrown on registering an existing cppregion.

- Updated integration tests for this functionality. 
- Also added the `tests_py_region` make target (builds/runs `src/test/integration/PyRegionTest.cpp`) and added to ```tests_all```