### PR TITLE
Windows 64 (GCC) bindings changes

### DIFF
--- a/bindings/py/nupic/bindings/algorithms.i
+++ b/bindings/py/nupic/bindings/algorithms.i
@@ -5,15 +5,15 @@
  * following terms and conditions apply:
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
+ * it under the terms of the GNU Affero Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
+ * See the GNU Affero Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Affero Public License
  * along with this program.  If not, see http://www.gnu.org/licenses.
  *
  * http://numenta.org/licenses/
@@ -32,15 +32,15 @@
 # following terms and conditions apply:
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 3 as
+# it under the terms of the GNU Affero Public License version 3 as
 # published by the Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the GNU General Public License for more details.
+# See the GNU Affero Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Affero Public License
 # along with this program.  If not, see http://www.gnu.org/licenses.
 #
 # http://numenta.org/licenses/
@@ -60,15 +60,15 @@ _ALGORITHMS = _algorithms
  * following terms and conditions apply:
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
+ * it under the terms of the GNU Affero Public License version 3 as
  * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
+ * See the GNU Affero Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Affero Public License
  * along with this program.  If not, see http://www.gnu.org/licenses.
  *
  * http://numenta.org/licenses/
@@ -110,7 +110,7 @@ _ALGORITHMS = _algorithms
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <nupic/py_support/NumpyVector.hpp>
-#include <nupic/py_support/PyCapnp.hpp>
+//#include <nupic/py_support/PyCapnp.hpp>
 #include <nupic/py_support/PythonStream.hpp>
 #include <nupic/py_support/PyHelpers.hpp>
 
@@ -1127,19 +1127,6 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
     self->stripUnlearnedColumns((nupic::UInt*) PyArray_DATA(x));
-  }
-
-  inline void write(PyObject* pyBuilder) const
-  {
-    SpatialPoolerProto::Builder proto =
-        getBuilder<SpatialPoolerProto>(pyBuilder);
-    self->write(proto);
-  }
-
-  inline void read(PyObject* pyReader)
-  {
-    SpatialPoolerProto::Reader proto = getReader<SpatialPoolerProto>(pyReader);
-    self->read(proto);
   }
 
   void loadFromString(const std::string& inString)

--- a/bindings/py/requirements.txt
+++ b/bindings/py/requirements.txt
@@ -1,3 +1,5 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
-pycapnp==0.5.5
-numpy>=1.9.2
+pytest==2.5.1
+pytest-cov==1.6
+pytest-xdist==1.8
+numpy==1.9.2


### PR DESCRIPTION
@scottpurdy Changes to the bindings building. Including removal of SP capnp functions to overcome the Dynamic and Schema issues in lite mode.