### PR TITLE
Remove unused synapses in Temporal Memory

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -145,7 +145,8 @@ void Connections::updateSynapsePermanence(const Synapse& synapse,
 
   cells_[cell.idx].segments[segment.idx].synapses[synapse.idx].permanence = permanence;
 
-  if (permanence == 0) {
+  if (permanence == 0)
+  {
     destroySynapse(synapse);
   }
 }

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -144,6 +144,10 @@ void Connections::updateSynapsePermanence(const Synapse& synapse,
   const Cell& cell = segment.cell;
 
   cells_[cell.idx].segments[segment.idx].synapses[synapse.idx].permanence = permanence;
+
+  if (permanence == 0) {
+    destroySynapse(synapse);
+  }
 }
 
 vector<Segment> Connections::segmentsForCell(const Cell& cell) const


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic.core/issues/495.

I confirmed that this has no performance implications for running on a large hotgym dataset.