### PR TITLE
Win32 binding reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,10 +97,14 @@ install:
   - "mkdir -p $TRAVIS_BUILD_DIR/build/scripts"
   - "cd $TRAVIS_BUILD_DIR/build/scripts"
   - "mkdir -p $TRAVIS_BUILD_DIR/build/release"
+
   # Enable test coverage for travis-ci build
   - "cmake $TRAVIS_BUILD_DIR -DNTA_COV_ENABLED=ON -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/release"
   - "make -j3"
-  - "make install"
+
+  # install (but silence "Install" output due to Travis build log limit)
+  - "make install | grep -v 'Up-to-date: ' | grep -v 'Installing: '"
+
   - "cd $TRAVIS_BUILD_DIR"
   - "python setup.py install --user --nupic-core-dir=${TRAVIS_BUILD_DIR}/build/release"
 

--- a/bindings/py/requirements.txt
+++ b/bindings/py/requirements.txt
@@ -2,5 +2,5 @@
 pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8
-numpy==1.9.2
-pycapnp==0.5.5
+numpy==1.9.2; 'win32' not in sys_platform
+pycapnp==0.5.5; 'win32' not in sys_platform

--- a/bindings/py/requirements.txt
+++ b/bindings/py/requirements.txt
@@ -1,4 +1,5 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
+pip>=7.1.2
 pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8

--- a/bindings/py/requirements.txt
+++ b/bindings/py/requirements.txt
@@ -1,5 +1,6 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
 pip>=7.1.2
+distribute>=0.7.3
 pytest==2.5.1
 pytest-cov==1.6
 pytest-xdist==1.8

--- a/ci/appveyor/install_python_pip.ps1
+++ b/ci/appveyor/install_python_pip.ps1
@@ -79,7 +79,7 @@ function main () {
 
     Write-Host "python -m pip install --upgrade pip"
     $python_path = $env:PYTHONPATH + "/python.exe"
-    & $python_path -m pip install --upgrade pip
+    & $python_path -m pip install --ignore-installed --upgrade pip
 
     $pip_path = $env:PYTHONPATH + "/Scripts/pip.exe"
     Write-Host "pip install " wheel

--- a/ci/appveyor/install_python_pip.ps1
+++ b/ci/appveyor/install_python_pip.ps1
@@ -77,9 +77,9 @@ function main () {
     InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHONPATH
     InstallPip $env:PYTHONPATH
 
-    Write-Host "python -m pip install --upgrade pip"
+    Write-Host "python -m pip install --ignore-installed --upgrade pip>=7.1.2"
     $python_path = $env:PYTHONPATH + "/python.exe"
-    & $python_path -m pip install --ignore-installed --upgrade pip
+    & $python_path -m pip install --ignore-installed --upgrade pip>=7.1.2
 
     $pip_path = $env:PYTHONPATH + "/Scripts/pip.exe"
     Write-Host "pip install " wheel

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -41,9 +41,9 @@ export PATH=$HOME/.local/bin:$PATH
 export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 
 echo "Installing latest pip"
-pip install --ignore-installed --user setuptools
-pip install --ignore-installed --user --upgrade pip>=7.1.2
-pip install --ignore-installed --user --upgrade distribute>=0.7.3
+pip install --ignore-installed setuptools
+pip install --ignore-installed --upgrade pip>=7.1.2
+pip install --ignore-installed --upgrade distribute>=0.7.3
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -41,9 +41,9 @@ export PATH=$HOME/.local/bin:$PATH
 export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 
 echo "Installing latest pip"
-pip install --ignore-installed setuptools
-pip install --ignore-installed --upgrade pip>=7.1.2
-pip install --ignore-installed --upgrade distribute>=0.7.3
+sudo pip install --ignore-installed setuptools
+sudo pip install --ignore-installed --upgrade pip>=7.1.2
+sudo pip install --ignore-installed --upgrade distribute>=0.7.3
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -42,7 +42,8 @@ export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 
 echo "Installing latest pip"
 pip install --ignore-installed --user setuptools
-pip install --ignore-installed --user pip
+pip install --ignore-installed --user --upgrade pip>=7.1.2
+pip install --ignore-installed --user --upgrade distribute>=0.7.3
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-osx.sh
+++ b/ci/travis/before_install-osx.sh
@@ -38,9 +38,9 @@ export PATH=$HOME/Library/Python/2.7/bin:$PATH
 export PYTHONPATH=$HOME/Library/Python/2.7/lib/python/site-packages:$PYTHONPATH
 
 echo "Installing latest pip"
-pip install --ignore-installed --user setuptools
-pip install --ignore-installed --user --upgrade pip>=7.1.2
-pip install --ignore-installed --user --upgrade distribute>=0.7.3
+pip install --ignore-installed setuptools
+pip install --ignore-installed --upgrade pip>=7.1.2
+pip install --ignore-installed --upgrade distribute>=0.7.3
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-osx.sh
+++ b/ci/travis/before_install-osx.sh
@@ -38,9 +38,9 @@ export PATH=$HOME/Library/Python/2.7/bin:$PATH
 export PYTHONPATH=$HOME/Library/Python/2.7/lib/python/site-packages:$PYTHONPATH
 
 echo "Installing latest pip"
-pip install --ignore-installed setuptools
-pip install --ignore-installed --upgrade pip>=7.1.2
-pip install --ignore-installed --upgrade distribute>=0.7.3
+sudo pip install --ignore-installed setuptools
+sudo pip install --ignore-installed --upgrade pip>=7.1.2
+sudo pip install --ignore-installed --upgrade distribute>=0.7.3
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-osx.sh
+++ b/ci/travis/before_install-osx.sh
@@ -37,6 +37,11 @@ fi
 export PATH=$HOME/Library/Python/2.7/bin:$PATH
 export PYTHONPATH=$HOME/Library/Python/2.7/lib/python/site-packages:$PYTHONPATH
 
+echo "Installing latest pip"
+pip install --ignore-installed --user setuptools
+pip install --ignore-installed --user --upgrade pip>=7.1.2
+pip install --ignore-installed --user --upgrade distribute>=0.7.3
+
 echo "Installing wheel..."
 pip install wheel --user || exit
 echo "Installing Python dependencies"


### PR DESCRIPTION
Fixes #682 NumPy can be built from source with a Microsoft Python Compiler Package, but that complicates the building of bindings. Pycapnp needs source changes to support Windows. This change stops a pip install of the Windows wheel from trying to install these two packages. And includes the re-addition of grep filtering during a make install on Travis.