### PR TITLE
Remove dependency on NUPIC_CORE_RELEASE environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,11 @@ before_deploy:
   - ./ci/travis/before_deploy.sh
   - cp $TRAVIS_BUILD_DIR/bindings/py/requirements.txt $TRAVIS_BUILD_DIR/bindings/py/dist/
   - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic
-  - cp $NUPIC_CORE_RELEASE/include/nupic/Version.hpp $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic
+  - cp ${TRAVIS_BUILD_DIR}/build/release/include/nupic/Version.hpp $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic
   - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic/proto
   - cp $TRAVIS_BUILD_DIR/src/nupic/proto/*.capnp $TRAVIS_BUILD_DIR/bindings/py/dist/include/nupic/proto
   - mkdir -p $TRAVIS_BUILD_DIR/bindings/py/dist/bin
-  - cp $NUPIC_CORE_RELEASE/bin/py_region_test $TRAVIS_BUILD_DIR/bindings/py/dist/bin
+  - cp ${TRAVIS_BUILD_DIR}/build/release/bin/py_region_test $TRAVIS_BUILD_DIR/bindings/py/dist/bin
   - mkdir -p $TRAVIS_BUILD_DIR/release
   - tar -zcvf $TRAVIS_BUILD_DIR/release/nupic_core-${TRAVIS_COMMIT}-${PLATFORM}64.tar.gz $TRAVIS_BUILD_DIR/bindings/py/dist
 
@@ -77,7 +77,7 @@ deploy:
   skip_cleanup: true
   # Deploying on master branch from linux/gcc and osx/clang
   on:
-    branch: master
+    branch: remove_env_var
     condition:
       - "( ${TRAVIS_OS_NAME}--${CC} = 'linux--gcc-4.8' ) || ( ${TRAVIS_OS_NAME}--${CC} = 'linux--gcc' ) || ( ${TRAVIS_OS_NAME}--${CC} = 'osx--clang' )"
 
@@ -103,8 +103,7 @@ install:
   - "make -j3"
   - "make install"
   - "cd $TRAVIS_BUILD_DIR"
-  - "export NUPIC_CORE_RELEASE=\"${TRAVIS_BUILD_DIR}/build/release\""
-  - "python setup.py install --user"
+  - "python setup.py install --user --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release"
 
 script:
   - "cd $TRAVIS_BUILD_DIR/build/scripts"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ deploy:
   skip_cleanup: true
   # Deploying on master branch from linux/gcc and osx/clang
   on:
-    branch: remove_env_var
+    branch: master
     condition:
       - "( ${TRAVIS_OS_NAME}--${CC} = 'linux--gcc-4.8' ) || ( ${TRAVIS_OS_NAME}--${CC} = 'linux--gcc' ) || ( ${TRAVIS_OS_NAME}--${CC} = 'osx--clang' )"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,8 +116,7 @@ build_script:
   - msbuild %MSBuildOptions% INSTALL.vcxproj
   - cd %REPO_DIR%
   - set INCLUDE='C:\Program Files (x86)\MSBuild\14.0\Include';%INCLUDE%
-  - set NUPIC_CORE_RELEASE=%REPO_DIR%\build\Release
-  - python setup.py install --user
+  - python setup.py install --user --nupic-core-dir=%REPO_DIR%\build\Release
 
 test: off
 

--- a/bindings/py/setup.py
+++ b/bindings/py/setup.py
@@ -92,9 +92,9 @@ def getCommandLineOptions():
   # optionDesc = [name, value, description]
   optionsDesc = []
   optionsDesc.append(
-    ["skip-compare-versions",
-     "",
-     "(optional) Skip nupic.core version comparison"]
+    ["nupic-core-dir",
+     "dir",
+     "Absolute path to nupic.core binary release directory"]
   )
   optionsDesc.append(
     ["optimizations-native",
@@ -529,9 +529,9 @@ if __name__ == "__main__":
   print "NUMPY VERSION: {}".format(numpy.__version__)
 
   try:
-    nupicCoreReleaseDir = os.environ.get('NUPIC_CORE_RELEASE')
+    nupicCoreReleaseDir = getCommandLineOption("nupic-core-dir", options)
     if nupicCoreReleaseDir is None:
-      raise Exception("Must provide path to nupic core release. export NUPIC_CORE_RELEASE=<path>")
+      raise Exception("Must provide nupic core release directory. --nupic-core-dir")
     nupicCoreReleaseDir = fixPath(nupicCoreReleaseDir)
     print "Nupic Core Release Directory: {}\n".format(nupicCoreReleaseDir)
     if not os.path.isdir(nupicCoreReleaseDir):

--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -36,7 +36,7 @@ pip install twine --user || exit
 echo "Creating distribution files..."
 # This release build creates the source distribution. All other release builds
 # should not.
-python setup.py sdist bdist bdist_wheel || exit
+python setup.py sdist bdist bdist_wheel --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release || exit
 
 echo "Created the following distribution files:"
 ls -l dist

--- a/ci/travis/after_success-release-osx.sh
+++ b/ci/travis/after_success-release-osx.sh
@@ -38,7 +38,7 @@ export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
 echo "Creating distribution files..."
 # We are not creating sdist here, because it's being created and uploaded in the
 # linux Travis-CI release build.
-python setup.py bdist bdist_wheel || exit
+python setup.py bdist bdist_wheel --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release || exit
 
 echo "Created the following distribution files:"
 ls -l dist

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -26,7 +26,7 @@ echo
 
 # If this branch is master, this is an iterative deployment, so we'll package
 # wheels ourselves for deployment to S3. No need to build docs.
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
+if [ "${TRAVIS_BRANCH}" = "remove_env_var" ]; then
 
     # Upgrading pip
     pip install --upgrade pip
@@ -35,10 +35,14 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     echo "pip install wheel --user"
     pip install wheel --user
 
+    cd ${TRAVIS_BUILD_DIR}/bindings/py
+
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
-    echo "pip wheel --wheel-dir=dist/wheels ."
-    pip wheel --wheel-dir=dist/wheels .
+    echo "pip wheel -r requirements.txt"
+    pip wheel --wheel-dir=dist/wheels -r requirements.txt
+    echo "python setup.py bdist_wheel"
+    python setup.py bdist_wheel -d dist/wheels --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release
     # The dist/wheels folder is expected to be deployed to S3.
 
 # If this is a tag, we're doing a release deployment, so we want to build docs

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -43,6 +43,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     pip wheel --wheel-dir=dist/wheels -r requirements.txt
     echo "python setup.py bdist_wheel"
     python setup.py bdist_wheel -d dist/wheels --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release
+    python setup.py bdist_egg -d dist --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release
     # The dist/wheels folder is expected to be deployed to S3.
 
 # If this is a tag, we're doing a release deployment, so we want to build docs

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -24,6 +24,8 @@ echo
 echo Running before_deploy.sh...
 echo
 
+set -o xtrace
+
 # If this branch is master, this is an iterative deployment, so we'll package
 # wheels ourselves for deployment to S3. No need to build docs.
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
@@ -32,16 +34,13 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     pip install --upgrade pip
 
     # Assuming pip 1.5.X is installed.
-    echo "pip install wheel --user"
     pip install wheel --user
 
     cd ${TRAVIS_BUILD_DIR}/bindings/py
 
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
-    echo "pip wheel -r requirements.txt"
     pip wheel --wheel-dir=dist/wheels -r requirements.txt
-    echo "python setup.py bdist_wheel"
     python setup.py bdist_wheel -d dist/wheels --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release
     python setup.py bdist_egg -d dist --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release
     # The dist/wheels folder is expected to be deployed to S3.

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -26,7 +26,7 @@ echo
 
 # If this branch is master, this is an iterative deployment, so we'll package
 # wheels ourselves for deployment to S3. No need to build docs.
-if [ "${TRAVIS_BRANCH}" = "remove_env_var" ]; then
+if [ "${TRAVIS_BRANCH}" = "master" ]; then
 
     # Upgrading pip
     pip install --upgrade pip


### PR DESCRIPTION
Now the user must use the flag --nupic-core-dir when calling setup.py.  This should allow us to eliminate the setup.py that is at the top level as well since that was just there to run "pip wheel ." and we no longer run that.

Fixes #551

@oxtopus @scottpurdy 