### PR TITLE
Removing manual pip upgrades and setting wheel version==0.25.0

### DIFF
--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -29,7 +29,7 @@ cd ${TRAVIS_BUILD_DIR}
 echo "Installing boto..."
 pip install boto --user || exit
 echo "Installing wheel..."
-pip install wheel --user || exit
+pip install wheel==0.25.0 --user || exit
 echo "Installing twine..."
 pip install twine --user || exit
 

--- a/ci/travis/after_success-release-osx.sh
+++ b/ci/travis/after_success-release-osx.sh
@@ -27,7 +27,7 @@ echo
 cd ${TRAVIS_BUILD_DIR}
 
 echo "Installing wheel..."
-pip install wheel --user || exit
+pip install wheel==0.25.0 --user || exit
 echo "Installing twine..."
 pip install twine --user -v || exit
 

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -30,8 +30,8 @@ set -o xtrace
 # wheels ourselves for deployment to S3. No need to build docs.
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
 
-    # Assuming pip 1.5.X is installed.
-    pip install wheel --user
+    # Assuming pip 1.5.X+ is installed.
+    pip install wheel==0.25.0 --user
 
     cd ${TRAVIS_BUILD_DIR}/bindings/py
 

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -30,6 +30,8 @@ set -o xtrace
 # wheels ourselves for deployment to S3. No need to build docs.
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
 
+    # Upgrading pip
+    pip install --upgrade pip
     # Assuming pip 1.5.X+ is installed.
     pip install wheel==0.25.0 --user
 

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -30,9 +30,6 @@ set -o xtrace
 # wheels ourselves for deployment to S3. No need to build docs.
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
 
-    # Upgrading pip
-    pip install --upgrade pip
-
     # Assuming pip 1.5.X is installed.
     pip install wheel --user
 

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -43,7 +43,7 @@ export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 pip install --ignore-installed --user setuptools
 
 echo "Installing wheel..."
-pip install wheel --user || exit
+pip install wheel==0.25.0 --user || exit
 echo "Installing Python dependencies"
 pip install --use-wheel --user -r bindings/py/requirements.txt --quiet || exit
 

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -40,9 +40,7 @@ fi
 export PATH=$HOME/.local/bin:$PATH
 export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 
-echo "Installing latest pip"
 pip install --ignore-installed --user setuptools
-pip install --ignore-installed --user pip
 
 echo "Installing wheel..."
 pip install wheel --user || exit

--- a/ci/travis/before_install-linux.sh
+++ b/ci/travis/before_install-linux.sh
@@ -40,7 +40,9 @@ fi
 export PATH=$HOME/.local/bin:$PATH
 export PYTHONPATH=$HOME/.local/lib/python2.7/site-packages:$PYTHONPATH
 
+echo "Installing latest pip"
 pip install --ignore-installed --user setuptools
+pip install --ignore-installed --user pip
 
 echo "Installing wheel..."
 pip install wheel==0.25.0 --user || exit

--- a/ci/travis/before_install-osx.sh
+++ b/ci/travis/before_install-osx.sh
@@ -38,7 +38,7 @@ export PATH=$HOME/Library/Python/2.7/bin:$PATH
 export PYTHONPATH=$HOME/Library/Python/2.7/lib/python/site-packages:$PYTHONPATH
 
 echo "Installing wheel..."
-pip install wheel --user || exit
+pip install wheel==0.25.0 --user || exit
 echo "Installing Python dependencies"
 pip install --use-wheel --user -r bindings/py/requirements.txt --quiet || exit
 


### PR DESCRIPTION
Fixes #862

Regression tests are failing because different versions of pip are packaging / unpackaging nupic.core binary files. I could not get the regression build to upgrade properly to the latest version of pip, so I'm trying to prevent an upgrade during this build with these changes. I'm not sure if this will work or not.