### PR TITLE
correct paths for deployment of swig bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ before_deploy:
   - make package
   - mkdir -p $TRAVIS_BUILD_DIR/release
   - mv nupic_core-${TRAVIS_COMMIT}-${PLATFORM}64.tar.gz $TRAVIS_BUILD_DIR/release/.
-  - cd $TRAVIS_BUILD_DIR/bindings/py
-  - . ../../ci/travis/before_deploy.sh
+  - cd $TRAVIS_BUILD_DIR
+  - . ci/travis/before_deploy.sh
 
 deploy:
   provider: s3
@@ -79,7 +79,7 @@ install:
   - "cmake $TRAVIS_BUILD_DIR/src -DNTA_COV_ENABLED=ON -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/release"
   - "make -j3"
   - "make install"
-  - "cd $TRAVIS_BUILD_DIR/bindings/py"
+  - "cd $TRAVIS_BUILD_DIR"
   - "export NUPIC_CORE_RELEASE=\"${TRAVIS_BUILD_DIR}/build/release\""
   - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then python setup.py install --user; fi"
   - "if [ ${TRAVIS_OS_NAME:-'osx'} = 'osx' ]; then ARCHFLAGS=\"-arch x86_64\" python setup.py install --user; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_deploy:
   - mkdir -p $TRAVIS_BUILD_DIR/release
   - mv nupic_core-${TRAVIS_COMMIT}-${PLATFORM}64.tar.gz $TRAVIS_BUILD_DIR/release/.
   - cd $TRAVIS_BUILD_DIR
-  - . ci/travis/before_deploy.sh
+  - ./ci/travis/before_deploy.sh
 
 deploy:
   provider: s3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,7 +114,7 @@ build_script:
   - msbuild %MSBuildOptions% nupic_core.sln
   - set MSBuildOptions=/v:q /p:Configuration=Release /logger:%MSBuildLogger%
   - msbuild %MSBuildOptions% INSTALL.vcxproj
-  - cd %REPO_DIR%\bindings\py
+  - cd %REPO_DIR%
   - set INCLUDE='C:\Program Files (x86)\MSBuild\14.0\Include';%INCLUDE%
   - set NUPIC_CORE_RELEASE=%REPO_DIR%\build\Release
   - python setup.py install --user

--- a/bindings/py/setup.py
+++ b/bindings/py/setup.py
@@ -36,6 +36,14 @@ This file builds and installs the NuPIC Core bindings
 
 
 
