### PR TITLE
after release without bdist_egg command

### DIFF
--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -36,7 +36,7 @@ pip install twine --user || exit
 echo "Creating distribution files..."
 # This release build creates the source distribution. All other release builds
 # should not.
-python setup.py sdist bdist bdist_egg bdist_wheel -d dist || exit
+python setup.py sdist bdist bdist_wheel -d dist || exit
 
 echo "Created the following distribution files:"
 ls -l dist

--- a/ci/travis/after_success-release-osx.sh
+++ b/ci/travis/after_success-release-osx.sh
@@ -38,7 +38,7 @@ export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
 echo "Creating distribution files..."
 # We are not creating sdist here, because it's being created and uploaded in the
 # linux Travis-CI release build.
-python setup.py bdist bdist_egg bdist_wheel -d dist || exit
+python setup.py bdist bdist_wheel -d dist || exit
 
 echo "Created the following distribution files:"
 ls -l dist


### PR DESCRIPTION
Updated the setup.py call so we don't use bdist_egg

@rhyolight 