### PR TITLE
Remove Tester class for test in tests/unit/math

### DIFF
--- a/src/test/unit/math/SparseBinaryMatrixTest.cpp
+++ b/src/test/unit/math/SparseBinaryMatrixTest.cpp
@@ -33,71 +33,67 @@
 #include <nupic/proto/SparseBinaryMatrixProto.capnp.h>
 #include <nupic/types/Types.h>
 
-namespace nupic
+
+using namespace nupic;
+
+TEST(SparseBinaryMatrixReadWrite, EmptyMatrix)
 {
-  namespace
-  {
+  SparseBinaryMatrix<UInt32, UInt32> m1, m2;
 
-    TEST(SparseBinaryMatrixReadWrite, EmptyMatrix)
-    {
-      SparseBinaryMatrix<UInt32, UInt32> m1, m2;
+  m1.resize(3, 4);
 
-      m1.resize(3, 4);
+  std::stringstream ss;
 
-      std::stringstream ss;
+  // write
+  capnp::MallocMessageBuilder message1;
+  SparseBinaryMatrixProto::Builder protoBuilder = message1.initRoot<SparseBinaryMatrixProto>();
+  m1.write(protoBuilder);
+  kj::std::StdOutputStream out(ss);
+  capnp::writeMessage(out, message1);
 
-      // write
-      capnp::MallocMessageBuilder message1;
-      SparseBinaryMatrixProto::Builder protoBuilder = message1.initRoot<SparseBinaryMatrixProto>();
-      m1.write(protoBuilder);
-      kj::std::StdOutputStream out(ss);
-      capnp::writeMessage(out, message1);
+  // read
+  kj::std::StdInputStream in(ss);
+  capnp::InputStreamMessageReader message2(in);
+  SparseBinaryMatrixProto::Reader protoReader = message2.getRoot<SparseBinaryMatrixProto>();
+  m2.read(protoReader);
 
-      // read
-      kj::std::StdInputStream in(ss);
-      capnp::InputStreamMessageReader message2(in);
-      SparseBinaryMatrixProto::Reader protoReader = message2.getRoot<SparseBinaryMatrixProto>();
-      m2.read(protoReader);
+  // compare
+  ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
+  ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
+}
 
-      // compare
-      ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
-      ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
-    }
+TEST(SparseBinaryMatrixReadWrite, Basic)
+{
+  SparseBinaryMatrix<UInt, Real> m1, m2;
 
-    TEST(SparseBinaryMatrixReadWrite, Basic)
-    {
-      SparseBinaryMatrix<UInt, Real> m1, m2;
+  m1.resize(3, 4);
+  m1.set(1, 1, 1);
 
-      m1.resize(3, 4);
-      m1.set(1, 1, 1);
+  std::stringstream ss;
 
-      std::stringstream ss;
+  // write
+  capnp::MallocMessageBuilder message1;
+  SparseBinaryMatrixProto::Builder protoBuilder = message1.initRoot<SparseBinaryMatrixProto>();
+  m1.write(protoBuilder);
+  kj::std::StdOutputStream out(ss);
+  capnp::writeMessage(out, message1);
 
-      // write
-      capnp::MallocMessageBuilder message1;
-      SparseBinaryMatrixProto::Builder protoBuilder = message1.initRoot<SparseBinaryMatrixProto>();
-      m1.write(protoBuilder);
-      kj::std::StdOutputStream out(ss);
-      capnp::writeMessage(out, message1);
+  // read
+  kj::std::StdInputStream in(ss);
+  capnp::InputStreamMessageReader message2(in);
+  SparseBinaryMatrixProto::Reader protoReader = message2.getRoot<SparseBinaryMatrixProto>();
+  m2.read(protoReader);
 
-      // read
-      kj::std::StdInputStream in(ss);
-      capnp::InputStreamMessageReader message2(in);
-      SparseBinaryMatrixProto::Reader protoReader = message2.getRoot<SparseBinaryMatrixProto>();
-      m2.read(protoReader);
+  // compare
+  ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
+  ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
 
-      // compare
-      ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
-      ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
+  auto m1r1 = m1.getSparseRow(1);
+  ASSERT_EQ(m1r1.size(), 1) << "Invalid # of elements in original matrix";
+  auto m2r1 = m2.getSparseRow(1);
+  ASSERT_EQ(m2r1.size(), 1) << "Invalid # of elements in copied matrix";
 
-      auto m1r1 = m1.getSparseRow(1);
-      ASSERT_EQ(m1r1.size(), 1) << "Invalid # of elements in original matrix";
-      auto m2r1 = m2.getSparseRow(1);
-      ASSERT_EQ(m2r1.size(), 1) << "Invalid # of elements in copied matrix";
+  ASSERT_EQ(m1r1[0], 1) << "Invalid col index in original matrix";
+  ASSERT_EQ(m1r1[0], m2r1[0]) << "Invalid col index in copied matrix";
+}
 
-      ASSERT_EQ(m1r1[0], 1) << "Invalid col index in original matrix";
-      ASSERT_EQ(m1r1[0], m2r1[0]) << "Invalid col index in copied matrix";
-    }
-
-  }  // namespace
-}  // namespace nupic

--- a/src/test/unit/math/SparseMatrixTest.cpp
+++ b/src/test/unit/math/SparseMatrixTest.cpp
@@ -33,75 +33,70 @@
 #include <nupic/proto/SparseMatrixProto.capnp.h>
 #include <nupic/types/Types.h>
 
