### PR TITLE
Use stable sort in Segment::freeNSynapses()

### DIFF
--- a/bindings/py/setup.py
+++ b/bindings/py/setup.py
@@ -561,7 +561,7 @@ if __name__ == "__main__":
     setup(
       name="nupic.bindings",
       ext_modules=extensions,
-      version="0.2",
+      version="0.2.1",
       namespace_packages=["nupic"],
       install_requires=findRequirements(),
       description="Numenta Platform for Intelligent Computing - bindings",

--- a/src/nupic/algorithms/Segment.cpp
+++ b/src/nupic/algorithms/Segment.cpp
@@ -342,9 +342,6 @@ struct InSrcCellOrder
  * Free up some synapses in this segment. We always free up inactive
  * synapses (lowest permanence freed up first) before we start to free
  * up active ones.
- *
- * TODO: Implement stable tie breaker for the case where you have multiple
- * synapses with the same lowest permanence
  */
 void Segment::freeNSynapses(UInt numToFree,
                             std::vector<UInt> &inactiveSynapseIndices,
@@ -392,7 +389,7 @@ void Segment::freeNSynapses(UInt numToFree,
   }
 
   // Now sort the list of candidate synapses
-  std::sort(candidates.begin(), candidates.end(), InPermanenceOrder());
+  std::stable_sort(candidates.begin(), candidates.end(), InPermanenceOrder());
 
   //----------------------------------------------------------------------
   // Create the final list of synapses we will remove

--- a/src/nupic/math/SparseBinaryMatrix.hpp
+++ b/src/nupic/math/SparseBinaryMatrix.hpp
@@ -1803,11 +1803,12 @@ private:
 
     InputIterator last = begin;
     for (InputIterator it = begin; it != end; ++it) {
-      if (it != begin)
+      if (it != begin) {
         NTA_ASSERT(*last < *it)
             << "SparseBinaryMatrix::" << where << ": "
             << "Invalid indices: " << *last << " and: " << *it
             << " - Indices need to be in strictly increasing order";
+      }
       last = it;
     }
   }


### PR DESCRIPTION
Fixes #616

re: TODO in `Segment::freeNSynapses()` to apply stable sort to consistently break ties between multiple synapses with the same lowest permanence.  This comes with a possible speed hit, since std::stable_sort() is slower than std::sort(), but gives me consistent behavior where I was otherwise getting divergent results.

cc @scottpurdy 