### PR TITLE
Make Connections.mostActiveSegmentForCell ignore destroyed synapses

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -229,7 +229,7 @@ bool Connections::mostActiveSegmentForCells(const vector<Cell>& cells,
 
       for (auto synapse : synapses)
       {
-        if (binary_search(input.begin(), input.end(), synapse.presynapticCell))
+        if (!synapse.destroyed && binary_search(input.begin(), input.end(), synapse.presynapticCell))
         {
           numSynapses++;
         }


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic.core/issues/497.