### PR TITLE
Delete segments with no synapses

### DIFF
--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -358,6 +358,7 @@ void TemporalMemory::learnOnSegments(
   vector<Segment>& prevMatchingSegments)
 {
   vector<Segment> _allSegments;
+  vector<Segment> segmentsMarkedForDeletion;
 
   for (auto segment : prevActiveSegments)
     _allSegments.push_back(segment);
@@ -397,6 +398,9 @@ void TemporalMemory::learnOnSegments(
           segment, presynapticCell, initialPermanence_);
       }
     }
+
+    if (_connections.dataForSegment(segment).synapses.size() == 0)
+      segmentsMarkedForDeletion.push_back(segment);
   }
 
   if (predictedSegmentDecrement_ > 0.0)
@@ -415,8 +419,16 @@ void TemporalMemory::learnOnSegments(
         adaptSegment(segment, activeSynapses, _connections,
           -predictedSegmentDecrement_, 0.0);
       }
+
+      if (_connections.dataForSegment(segment).synapses.size() == 0)
+        segmentsMarkedForDeletion.push_back(segment);
+      
     }
   }
+
+  for (Segment segment : segmentsMarkedForDeletion)
+    if (!_connections.dataForSegment(segment).destroyed)
+      connections.destroySegment(segment);
 }
 
 tuple<vector<Segment>, set<Cell>, vector<Segment>, set<Cell>>


### PR DESCRIPTION
Fixes #824 

Here is the reasoning for this implementation. There only time when a segment may have its synapse count decreased is during a call to `adaptSegment`, and `adaptSegment` is only called twice, both times in `TemporalMemory::learnOnSegments`, once in each of two loops over segments. The only time a segment's synapse count can be increased is also in `TemporalMemory::learnOnSegments` in the first loop. The first loop can either increase or decrease the number of synapses, but the second loop can only decrease or leave unchanged the number of synapses. Thus, if a segment has 0 synapses at the end of each iteration of either loop, it should always be deleted.

However, immediately deleting a segment at the end of each iteration of either loop has the unintended consequence that the call to `adaptSegment` in the second loop will throw an exception if the segment is already deleted when it is called. There are several ways one could deal with this issue:

1. Deleting the segments immediately, but checking whether the segment is deleted before calling `adaptSegment` in the second loop. 

2. At the end of `learnOnSegments` iterate through all segments and delete any segments that have 0 synapses.

3. Keep track of any segments that need to be deleted, but only delete them at the end of `learnOnSegments`.

I've chosen option 3. Option 2 may be more flexible to future changes in the algorithm, but it requires a third loop through all segments, which is non-performant. I think option 1 could work too.

One consideration is that `destroySegment` does not actually remove a segment from the vector of segments for each cell but merely deletes its synapses (which is moot here) and marks that segment with a flag indicating that it is destroyed, thus currently destroying a segment does not save any space. I believe the reason for this is that each Segment object stores its index within the segment vector of its parent cell. Thus, removing the segment from the segment vector would require updating the indices of all the other segments. Given this design choice, updating those indices would require additional computation time. So it's a space vs. time tradeoff. If we want to change the behavior of `destroySegment`, this can be addressed in a separate PR.

Unit tests are still to be added.

@scottpurdy @subutai 