### PR TITLE
Makes build-from-source the default behavior for capnp and swig, requ…

### DIFF
--- a/external/CapnProto.cmake
+++ b/external/CapnProto.cmake
@@ -19,9 +19,9 @@
 # http://numenta.org/licenses/
 # -----------------------------------------------------------------------------
 
-option(SOURCE_CAPNP "Build Cap'n Proto from source even if it is found." OFF)
+option(FIND_CAPNP "Use preinstalled Cap'n Proto." OFF)
 
-if (NOT ${SOURCE_CAPNP})
+if (${FIND_CAPNP})
   find_package(CapnProto)
   # Most CAPNP* variables are set correctly but make sure we have the
   # static libraries.
@@ -30,9 +30,11 @@ if (NOT ${SOURCE_CAPNP})
   find_library(LIB_CAPNPC ${STATIC_PRE}capnpc${STATIC_SUF})
   set(CAPNP_LIBRARIES ${LIB_CAPNPC} ${LIB_CAPNP} ${LIB_KJ})
   set(CAPNP_LIBRARIES_LITE ${LIB_CAPNP} ${LIB_KJ})
-endif ()
 
-if (NOT CAPNP_FOUND)
+  # Create a dummy target to depend on.
+  add_custom_target(CapnProto)
+
+else ()
   # Build Cap'n Proto from source.
   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(CAPNP_DEFINITIONS "-DCAPNP_LITE=1 -DEXTERNAL_CAPNP=1")
@@ -81,10 +83,7 @@ if (NOT CAPNP_FOUND)
   set(CAPNP_INCLUDE_DIRS ${INCLUDE_PRE})
   set(CAPNP_EXECUTABLE ${BIN_PRE}/capnp${CMAKE_EXECUTABLE_SUFFIX})
   set(CAPNPC_CXX_EXECUTABLE ${BIN_PRE}/capnpc-c++${CMAKE_EXECUTABLE_SUFFIX})
-else()
-  # Create a dummy target to depend on.
-  add_custom_target(CapnProto)
-endif()
+endif ()
 
 function(CREATE_CAPNPC_COMMAND
          GROUP_NAME SPEC_FILES SRC_PREFIX INCLUDE_DIR TARGET_DIR OUTPUT_FILES)

--- a/external/Swig.cmake
+++ b/external/Swig.cmake
@@ -19,13 +19,14 @@
 # http://numenta.org/licenses/
 # -----------------------------------------------------------------------------
 
-option(SOURCE_SWIG "Build SWIG from source even if it is found." OFF)
+option(FIND_SWIG "Use preinstalled SWIG." OFF)
 
-if (NOT ${SOURCE_SWIG})
+if (${FIND_SWIG})
   find_package(SWIG)
-endif ()
+  # Create a dummy target to depend on.
+  add_custom_target(Swig)
 
-if (NOT SWIG_FOUND)
+else ()
   # Build SWIG from source.
   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     add_custom_target(Swig)
@@ -47,10 +48,7 @@ if (NOT SWIG_FOUND)
     set(SWIG_EXECUTABLE ${EP_BASE}/Install/bin/swig)
     set(SWIG_DIR ${EP_BASE}/Install/share/swig/3.0.2)
   endif()
-else()
-  # Create a dummy target to depend on.
-  add_custom_target(Swig)
-endif()
+endif ()
 
 set(SWIG_EXECUTABLE ${SWIG_EXECUTABLE} PARENT_SCOPE)
 set(SWIG_DIR ${SWIG_DIR} PARENT_SCOPE)


### PR DESCRIPTION
…iring the flags FIND_CAPNP or FIND_SWIG to be specified in order to use a preinstalled version.

@oxtopus please review

fixes #749 