### PR TITLE
Fix: TM compatibility tests fail when predictedSegmentDecrement is nonzero

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -183,7 +183,7 @@ vector<Synapse> Connections::synapsesForSegment(const Segment& segment)
     synapse.segment = segment;
     synapseData = dataForSynapse(synapse);
 
-    if (!synapseData.destroyed && synapseData.permanence > 0)
+    if (!synapseData.destroyed)
     {
       synapses.push_back(synapse);
     }

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -619,7 +619,7 @@ void TemporalMemory::adaptSegment(
     if (permanence < 0.0)
       permanence = 0.0;
 
-    if (permanence < EPSILON)
+    if (permanence < 10 * EPSILON)
       _connections.destroySynapse(synapse);
     else
       _connections.updateSynapsePermanence(synapse, permanence);

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -452,13 +452,18 @@ TemporalMemory::computePredictiveCells(
   map<Segment, int> numActiveSynapsesForSegment;
   vector<Cell> activeCells(_activeCells.begin(), _activeCells.end());
 
-  Activity activity = _connections.computeActivity(activeCells, connectedPermanence_, activationThreshold_);
+  // Reduce permanence threshold by epsilon before comparing
+  // to avoid rounding edge cases
+  Permanence connectedPermanence = connectedPermanence_ - EPSILON;
+  Permanence minThreshold = minThreshold_ - EPSILON;
+
+  Activity activity = _connections.computeActivity(activeCells, connectedPermanence, activationThreshold_);
 
   vector<Segment> _activeSegments = _connections.activeSegments(activity);
   vector<Cell> predictiveCellsVec = _connections.activeCells(activity);
   set<Cell> _predictiveCells(predictiveCellsVec.begin(), predictiveCellsVec.end());
 
-  Activity matchingActivity = _connections.computeActivity(activeCells, 0.0, minThreshold_, false);
+  Activity matchingActivity = _connections.computeActivity(activeCells, 0.0, minThreshold, false);
 
   vector<Segment> _matchingSegments = _connections.activeSegments(matchingActivity);
   vector<Cell> matchingCellsVec = _connections.activeCells(matchingActivity);

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -455,15 +455,13 @@ TemporalMemory::computePredictiveCells(
   // Reduce permanence threshold by epsilon before comparing
   // to avoid rounding edge cases
   Permanence connectedPermanence = connectedPermanence_ - EPSILON;
-  Permanence minThreshold = minThreshold_ - EPSILON;
-
   Activity activity = _connections.computeActivity(activeCells, connectedPermanence, activationThreshold_);
 
   vector<Segment> _activeSegments = _connections.activeSegments(activity);
   vector<Cell> predictiveCellsVec = _connections.activeCells(activity);
   set<Cell> _predictiveCells(predictiveCellsVec.begin(), predictiveCellsVec.end());
 
-  Activity matchingActivity = _connections.computeActivity(activeCells, 0.0, minThreshold, false);
+  Activity matchingActivity = _connections.computeActivity(activeCells, 0.0, minThreshold_, false);
 
   vector<Segment> _matchingSegments = _connections.activeSegments(matchingActivity);
   vector<Cell> matchingCellsVec = _connections.activeCells(matchingActivity);

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -44,7 +44,7 @@ using namespace nupic;
 using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 
-#define EPSILON 0.0000001
+#define EPSILON 0.000001
 
 TemporalMemory::TemporalMemory()
 {

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -45,6 +45,8 @@ using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 
 #define EPSILON 0.0000001
+// The permanence threshold under which synapse is treated as 0 permanence
+#define EPSILON_THRESHOLD (10 * EPSILON)
 
 TemporalMemory::TemporalMemory()
 {
@@ -619,7 +621,7 @@ void TemporalMemory::adaptSegment(
     if (permanence < 0.0)
       permanence = 0.0;
 
-    if (permanence < 10 * EPSILON)
+    if (permanence < EPSILON_THRESHOLD)
       _connections.destroySynapse(synapse);
     else
       _connections.updateSynapsePermanence(synapse, permanence);

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -529,8 +529,9 @@ TemporalMemory::bestMatchingSegment(
     {
       SynapseData synapseData = _connections.dataForSynapse(synapse);
 
-      if (find(activeCells.begin(), activeCells.end(),
-        synapseData.presynapticCell) != activeCells.end())
+      if (synapseData.permanence > 0 &&
+          find(activeCells.begin(), activeCells.end(),
+            synapseData.presynapticCell) != activeCells.end())
       {
         numActiveSynapses += 1;
       }

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -45,8 +45,6 @@ using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 
 #define EPSILON 0.0000001
-// The permanence threshold under which synapse is treated as 0 permanence
-#define EPSILON_THRESHOLD (10 * EPSILON)
 
 TemporalMemory::TemporalMemory()
 {
@@ -452,10 +450,7 @@ TemporalMemory::computePredictiveCells(
   map<Segment, int> numActiveSynapsesForSegment;
   vector<Cell> activeCells(_activeCells.begin(), _activeCells.end());
 
-  // Reduce permanence threshold by epsilon before comparing
-  // to avoid rounding edge cases
-  Permanence connectedPermanence = connectedPermanence_ - EPSILON;
-  Activity activity = _connections.computeActivity(activeCells, connectedPermanence, activationThreshold_);
+  Activity activity = _connections.computeActivity(activeCells, connectedPermanence_, activationThreshold_);
 
   vector<Segment> _activeSegments = _connections.activeSegments(activity);
   vector<Cell> predictiveCellsVec = _connections.activeCells(activity);
@@ -536,7 +531,7 @@ TemporalMemory::bestMatchingSegment(
 
       if (synapseData.permanence > 0 &&
           find(activeCells.begin(), activeCells.end(),
-            synapseData.presynapticCell) != activeCells.end())
+               synapseData.presynapticCell) != activeCells.end())
       {
         numActiveSynapses += 1;
       }
@@ -624,7 +619,7 @@ void TemporalMemory::adaptSegment(
     if (permanence < 0.0)
       permanence = 0.0;
 
-    if (permanence < EPSILON_THRESHOLD)
+    if (permanence < EPSILON)
       _connections.destroySynapse(synapse);
     else
       _connections.updateSynapsePermanence(synapse, permanence);

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1708,7 +1708,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
         self, columnDimensions, cellsPerColumn, activationThreshold,
         initialPermanence, connectedPermanence,
         minThreshold, maxNewSynapseCount, permanenceIncrement,
-        permanenceDecrement, predictedSegmentDecrement, seed)
+        permanenceDecrement, predictedSegmentDecrement, seed,
+        maxSegmentsPerCell, maxSynapsesPerSegment)
 
     def __getstate__(self):
       # Save the local attributes but override the C++ temporal memory with the


### PR DESCRIPTION
Replaces #855 
fixes #845 