### PR TITLE
Use py.test --pyargs option for collecting nupic.bindings tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ script:
   # unit tests
   - "make tests_unit"
   # run python tests
-  - "py.test $TRAVIS_BUILD_DIR/bindings/py/nupic/bindings/tests"
+  - "py.test --pyargs nupic.bindings"
   # output unit tests report
   - "cd $TRAVIS_BUILD_DIR/build/artifacts/"
   # transform the JUnit-style xml report to html

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Once it is installed, you can import NuPIC bindings library to your python scrip
 
     import nupic.bindings
 
+You can run the nupic.bindings tests with `py.test`:
+
+    py.test --pyargs nupic.bindings
+
 ### Using graphical interface
 
 #### Generate the IDE solution:


### PR DESCRIPTION
fixes #602 

@rhyolight @oxtopus - What do you guys think about this for running Python tests? We decided a while back to move tests into the python packages so they are on the PYTHONPATH (in an internal email chain titled "A few Python convention changes"). One advantage is that we can run them like this to ensure we are running the version of the tests that corresponds to the version that is installed.

Let me know what you think about the `--pyargs` option for running Python tests via Python import path instead of disk path.