### PR TITLE
Fixes for building with `cmake -GNinja`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -627,6 +627,10 @@ target_link_libraries(${EXECUTABLE_GTESTS}
 set_target_properties(${EXECUTABLE_GTESTS}
                       PROPERTIES COMPILE_FLAGS ${COMMON_COMPILE_FLAGS}
                                  LINK_FLAGS "${COMMON_LINK_FLAGS}")
+add_custom_target(tests_unit
+                  COMMAND ${EXECUTABLE_GTESTS}
+                  DEPENDS ${EXECUTABLE_GTESTS}
+                  VERBATIM)
 add_dependencies(${EXECUTABLE_GTESTS} ${LIB_STATIC_GTEST} ${COMMON_LIBS})
 set(TEST_HEADERS
     test/unit/math/DenseTensorUnitTest.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -678,56 +678,58 @@ add_custom_target(tests_all
                   VERBATIM)
 
 if(UNIX OR MSYS OR MINGW)
+  set(LIB_STATIC_NUPICCORE_COMBINED "${PROJECT_BINARY_DIR}/libnupic_core.a")
   if(MSYS OR MINGW)
-    add_custom_target(combined ALL
-                      COMMAND ${CMAKE_AR} -x $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_CPP_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APRUTIL1_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
-                      COMMAND ${CMAKE_AR} rcs libnupic_core.a *.o *.obj
-                      DEPENDS ${LIB_STATIC_NUPICCORE}
-                              ${LIB_STATIC_GTEST}
-                              ${EXECUTABLE_HELLOREGION}
-                              ${EXECUTABLE_CPPREGIONTEST}
-                              ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                              ${EXECUTABLE_GTESTS}
-                              ${EXECUTABLE_HELLOSPTP})
+    add_custom_command(OUTPUT ${LIB_STATIC_NUPICCORE_COMBINED}
+                       COMMAND ${CMAKE_AR} -x $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_CPP_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APRUTIL1_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
+                       COMMAND ${CMAKE_AR} rcs ${LIB_STATIC_NUPICCORE_COMBINED} *.o *.obj
+                       DEPENDS ${LIB_STATIC_NUPICCORE}
+                               ${LIB_STATIC_GTEST}
+                               ${EXECUTABLE_HELLOREGION}
+                               ${EXECUTABLE_CPPREGIONTEST}
+                               ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
+                               ${EXECUTABLE_GTESTS}
+                               ${EXECUTABLE_HELLOSPTP})
   else()
-    add_custom_target(combined ALL
-                      COMMAND ${CMAKE_AR} -x $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_CPP_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APRUTIL1_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
-                      COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
-                      COMMAND ${CMAKE_AR} rcs libnupic_core.a *.o
-                      DEPENDS ${LIB_STATIC_NUPICCORE}
-                              ${LIB_STATIC_GTEST}
-                              ${EXECUTABLE_HELLOREGION}
-                              ${EXECUTABLE_CPPREGIONTEST}
-                              ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                              ${EXECUTABLE_GTESTS}
-                              ${EXECUTABLE_HELLOSPTP})
+    add_custom_command(OUTPUT ${LIB_STATIC_NUPICCORE_COMBINED}
+                       COMMAND ${CMAKE_AR} -x $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_CPP_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_YAML_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APRUTIL1_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
+                       COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
+                       COMMAND ${CMAKE_AR} rcs ${LIB_STATIC_NUPICCORE_COMBINED} *.o
+                       DEPENDS ${LIB_STATIC_NUPICCORE}
+                               ${LIB_STATIC_GTEST}
+                               ${EXECUTABLE_HELLOREGION}
+                               ${EXECUTABLE_CPPREGIONTEST}
+                               ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
+                               ${EXECUTABLE_GTESTS}
+                               ${EXECUTABLE_HELLOSPTP})
   endif()
 else()
-  add_custom_target(combined ALL
-                    COMMAND lib.exe /OUT:nupic_core.lib
-                            $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
-                            ${LIB_STATIC_YAML_CPP_LOC}
-                            ${LIB_STATIC_YAML_LOC}
-                            ${LIB_STATIC_APRUTIL1_LOC}
-                            ${LIB_STATIC_APR1_LOC}
-                            ${LIB_STATIC_Z_LOC}
-                    DEPENDS ${LIB_STATIC_NUPICCORE}
-                            ${LIB_STATIC_GTEST}
-                            ${EXECUTABLE_HELLOREGION}
-                            ${EXECUTABLE_CPPREGIONTEST}
-                            ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                            ${EXECUTABLE_GTESTS}
-                            ${EXECUTABLE_HELLOSPTP}
-                    VERBATIM)
+  set(LIB_STATIC_NUPICCORE_COMBINED "${PROJECT_BINARY_DIR}/nupic_core.lib")
+  add_custom_command(OUTPUT ${LIB_STATIC_NUPICCORE_COMBINED}
+                     COMMAND lib.exe /OUT:${LIB_STATIC_NUPICCORE_COMBINED}
+                             $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
+                             ${LIB_STATIC_YAML_CPP_LOC}
+                             ${LIB_STATIC_YAML_LOC}
+                             ${LIB_STATIC_APRUTIL1_LOC}
+                             ${LIB_STATIC_APR1_LOC}
+                             ${LIB_STATIC_Z_LOC}
+                     DEPENDS ${LIB_STATIC_NUPICCORE}
+                             ${LIB_STATIC_GTEST}
+                             ${EXECUTABLE_HELLOREGION}
+                             ${EXECUTABLE_CPPREGIONTEST}
+                             ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
+                             ${EXECUTABLE_GTESTS}
+                             ${EXECUTABLE_HELLOSPTP}
+                     VERBATIM)
 endif()
 
 #
@@ -780,7 +782,7 @@ set(SWIG_SUPPORT_FILES
 )
 
 set(SWIG_LINK_LIBRARIES
-    ${PROJECT_BINARY_DIR}/libnupic_core.a
+    ${LIB_STATIC_NUPICCORE_COMBINED}
     ${PYTHON_LIBRARIES}
     ${COMMON_OS_LIBS})
 
@@ -802,13 +804,12 @@ set_source_files_properties(${SWIG_ALGORITHMS_FILES} PROPERTIES
                             SWIG_FLAGS "${SWIG_FLAGS}")
 set(SWIG_ALGORITHMS algorithms)
 # Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${SWIG_ALGORITHMS}_EXTRA_DEPS Swig combined)
+set(SWIG_MODULE_${SWIG_ALGORITHMS}_EXTRA_DEPS Swig ${LIB_STATIC_NUPICCORE_COMBINED})
 # Create custom command for generating files from SWIG.
 swig_add_module(${SWIG_ALGORITHMS} python
                 ${SWIG_SUPPORT_FILES}
                 ${SWIG_ALGORITHMS_FILES})
 list(APPEND SWIG_GENERATED_FILES ${swig_generated_file_fullname})
-#TODO add_dependencies(${SWIG_MODULE_${SWIG_ALGORITHMS}_REAL_NAME}
 swig_link_libraries(${SWIG_ALGORITHMS}
                     ${SWIG_LINK_LIBRARIES})
 
@@ -820,7 +821,7 @@ set_source_files_properties(${SWIG_ENGINE_FILES} PROPERTIES
                             SWIG_FLAGS "${SWIG_FLAGS}")
 set(SWIG_ENGINE engine_internal)
 # Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${SWIG_ENGINE}_EXTRA_DEPS Swig combined)
+set(SWIG_MODULE_${SWIG_ENGINE}_EXTRA_DEPS Swig ${LIB_STATIC_NUPICCORE_COMBINED})
 # Create custom command for generating files from SWIG.
 swig_add_module(${SWIG_ENGINE} python
                 ${SWIG_SUPPORT_FILES}
@@ -837,7 +838,7 @@ set_source_files_properties(${SWIG_MATH_FILES} PROPERTIES
                             SWIG_FLAGS "${SWIG_FLAGS}")
 set(SWIG_MATH math)
 # Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${SWIG_MATH}_EXTRA_DEPS Swig combined)
+set(SWIG_MODULE_${SWIG_MATH}_EXTRA_DEPS Swig ${LIB_STATIC_NUPICCORE_COMBINED})
 # Create custom command for generating files from SWIG.
 swig_add_module(${SWIG_MATH} python
                 ${SWIG_SUPPORT_FILES}
@@ -919,13 +920,8 @@ foreach(directory ${CAPNP_INCLUDE_DIRS})
   install(DIRECTORY "${directory}/kj"
           DESTINATION include)
 endforeach()
-if(UNIX OR MSYS OR MINGW)
-  install(FILES "${PROJECT_BINARY_DIR}/libnupic_core.a"
-          DESTINATION lib)
-else()
-  install(FILES "${PROJECT_BINARY_DIR}/nupic_core.lib"
-          DESTINATION lib)
-endif()
+install(FILES ${LIB_STATIC_NUPICCORE_COMBINED}
+        DESTINATION lib)
 
 install(DIRECTORY nupic/py_support DESTINATION include/nupic
         FILES_MATCHING PATTERN "*.c*")


### PR DESCRIPTION
Fixes #809

One of the great things about CMake is being able to use `ninja` (https://ninja-build.org/) by specifying `cmake -GNinja`. I gave it a shot but ran into some errors (nothing major; the things would probably be worth fixing anyway). More details in the commit messages.

I'm building locally with this configure line (on Ubuntu 15.04):
```
cmake -GNinja $NUPIC_CORE -DCMAKE_INSTALL_PREFIX=../ninja-release -DPY_EXTENSIONS_DIR=$NUPIC_CORE/bindings/py/nupic/bindings -DFIND_CAPNP=ON -DFIND_SWIG=ON
```


Some potentially relevant reviewers (and the relevant commits I found them by)
@oxtopus ddc622bf99c886692f2b19892a56ecc70e8fa5de
@rcrowder 6258ba8016e71e13103b2b495c99f585cba733f4