### PR TITLE
correct paths for additional files in nupic.bindings release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ before_deploy:
   - cd $TRAVIS_BUILD_DIR
   - ./ci/travis/before_deploy.sh
   - cp $TRAVIS_BUILD_DIR/bindings/py/requirements.txt $TRAVIS_BUILD_DIR/bindings/py/dist/
-  - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/proto
-  - cp $TRAVIS_BUILD_DIR/src/nupic/proto/*.capnp $TRAVIS_BUILD_DIR/bindings/py/dist/proto
-  - cp $NUPIC_CORE_RELEASE/include/nupic/Version.hpp $TRAVIS_BUILD_DIR/bindings/py/dist
+  - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic
+  - cp $NUPIC_CORE_RELEASE/include/nupic/Version.hpp $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic
+  - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic/proto
+  - cp $TRAVIS_BUILD_DIR/src/nupic/proto/*.capnp $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic/proto
   - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/bin
   - cp $NUPIC_CORE_RELEASE/bin/py_region_test $TRAVIS_BUILD_DIR/bindings/py/dist/bin
   - mkdir -p $TRAVIS_BUILD_DIR/release


### PR DESCRIPTION
When the user provides a local version of nupic.core the paths should match the released version.  This fixes the paths in the release version to match the local version.

@scottpurdy 
Fixes #540