+PY_BINDINGS = os.path.dirname(os.path.realpath(__file__))
+DARWIN_PLATFORM = "darwin"
+LINUX_PLATFORM = "linux"
+UNIX_PLATFORMS = [LINUX_PLATFORM, DARWIN_PLATFORM]
+WINDOWS_PLATFORMS = ["windows"]
+
+
+
 def fixPath(path):
   """
   Ensures paths are correct for linux and windows
@@ -45,18 +53,6 @@ def fixPath(path):
     return "C:" + path
 
   return path
-
-
-
-PY_BINDINGS = os.environ.get('PY_BINDINGS')
-if PY_BINDINGS is None:
-  PY_BINDINGS = os.path.dirname(os.path.realpath(__file__))
-else:
-  PY_BINDINGS = fixPath(PY_BINDINGS)
-DARWIN_PLATFORM = "darwin"
-LINUX_PLATFORM = "linux"
-UNIX_PLATFORMS = [LINUX_PLATFORM, DARWIN_PLATFORM]
-WINDOWS_PLATFORMS = ["windows"]
 
 
 
@@ -425,10 +421,10 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
       getLibPrefix(platform) + "nupic_core" + getStaticLibExtension(platform))]
 
   supportFiles = [
-    os.path.relpath(fixPath(nupicCoreReleaseDir + "/include/nupic/py_support/NumpyVector.cpp")),
-    os.path.relpath(fixPath(nupicCoreReleaseDir + "/include/nupic/py_support/PyArray.cpp")),
-    os.path.relpath(fixPath(nupicCoreReleaseDir + "/include/nupic/py_support/PyHelpers.cpp")),
-    os.path.relpath(fixPath(nupicCoreReleaseDir + "/include/nupic/py_support/PythonStream.cpp"))]
+    os.path.relpath("../../src/nupic/py_support/NumpyVector.cpp"),
+    os.path.relpath("../../src/nupic/py_support/PyArray.cpp"),
+    os.path.relpath("../../src/nupic/py_support/PyHelpers.cpp"),
+    os.path.relpath("../../src/nupic/py_support/PythonStream.cpp")]
 
   extensions = []
 
@@ -478,7 +474,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
 
   wrapAlgorithms = generateSwigWrap(swigExecutable,
                                     swigFlags,
-                                    os.path.relpath(fixPath("nupic/bindings/algorithms.i")))
+                                    "nupic/bindings/algorithms.i")
   libModuleAlgorithms = Extension(
     "nupic.bindings._algorithms",
     extra_compile_args=commonCompileFlags,
@@ -492,7 +488,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
 
   wrapEngineInternal = generateSwigWrap(swigExecutable,
                                         swigFlags,
-                                        os.path.relpath(fixPath("nupic/bindings/engine_internal.i")))
+                                        "nupic/bindings/engine_internal.i")
   libModuleEngineInternal = Extension(
     "nupic.bindings._engine_internal",
     extra_compile_args=commonCompileFlags,
@@ -506,7 +502,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
 
   wrapMath = generateSwigWrap(swigExecutable,
                               swigFlags,
-                              os.path.relpath(fixPath("nupic/bindings/math.i")))
+                              "nupic/bindings/math.i")
   libModuleMath = Extension(
     "nupic.bindings._math",
     extra_compile_args=commonCompileFlags,
@@ -514,7 +510,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
     extra_link_args=commonLinkFlags,
     include_dirs=commonIncludeDirs,
     libraries=commonLibraries,
-    sources=supportFiles + [wrapMath, os.path.relpath(fixPath("nupic/bindings/PySparseTensor.cpp"))],
+    sources=supportFiles + [wrapMath, "nupic/bindings/PySparseTensor.cpp"],
     extra_objects=commonObjects)
   extensions.append(libModuleMath)
 
@@ -535,6 +531,7 @@ if __name__ == "__main__":
   platform, bitness = getPlatformInfo()
   cxxCompiler = getCompilerInfo()
 
+  print "Python Bindings directory: {}".format(PY_BINDINGS)
   print "NUMPY VERSION: {}".format(numpy.__version__)
 
   try:

--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -24,7 +24,7 @@ echo
 echo "Running after_success-release.sh..."
 echo
 
-cd ${TRAVIS_BUILD_DIR}/bindings/py
+cd ${TRAVIS_BUILD_DIR}
 
 echo "Installing boto..."
 pip install boto --user || exit

--- a/ci/travis/after_success-release-osx.sh
+++ b/ci/travis/after_success-release-osx.sh
@@ -24,7 +24,7 @@ echo
 echo "Running after_success-release.sh..."
 echo
 
-cd ${TRAVIS_BUILD_DIR}/bindings/py
+cd ${TRAVIS_BUILD_DIR}
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -40,7 +40,6 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
 
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
-    export PY_BINDINGS="${TRAVIS_BUILD_DIR}/bindings/py"
     echo "pip wheel --wheel-dir=dist/wheels ."
     pip wheel --wheel-dir=dist/wheels . 
     # The dist/wheels folder is expected to be deployed to S3.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,58 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+"""
+Based on: http://stackoverflow.com/questions/5317672/pip-not-finding-setup-file
+"""
+
+import os
+
+from setuptools.command import egg_info
+
+REPO_DIR = os.path.dirname(os.path.realpath(__file__))
+filename = os.path.basename(__file__)
+
+os.chdir(os.path.join(REPO_DIR, "bindings/py"))
+setupdir = os.getcwd()
+
+egginfo = "pip-egg-info"
+
+if not os.path.exists(egginfo) and os.path.exists(os.path.join("../..", egginfo)):
+  print "Symlinking pip-egg-info"
+  os.symlink(os.path.join("../..", egginfo), os.path.join(REPO_DIR, "bindings/py", egginfo))
+
+__file__ = os.path.join(setupdir, filename)
+
+def replacement_run(self):
+  self.mkpath(self.egg_info)
+
+  installer = self.distribution.fetch_build_egg
+
+  for ep in egg_info.iter_entry_points('egg_info.writers'):
+    # require=False is the change we're making from pip
+    writer = ep.load(require=False)
+
+    if writer:
+      writer(self, ep.name, egg_info.os.path.join(self.egg_info,ep.name))
+
+  self.find_sources()
+
+egg_info.egg_info.run = replacement_run
+execfile(__file__)


### PR DESCRIPTION
After we merged the SWIG files into nupic.core there was a problem with deployment:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/74106807/log.txt

I couldn't get it to find the pip-egg-info directory and have valid paths by just using the setup.py in bindings/py since I needed files that were in ../../external and I needed the relative path to the py_support files for the SWIG extensions. When I added a second setup.py to the root directory, symlinked pip-egg-info into bindings/py/pip-egg-info and executed the one in bindings/py from there, it worked.

This corrects the paths of setup.py so swig should be able to deploy on travis.

SO discussion: http://stackoverflow.com/questions/5317672/pip-not-finding-setup-file

@scottpurdy 

Fixes #528