### PR TITLE
Remove CPPFLAGS and LDFLAGS that aren't needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ env:
   global:
     - NUPICCORE = ${TRAVIS_BUILD_DIR}
     - PATH=${TRAVIS_BUILD_DIR}/python/bin:$PATH
-    - CPPFLAGS=-I${TRAVIS_BUILD_DIR}/include
-    - LDFLAGS=-L${TRAVIS_BUILD_DIR}/lib
     - PLATFORM=${TRAVIS_OS_NAME}
     - ARCHFLAGS="-arch x86_64"
     # AWS keys are for manual uploads of linux wheel to S3.

--- a/bindings/py/setup.py
+++ b/bindings/py/setup.py
@@ -364,7 +364,6 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
       # for Cap'n'Proto serialization
       "-lkj",
       "-lcapnp",
-      "-lcapnpc",
       # optimization (safe defaults)
       "-O2"]
 
@@ -378,7 +377,6 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
     # for Cap'n'Proto serialization
     "-lkj",
     "-lcapnp",
-    "-lcapnpc",
     # optimization (safe defaults)
     "-O2"
   ]
@@ -404,8 +402,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness, cxxCompiler, cmd
     pythonLib,
     "dl",
     "kj",
-    "capnp",
-    "capnpc"]
+    "capnp"]
   if platform == "linux":
     commonLibraries.extend(["pthread"])
   elif platform in WINDOWS_PLATFORMS:


### PR DESCRIPTION
These were needed when capnp libs/headers weren't included in install but as of #598 this is resolved.

fixes #596 (again)

@oxtopus please review - forgot this clean up step