### PR TITLE
Prevents rebuilding libraries regardless of changes

### DIFF
--- a/external/CapnProto.cmake
+++ b/external/CapnProto.cmake
@@ -66,19 +66,19 @@ else()
   add_custom_target(CapnProto)
 endif()
 
-function(CREATE_CAPNPC_TARGET
-         TARGET_NAME SPEC_FILES SRC_PREFIX INCLUDE_DIR TARGET_DIR)
-  add_custom_target(
-    ${TARGET_NAME}
+function(CREATE_CAPNPC_COMMAND
+         GROUP_NAME SPEC_FILES SRC_PREFIX INCLUDE_DIR TARGET_DIR OUTPUT_FILES)
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILES}
     COMMAND ${CAPNP_EXECUTABLE}
         compile -o ${CAPNPC_CXX_EXECUTABLE}:${TARGET_DIR}
         --src-prefix ${SRC_PREFIX} -I ${INCLUDE_DIR}
         ${SPEC_FILES}
-    SOURCES ${SPEC_FILES}
     DEPENDS CapnProto
     COMMENT "Executing Cap'n Proto compiler"
   )
-endfunction(CREATE_CAPNPC_TARGET)
+  add_custom_target(${GROUP_NAME} ALL SOURCES ${CAPNP_SPECS})
+endfunction(CREATE_CAPNPC_COMMAND)
 
 # Set the relevant variables in the parent scope.
 set(CAPNP_LIBRARIES ${CAPNP_LIBRARIES} PARENT_SCOPE)

--- a/external/CapnProto.cmake
+++ b/external/CapnProto.cmake
@@ -73,7 +73,8 @@ function(CREATE_CAPNPC_TARGET
     COMMAND ${CAPNP_EXECUTABLE}
         compile -o ${CAPNPC_CXX_EXECUTABLE}:${TARGET_DIR}
         --src-prefix ${SRC_PREFIX} -I ${INCLUDE_DIR}
-        ${CAPNP_SPECS}
+        ${SPEC_FILES}
+    SOURCES ${SPEC_FILES}
     DEPENDS CapnProto
     COMMENT "Executing Cap'n Proto compiler"
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -309,15 +309,15 @@ foreach(spec ${CAPNP_SPECS_REL})
   list(APPEND CAPNP_HDRS ${PROJECT_BINARY_DIR}/${spec}.h)
   list(APPEND CAPNP_SRCS ${PROJECT_BINARY_DIR}/${spec}.c++)
 endforeach(spec)
+set(CAPNP_ALL "${CAPNP_HDRS};${CAPNP_SRCS}")
 
 # Create custom target for generating C++ code from .capnp schema files.
-create_capnpc_target(generate_capnp_cpp
-                     "${CAPNP_SPECS}"
-                     ${PROJECT_SOURCE_DIR}
-                     ${PROJECT_SOURCE_DIR}
-                     ${PROJECT_BINARY_DIR})
-set_source_files_properties(${CAPNP_SRCS} ${CAPNP_HDRS} PROPERTIES
-                            GENERATED TRUE)
+create_capnpc_command(capnp_specs
+                      "${CAPNP_SPECS}"
+                      ${PROJECT_SOURCE_DIR}
+                      ${PROJECT_SOURCE_DIR}
+                      ${PROJECT_BINARY_DIR}
+                      "${CAPNP_ALL}")
 
 #
 # Python support
@@ -432,7 +432,6 @@ set(LIB_STATIC_NUPICCORE_LINK_FLAGS
 add_library(${LIB_STATIC_NUPICCORE} STATIC ${LIB_STATIC_NUPICCORE_SRCS})
 target_link_libraries(${LIB_STATIC_NUPICCORE}
                       ${LIB_STATIC_NUPICCORE_LINK_LIBS})
-add_dependencies(${LIB_STATIC_NUPICCORE} generate_capnp_cpp CapnProto)
 set_target_properties(${LIB_STATIC_NUPICCORE} PROPERTIES COMPILE_FLAGS
                       ${LIB_STATIC_NUPICCORE_COMPILE_FLAGS})
 set_target_properties(${LIB_STATIC_NUPICCORE} PROPERTIES LINK_FLAGS


### PR DESCRIPTION
There was a bug in the cmake that caused everything to rebuild no matter what on both `make` and `make install`. This fixes that issue while still ensuring that the .capnp schema files show up in XCode IDE.

fixes #655 

@oxtopus - please review
@rcrowder - fyi