### PR TITLE
Fix include order for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,20 @@ project(nupic_core_main CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# Identify platform name.
+string(TOLOWER ${CMAKE_SYSTEM_NAME} PLATFORM)
+string(TOUPPER ${PLATFORM} PLATFORM_UPPERCASE)
+
+# Identify platform "bitness".
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(BITNESS 64)
+else()
+  set(BITNESS 32)
+endif()
+
+# Make sure we can link against any specified paths.
+include_directories(SYSTEM ${CMAKE_INCLUDE_PATH})
+
 set(EP_BASE ${CMAKE_BINARY_DIR}/ThirdParty)
 
 # Set up external dependencies.
@@ -39,11 +53,7 @@ set(EP_BASE ${CMAKE_BINARY_DIR}/ThirdParty)
 #   create_capnpc_target - Creates target that generates C++ files from
 #       .capnp schema files.
 add_subdirectory(external)
-
-# Make sure we can link against any new external libraries.
-include_directories(AFTER SYSTEM ${EXTERNAL_INCLUDE_DIRS})
-# Make sure we can link against any specified paths.
-include_directories(BEFORE SYSTEM ${CMAKE_INCLUDE_PATH})
+include_directories(SYSTEM ${EXTERNAL_INCLUDE_DIRS})
 
 # Now build nupic_core project.
 add_subdirectory(src)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -36,6 +36,11 @@ set(INCLUDE_PRE ${EP_BASE}/Install/include)
 # The full prefix path for binaries.
 set(BIN_PRE ${EP_BASE}/Install/bin)
 
+# Add vendored prebuilt library include paths.
+list(APPEND EXTERNAL_INCLUDE_DIRS
+     "${PROJECT_SOURCE_DIR}/${PLATFORM}${BITNESS}/include"
+     "${PROJECT_SOURCE_DIR}/common/include")
+
 include(ExternalProject)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
@@ -43,4 +48,6 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 include(CapnProto)
 
 # Convenience variable that wraps all external include directories.
-set(EXTERNAL_INCLUDE_DIRS ${CAPNP_INCLUDE_DIRS} PARENT_SCOPE)
+list(APPEND EXTERNAL_INCLUDE_DIRS ${CAPNP_INCLUDE_DIRS})
+
+set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,29 +44,16 @@ endif()
 #
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
-#
-# Identify platform
-#
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(PLATFORM "darwin")
   set(STDLIB "-stdlib=libc++")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(PLATFORM "linux")
   set(STDLIB "")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(PLATFORM "windows")
   set(STDLIB "")
 endif()
-string(TOUPPER ${PLATFORM} PLATFORM_UPPERCASE)
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
    set(STDLIB "${STDLIB} -static-libgcc -static-libstdc++")
-endif()
-
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(BITNESS 64)
-else()
-  set(BITNESS 32)
 endif()
 
 # Compiler `-D*` definitions
@@ -129,12 +116,11 @@ find_package(PythonInterp REQUIRED)
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
                         "import numpy; import os; import sys; sys.stdout.write(os.path.dirname(numpy.get_include()))"
                          OUTPUT_VARIABLE NUMPY_CORE)
-include_directories(BEFORE SYSTEM
-                    "${REPOSITORY_DIR}/external/${PLATFORM}${BITNESS}/include"
-                    "${REPOSITORY_DIR}/external/common/include"
-                    "${PROJECT_SOURCE_DIR}"
-                    "${PROJECT_BINARY_DIR}"
-                    "${NUMPY_CORE}/include")
+include_directories(SYSTEM
+                    ${NUMPY_CORE}/include
+                    ${PROJECT_BINARY_DIR})
+
+include_directories(${PROJECT_SOURCE_DIR})
 
 #
 # Set linker (ld)
@@ -297,7 +283,7 @@ add_library(${LIB_STATIC_Z} STATIC IMPORTED GLOBAL)
 # Setup for python
 #
 find_package(PythonLibs REQUIRED)
-include_directories(BEFORE SYSTEM ${PYTHON_INCLUDE_DIRS})
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
 
 # List all .capnp files here. The C++ files will be generated and included
 # when compiling later on.

--- a/src/nupic/regions/PyRegion.hpp
+++ b/src/nupic/regions/PyRegion.hpp
@@ -66,8 +66,8 @@ namespace nupic
     static int NTA_destroySpec(const char * nodeType, const char* className="");
 
     // Manual serialization methods. Current recommended method.
-    void serialize(BundleIO& bundle);
-    void deserialize(BundleIO& bundle);
+    void serialize(BundleIO& bundle) override;
+    void deserialize(BundleIO& bundle) override;
 
     // Capnp serialization methods - not yet implemented for PyRegions. This
     // method will replace serialize/deserialize once fully implemented
@@ -81,38 +81,60 @@ namespace nupic
 
     // RegionImpl interface
     
