### PR TITLE
Bump version to 0.2 to reflect change in behavior of nupic.bindings.math.Random

### DIFF
--- a/bindings/py/setup.py
+++ b/bindings/py/setup.py
@@ -561,7 +561,7 @@ if __name__ == "__main__":
     setup(
       name="nupic.bindings",
       ext_modules=extensions,
-      version="0.1.5",
+      version="0.2",
       namespace_packages=["nupic"],
       install_requires=findRequirements(),
       description="Numenta Platform for Intelligent Computing - bindings",


### PR DESCRIPTION
Fixes #615 

Currently experiencing non-deterministic results due to different versions of nupic.core that share a common 0.1.5 semantic version.