### PR TITLE
Remove unnecessary dependencies for ${LIB_STATIC_NUPICCORE_COMBINED}

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -692,13 +692,7 @@ if(UNIX OR MSYS OR MINGW)
                        COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
                        COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
                        COMMAND ${CMAKE_AR} rcs ${LIB_STATIC_NUPICCORE_COMBINED} *.o *.obj
-                       DEPENDS ${LIB_STATIC_NUPICCORE}
-                               ${LIB_STATIC_GTEST}
-                               ${EXECUTABLE_HELLOREGION}
-                               ${EXECUTABLE_CPPREGIONTEST}
-                               ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                               ${EXECUTABLE_GTESTS}
-                               ${EXECUTABLE_HELLOSPTP})
+                       DEPENDS ${LIB_STATIC_NUPICCORE})
   else()
     add_custom_command(OUTPUT ${LIB_STATIC_NUPICCORE_COMBINED}
                        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:${LIB_STATIC_NUPICCORE}>
@@ -708,13 +702,7 @@ if(UNIX OR MSYS OR MINGW)
                        COMMAND ${CMAKE_AR} -x ${LIB_STATIC_APR1_LOC}
                        COMMAND ${CMAKE_AR} -x ${LIB_STATIC_Z_LOC}
                        COMMAND ${CMAKE_AR} rcs ${LIB_STATIC_NUPICCORE_COMBINED} *.o
-                       DEPENDS ${LIB_STATIC_NUPICCORE}
-                               ${LIB_STATIC_GTEST}
-                               ${EXECUTABLE_HELLOREGION}
-                               ${EXECUTABLE_CPPREGIONTEST}
-                               ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                               ${EXECUTABLE_GTESTS}
-                               ${EXECUTABLE_HELLOSPTP})
+                       DEPENDS ${LIB_STATIC_NUPICCORE})
   endif()
 else()
   set(LIB_STATIC_NUPICCORE_COMBINED "${PROJECT_BINARY_DIR}/nupic_core.lib")
@@ -727,12 +715,6 @@ else()
                              ${LIB_STATIC_APR1_LOC}
                              ${LIB_STATIC_Z_LOC}
                      DEPENDS ${LIB_STATIC_NUPICCORE}
-                             ${LIB_STATIC_GTEST}
-                             ${EXECUTABLE_HELLOREGION}
-                             ${EXECUTABLE_CPPREGIONTEST}
-                             ${EXECUTABLE_CONNECTIONSPERFORMANCETEST}
-                             ${EXECUTABLE_GTESTS}
-                             ${EXECUTABLE_HELLOSPTP}
                      VERBATIM)
 endif()
 


### PR DESCRIPTION
The only build target that is an input to this build step is
${LIB_STATIC_NUPICCORE}, so that is all it should depend on. All the
other inputs are determined at configure time and reside in
`nupic.core/external`.

I noticed this when touching
`nupic.core/src/test/integration/ConnectionsPerformanceTest.cpp`
which is needed for the ${EXECUTABLE_CONNECTIONSPERFORMANCETEST} target.
This would cause ${LIB_STATIC_NUPICCORE_COMBINED} to be rebuilt as well,
which would also trigger rebuilding the SWIG bindings (which takes a
while).

Fixes #810