-    size_t getNodeOutputElementCount(const std::string& outputName);
-    void getParameterFromBuffer(const std::string& name, Int64 index, IWriteBuffer& value);
-    void setParameterFromBuffer(const std::string& name, Int64 index, IReadBuffer& value);
+    size_t getNodeOutputElementCount(const std::string& outputName) override;
+    void getParameterFromBuffer(const std::string& name, Int64 index, IWriteBuffer& value) override;
+    void setParameterFromBuffer(const std::string& name, Int64 index, IReadBuffer& value) override;
 
-    void initialize();
-    void compute();
-    std::string executeCommand(const std::vector<std::string>& args, Int64 index);
+    void initialize() override;
+    void compute() override;
+    std::string executeCommand(
+        const std::vector<std::string>& args, Int64 index) override;
 
-    size_t getParameterArrayCount(const std::string& name, Int64 index);
+    size_t getParameterArrayCount(const std::string& name, Int64 index)
+        override;
 
     virtual Byte getParameterByte(const std::string& name, Int64 index);
-    virtual Int32 getParameterInt32(const std::string& name, Int64 index);
-    virtual UInt32 getParameterUInt32(const std::string& name, Int64 index);
-    virtual Int64 getParameterInt64(const std::string& name, Int64 index);
-    virtual UInt64 getParameterUInt64(const std::string& name, Int64 index);
-    virtual Real32 getParameterReal32(const std::string& name, Int64 index);
-    virtual Real64 getParameterReal64(const std::string& name, Int64 index);
-    virtual Handle getParameterHandle(const std::string& name, Int64 index);
-    virtual std::string getParameterString(const std::string& name, Int64 index);
+    virtual Int32 getParameterInt32(const std::string& name, Int64 index)
+        override;
+    virtual UInt32 getParameterUInt32(const std::string& name, Int64 index)
+        override;
+    virtual Int64 getParameterInt64(const std::string& name, Int64 index)
+        override;
+    virtual UInt64 getParameterUInt64(const std::string& name, Int64 index)
+        override;
+    virtual Real32 getParameterReal32(const std::string& name, Int64 index)
+        override;
+    virtual Real64 getParameterReal64(const std::string& name, Int64 index)
+        override;
+    virtual Handle getParameterHandle(const std::string& name, Int64 index)
+        override;
+    virtual std::string getParameterString(
+        const std::string& name, Int64 index) override;
 
-    virtual void setParameterByte(const std::string& name, Int64 index, Byte value);
-    virtual void setParameterInt32(const std::string& name, Int64 index, Int32 value);
-    virtual void setParameterUInt32(const std::string& name, Int64 index, UInt32 value);
-    virtual void setParameterInt64(const std::string& name, Int64 index, Int64 value);
-    virtual void setParameterUInt64(const std::string& name, Int64 index, UInt64 value);
-    virtual void setParameterReal32(const std::string& name, Int64 index, Real32 value);
-    virtual void setParameterReal64(const std::string& name, Int64 index, Real64 value);
-    virtual void setParameterHandle(const std::string& name, Int64 index, Handle value);
-    virtual void setParameterString(const std::string& name, Int64 index, const std::string& value);
+    virtual void setParameterByte(
+        const std::string& name, Int64 index, Byte value);
+    virtual void setParameterInt32(
+        const std::string& name, Int64 index, Int32 value) override;
+    virtual void setParameterUInt32(
+        const std::string& name, Int64 index, UInt32 value) override;
+    virtual void setParameterInt64(
+        const std::string& name, Int64 index, Int64 value) override;
+    virtual void setParameterUInt64(
+        const std::string& name, Int64 index, UInt64 value) override;
+    virtual void setParameterReal32(
+        const std::string& name, Int64 index, Real32 value) override;
+    virtual void setParameterReal64(
+        const std::string& name, Int64 index, Real64 value) override;
+    virtual void setParameterHandle(
+        const std::string& name, Int64 index, Handle value) override;
+    virtual void setParameterString(
+        const std::string& name, Int64 index, const std::string& value)
+        override;
     
-    virtual void getParameterArray(const std::string& name, Int64 index, Array & array);
-    virtual void setParameterArray(const std::string& name, Int64 index, const Array & array);
+    virtual void getParameterArray(
+        const std::string& name, Int64 index, Array & array) override;
+    virtual void setParameterArray(
+        const std::string& name, Int64 index, const Array & array) override;
 
     // Helper methods
     template <typename T, typename PyT>


### PR DESCRIPTION
fixes #656

@jcasner is using brewed Python and having the Python include path show up before our hard-coded vendored dependencies caused problems since Boost was installed on his system with same include prefix as Python. This PR is primarily to make sure that our hard coded externals are before any introspected paths.

I also switched our source files to not be specified as `SYSTEM` includes which exposed so issues in PyRegion.hpp that I fixed.

@oxtopus please review