-namespace nupic
+
+using namespace nupic;
+
+TEST(SparseMatrixReadWrite, EmptyMatrix)
 {
-  namespace
-  {
+  SparseMatrix<UInt, Real> m1, m2;
 
-    TEST(SparseMatrixReadWrite, EmptyMatrix)
-    {
-      SparseMatrix<UInt, Real> m1, m2;
+  m1.resize(3, 4);
 
-      m1.resize(3, 4);
+  std::stringstream ss;
 
-      std::stringstream ss;
+  // write
+  capnp::MallocMessageBuilder message1;
+  SparseMatrixProto::Builder protoBuilder = message1.initRoot<SparseMatrixProto>();
+  m1.write(protoBuilder);
+  kj::std::StdOutputStream out(ss);
+  capnp::writeMessage(out, message1);
 
-      // write
-      capnp::MallocMessageBuilder message1;
-      SparseMatrixProto::Builder protoBuilder = message1.initRoot<SparseMatrixProto>();
-      m1.write(protoBuilder);
-      kj::std::StdOutputStream out(ss);
-      capnp::writeMessage(out, message1);
+  // read
+  kj::std::StdInputStream in(ss);
+  capnp::InputStreamMessageReader message2(in);
+  SparseMatrixProto::Reader protoReader = message2.getRoot<SparseMatrixProto>();
+  m2.read(protoReader);
 
-      // read
-      kj::std::StdInputStream in(ss);
-      capnp::InputStreamMessageReader message2(in);
-      SparseMatrixProto::Reader protoReader = message2.getRoot<SparseMatrixProto>();
-      m2.read(protoReader);
+  // compare
+  ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
+  ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
+}
 
-      // compare
-      ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
-      ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
-    }
+TEST(SparseMatrixReadWrite, Basic)
+{
+  SparseMatrix<UInt, Real> m1, m2;
 
-    TEST(SparseMatrixReadWrite, Basic)
-    {
-      SparseMatrix<UInt, Real> m1, m2;
+  m1.resize(3, 4);
+  m1.setNonZero(1, 1, 3.0);
 
-      m1.resize(3, 4);
-      m1.setNonZero(1, 1, 3.0);
+  std::stringstream ss;
 
-      std::stringstream ss;
+  // write
+  capnp::MallocMessageBuilder message1;
+  SparseMatrixProto::Builder protoBuilder = message1.initRoot<SparseMatrixProto>();
+  m1.write(protoBuilder);
+  kj::std::StdOutputStream out(ss);
+  capnp::writeMessage(out, message1);
 
-      // write
-      capnp::MallocMessageBuilder message1;
-      SparseMatrixProto::Builder protoBuilder = message1.initRoot<SparseMatrixProto>();
-      m1.write(protoBuilder);
-      kj::std::StdOutputStream out(ss);
-      capnp::writeMessage(out, message1);
+  // read
+  kj::std::StdInputStream in(ss);
+  capnp::InputStreamMessageReader message2(in);
+  SparseMatrixProto::Reader protoReader = message2.getRoot<SparseMatrixProto>();
+  m2.read(protoReader);
 
-      // read
-      kj::std::StdInputStream in(ss);
-      capnp::InputStreamMessageReader message2(in);
-      SparseMatrixProto::Reader protoReader = message2.getRoot<SparseMatrixProto>();
-      m2.read(protoReader);
+  // compare
+  ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
+  ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
 
-      // compare
-      ASSERT_EQ(m1.nRows(), m2.nRows()) << "Number of rows don't match";
-      ASSERT_EQ(m1.nCols(), m2.nCols()) << "Number of columns don't match";
+  std::vector<std::pair<UInt, Real> > m1r1(m1.nNonZerosOnRow(1));
+  m1.getRowToSparse(1, m1r1.begin());
+  ASSERT_EQ(m1r1.size(), 1) << "Invalid # of elements in original matrix";
+  std::vector<std::pair<UInt, Real> > m2r1(m2.nNonZerosOnRow(1));
+  m2.getRowToSparse(1, m2r1.begin());
+  ASSERT_EQ(m2r1.size(), 1) << "Invalid # of elements in copied matrix";
 
-      std::vector<std::pair<UInt, Real> > m1r1(m1.nNonZerosOnRow(1));
-      m1.getRowToSparse(1, m1r1.begin());
-      ASSERT_EQ(m1r1.size(), 1) << "Invalid # of elements in original matrix";
-      std::vector<std::pair<UInt, Real> > m2r1(m2.nNonZerosOnRow(1));
-      m2.getRowToSparse(1, m2r1.begin());
-      ASSERT_EQ(m2r1.size(), 1) << "Invalid # of elements in copied matrix";
-
-      ASSERT_EQ(m1r1[0].first, 1) << "Invalid col index in original matrix";
-      ASSERT_EQ(m1r1[0].first, m2r1[0].first) << "Invalid col index in copied matrix";
-      ASSERT_EQ(m1r1[0].second, 3.0) << "Invalid value in original matrix";
-      ASSERT_EQ(m1r1[0].second, m2r1[0].second) << "Invalid value in copied matrix";
-    }
-
-  }  // namespace
-}  // namespace nupic
+  ASSERT_EQ(m1r1[0].first, 1) << "Invalid col index in original matrix";
+  ASSERT_EQ(m1r1[0].first, m2r1[0].first) << "Invalid col index in copied matrix";
+  ASSERT_EQ(m1r1[0].second, 3.0) << "Invalid value in original matrix";
+  ASSERT_EQ(m1r1[0].second, m2r1[0].second) << "Invalid value in copied matrix";
+}


### PR DESCRIPTION
Fixes #719 

Note that no tests had to be translated to gtest for this sub-issue. All tests were already using gtest or were commented out as addressed in #376. I did remove unnecessary namespaces from the gtest test cases as has been the convention.

@scottpurdy 