### PR TITLE
added export ARCHFLAGS for OS X deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,7 @@ install:
   - "make install"
   - "cd $TRAVIS_BUILD_DIR"
   - "export NUPIC_CORE_RELEASE=\"${TRAVIS_BUILD_DIR}/build/release\""
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then python setup.py install --user; fi"
-  - "if [ ${TRAVIS_OS_NAME:-'osx'} = 'osx' ]; then ARCHFLAGS=\"-arch x86_64\" python setup.py install --user; fi"
+  - "python setup.py install --user"
 
 script:
   - "cd $TRAVIS_BUILD_DIR/build/scripts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - NUPICCORE = ${TRAVIS_BUILD_DIR}
     - PATH=${TRAVIS_BUILD_DIR}/python/bin:$PATH
     - PLATFORM=${TRAVIS_OS_NAME}
+    - ARCHFLAGS="-arch x86_64"
     # AWS keys are for manual uploads of linux wheel to S3.
     - AWS_ACCESS_KEY_ID=AKIAIGHYSEHV3WFKOWNQ
     # AWS_SECRET_ACCESS_KEY encrypted below

--- a/ci/travis/after_success-release-osx.sh
+++ b/ci/travis/after_success-release-osx.sh
@@ -40,7 +40,7 @@ export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
 echo "Creating distribution files..."
 # We are not creating sdist here, because it's being created and uploaded in the
 # linux Travis-CI release build.
-ARCHFLAGS="-arch x86_64" python setup.py bdist bdist_wheel || exit
+python setup.py bdist bdist_wheel || exit
 
 echo "Created the following distribution files:"
 ls -l dist

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -41,11 +41,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
     echo "pip wheel --wheel-dir=dist/wheels ."
-    if [ ${PLATFORM} = "darwin" ]; then
-      pip wheel --wheel-dir=dist/wheels .
-    else
-      pip wheel --wheel-dir=dist/wheels . 
-    fi
+    pip wheel --wheel-dir=dist/wheels . 
     # The dist/wheels folder is expected to be deployed to S3.
 
 # If this is a tag, we're doing a release deployment, so we want to build docs

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -42,7 +42,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # files.
     echo "pip wheel --wheel-dir=dist/wheels ."
     if [ ${PLATFORM} = "darwin" ]; then
-      export ARCHFLAGS="-arch x86_64" pip wheel --wheel-dir=dist/wheels .
+      pip wheel --wheel-dir=dist/wheels .
     else
       pip wheel --wheel-dir=dist/wheels . 
     fi

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -41,7 +41,11 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
     echo "pip wheel --wheel-dir=dist/wheels ."
-    pip wheel --wheel-dir=dist/wheels . 
+    if [ ${PLATFORM} = "darwin" ]; then
+      export ARCHFLAGS="-arch x86_64" pip wheel --wheel-dir=dist/wheels .
+    else
+      pip wheel --wheel-dir=dist/wheels . 
+    fi
     # The dist/wheels folder is expected to be deployed to S3.
 
 # If this is a tag, we're doing a release deployment, so we want to build docs


### PR DESCRIPTION
Added export ARCHFLAGS to before_deploy script if the platform is osx.

@scottpurdy 