### PR TITLE
C++ Encoder base, ScalarEncoder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,6 +418,7 @@ set(LIB_STATIC_NUPICCORE_SRCS
     nupic/algorithms/SpatialPooler.cpp
     nupic/algorithms/TemporalMemory.cpp
     nupic/algorithms/Svm.cpp
+    nupic/encoders/Scalar.cpp
     nupic/engine/Collections.cpp
     nupic/engine/Input.cpp
     nupic/engine/Link.cpp
@@ -585,6 +586,7 @@ add_executable(${EXECUTABLE_GTESTS}
                test/unit/algorithms/SegmentTest.cpp
                test/unit/algorithms/SpatialPoolerTest.cpp
                test/unit/algorithms/TemporalMemoryTest.cpp
+               test/unit/encoders/ScalarTest.cpp
                test/unit/engine/InputTest.cpp
                test/unit/engine/NetworkTest.cpp
                test/unit/engine/UniformLinkPolicyTest.cpp

--- a/src/nupic/encoders/Base.hpp
+++ b/src/nupic/encoders/Base.hpp
@@ -32,7 +32,7 @@
 
 namespace nupic
 {
-  /** An encoder converts a value to a sparse distributed representation.
+  /** An encoder converts a value to an array of bits.
    *
    * @b Description
    * This is the base class for encoders.

--- a/src/nupic/encoders/Base.hpp
+++ b/src/nupic/encoders/Base.hpp
@@ -1,0 +1,43 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef NTA_ENCODERS_BASE
+#define NTA_ENCODERS_BASE
+
+#include <nupic/ntypes/ArrayBase.hpp>
+#include <nupic/types/Types.hpp>
+
+namespace nupic
+{
+  class Encoder
+  {
+  public:
+    virtual ~Encoder()
+    {
+    }
+
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) = 0;
+    virtual int getWidth() const = 0;
+  };
+}
+
+#endif // NTA_ENCODERS_BASE

--- a/src/nupic/encoders/Base.hpp
+++ b/src/nupic/encoders/Base.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/encoders/Base.hpp
+++ b/src/nupic/encoders/Base.hpp
@@ -48,9 +48,10 @@ namespace nupic
     virtual ~Encoder()
     {}
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) = 0;
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
+                                 bool learn) = 0;
     virtual int getWidth() const = 0;
   };
-}
+} // end namespace nupic
 
 #endif // NTA_ENCODERS_BASE

--- a/src/nupic/encoders/Base.hpp
+++ b/src/nupic/encoders/Base.hpp
@@ -20,6 +20,10 @@
  * ---------------------------------------------------------------------
  */
 
+/** @file
+ * Defines the abstract Encoder base class
+ */
+
 #ifndef NTA_ENCODERS_BASE
 #define NTA_ENCODERS_BASE
 
@@ -28,12 +32,21 @@
 
 namespace nupic
 {
+  /** An encoder converts a value to a sparse distributed representation.
+   *
+   * @b Description
+   * This is the base class for encoders.
+   *
+   * Methods that must be implemented by subclasses:
+   * - getWidth() - returns the output width, in bits
+   * - encodeIntoArray() - encodes input and puts the encoded value into the
+   *   output, which is an array of length returned by getWidth()
+   */
   class Encoder
   {
   public:
     virtual ~Encoder()
-    {
-    }
+    {}
 
     virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) = 0;
     virtual int getWidth() const = 0;

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -83,7 +83,7 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    const int extentWidth = maxValue - minValue;
+    const double extentWidth = maxValue - minValue;
     if (extentWidth <= 0)
     {
       NTA_THROW << "minValue must be < maxValue. minValue=" << minValue <<
@@ -177,7 +177,7 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    const int extentWidth = maxValue - minValue;
+    const double extentWidth = maxValue - minValue;
     if (extentWidth <= 0)
     {
       NTA_THROW << "minValue must be < maxValue. minValue=" << minValue <<

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -105,7 +105,9 @@ namespace nupic
       const int nBuckets = n - (w - 1);
       const int nBands = nBuckets - 1;
       bucketWidth_ = extentWidth / nBands;
-    } else {
+    }
+    else
+    {
       bucketWidth_ = resolution || radius / w;
       if (bucketWidth_ == 0)
       {
@@ -132,7 +134,9 @@ namespace nupic
       if (clipInput_)
       {
         scalar = minValue_;
-      } else {
+      }
+      else
+      {
         NTA_THROW << "input (" << scalar << ") less than range [" << minValue_ <<
           ", " << maxValue_ << "]";
       }
@@ -140,7 +144,9 @@ namespace nupic
       if (clipInput_)
       {
         scalar = maxValue_;
-      } else {
+      }
+      else
+      {
         NTA_THROW << "input (" << scalar << ") greater than range [" << minValue_ <<
           ", " << maxValue_ << "]";
       }
@@ -191,7 +197,9 @@ namespace nupic
       // The resolution is the width of each band.
       const int nBuckets = n;
       bucketWidth_ = extentWidth / nBuckets;
-    } else {
+    }
+    else
+    {
       bucketWidth_ = resolution || radius / w;
       if (bucketWidth_ == 0)
       {

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -20,6 +20,10 @@
  * ---------------------------------------------------------------------
  */
 
+/** @file
+ * Implementations of the ScalarEncoder and PeriodicScalarEncoder
+ */
+
 #include <math.h>
 #include <nupic/encoders/Scalar.hpp>
 #include <nupic/utils/Log.hpp>

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -103,9 +103,9 @@ namespace nupic
       }
     }
 
-    const int nBuckets = n_ - (w_ - 1);
-    const double progress = (scalar - minval_) / (maxval_ - minval_);
-    const int firstBit = (int)round(progress * (nBuckets - 1));
+    const int iBucket = round((scalar - minval_) / resolution_);
+
+    const int firstBit = iBucket;
 
     memset(output, 0, n_*sizeof(output[0]));
     for (int i = 0; i < w_; i++) {
@@ -163,11 +163,20 @@ namespace nupic
     }
 
     const int iBucket = (int)((scalar - minval_) / resolution_);
-    const int firstBit = (iBucket - (int)((w_-1)/2) + n_) % n_;
+
+    const int middleBit = iBucket;
+    const double reach = (w_ - 1) / 2.0;
+    const int left = floor(reach);
+    const int right = ceil(reach);
 
     memset(output, 0, n_*sizeof(output[0]));
-    for (int i = 0; i < w_; i++) {
-      output[(firstBit + i) % n_] = 1;
+    output[middleBit] = 1;
+    for (int i = 1; i <= left; i++) {
+      const int index = middleBit - i;
+      output[(index < 0) ? index + n_ : index] = 1;
+    }
+    for (int i = 1; i <= right; i++) {
+      output[(middleBit + i) % n_] = 1;
     }
   }
 }

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -24,7 +24,8 @@
  * Implementations of the ScalarEncoder and PeriodicScalarEncoder
  */
 
-#include <math.h>
+#include <cstring> // memset
+#include <cmath>
 #include <nupic/encoders/Scalar.hpp>
 #include <nupic/utils/Log.hpp>
 

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -27,16 +27,37 @@
 namespace nupic
 {
   static Real64 extractScalar(const ArrayBase & input) {
-    Real64 scalar;
     switch (input.getType()) {
+    case NTA_BasicType_Byte:
+      return ((Byte*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_Int16:
+      return ((Int16*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_UInt16:
+      return ((UInt16*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_Int32:
+      return ((Int32*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_UInt32:
+      return ((UInt32*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_Int64:
+      return ((Int64*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_UInt64:
+      return ((UInt64*) input.getBuffer())[0];
+      break;
+    case NTA_BasicType_Real32:
+      return ((Real32*) input.getBuffer())[0];
+      break;
     case NTA_BasicType_Real64:
-      scalar = ((Real64*) input.getBuffer())[0];
+      return ((Real64*) input.getBuffer())[0];
       break;
     default:
-      NTA_THROW << "ScalarEncoder: Unsupported type " << input.getType();
+      NTA_THROW << "extractScalar: Unsupported type " << input.getType();
     }
-
-    return scalar;
   }
 
   ScalarEncoder::ScalarEncoder(int w, double minval, double maxval, int n,

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -31,8 +31,10 @@
 
 namespace nupic
 {
-  static Real64 extractScalar(const ArrayBase & input) {
-    switch (input.getType()) {
+  static Real64 extractScalar(const ArrayBase & input)
+  {
+    switch (input.getType())
+    {
     case NTA_BasicType_Byte:
       return ((Byte*) input.getBuffer())[0];
       break;
@@ -75,35 +77,38 @@ namespace nupic
   {
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
         (radius != 0 && (n != 0 || resolution != 0)) ||
-        (resolution != 0 && (n != 0 || radius != 0))) {
+        (resolution != 0 && (n != 0 || radius != 0)))
+    {
       NTA_THROW <<
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    if (minValue > maxValue) {
+    if (minValue > maxValue)
+    {
       NTA_THROW << "minValue must be <= maxValue. minValue=" << minValue <<
         " maxValue=" << maxValue;
     }
 
     const int extentWidth = maxValue - minValue;
 
-    if (n != 0) {
+    if (n != 0)
+    {
       n_ = n;
-      if (extentWidth != 0) {
+      if (extentWidth != 0)
+      {
         // Distribute nBuckets points along the domain [minValue, maxValue],
         // including the endpoints. The resolution is the width of each band
         // between the points.
         const int nBuckets = n - (w - 1);
         const int nBands = nBuckets - 1;
         bucketsPerUnit_ = nBands / extentWidth;
-      }
-      else {
+      } else {
         bucketsPerUnit_ = 0;
       }
-    }
-    else {
+    } else {
       const double inferredResolution = resolution || radius / w;
-      if (inferredResolution == 0) {
+      if (inferredResolution == 0)
+      {
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
@@ -114,7 +119,8 @@ namespace nupic
       n_ = neededBuckets + (w - 1);
     }
 
-    if (w_ < 1 || w_ > n_) {
+    if (w_ < 1 || w_ > n_)
+    {
       NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
     }
   }
@@ -124,24 +130,24 @@ namespace nupic
   }
 
   void ScalarEncoder::encodeIntoArray(
-      const ArrayBase & input, UInt output[], bool learn)
+    const ArrayBase & input, UInt output[], bool learn)
   {
     Real64 scalar = extractScalar(input);
 
-    if (scalar < minValue_) {
-      if (clipInput_) {
+    if (scalar < minValue_)
+    {
+      if (clipInput_)
+      {
         scalar = minValue_;
-      }
-      else {
+      } else {
         NTA_THROW << "input (" << scalar << ") less than range [" << minValue_ <<
           ", " << maxValue_ << "]";
       }
-    }
-    else if (scalar > maxValue_) {
-      if (clipInput_) {
+    } else if (scalar > maxValue_) {
+      if (clipInput_)
+      {
         scalar = maxValue_;
-      }
-      else {
+      } else {
         NTA_THROW << "input (" << scalar << ") greater than range [" << minValue_ <<
           ", " << maxValue_ << "]";
       }
@@ -152,7 +158,8 @@ namespace nupic
     const int firstBit = iBucket;
 
     memset(output, 0, n_*sizeof(output[0]));
-    for (int i = 0; i < w_; i++) {
+    for (int i = 0; i < w_; i++)
+    {
       output[firstBit + i] = 1;
     }
   }
@@ -165,32 +172,35 @@ namespace nupic
   {
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
         (radius != 0 && (n != 0 || resolution != 0)) ||
-        (resolution != 0 && (n != 0 || radius != 0))) {
+        (resolution != 0 && (n != 0 || radius != 0)))
+    {
       NTA_THROW <<
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    if (minValue > maxValue) {
+    if (minValue > maxValue)
+    {
       NTA_THROW << "minValue must be <= maxValue.";
     }
 
     const int extentWidth = maxValue - minValue;
 
-    if (n != 0) {
+    if (n != 0)
+    {
       n_ = n;
-      if (extentWidth != 0) {
+      if (extentWidth != 0)
+      {
         // Distribute nBuckets equal-width bands within the domain [minValue, maxValue].
         // The resolution is the width of each band.
         const int nBuckets = n;
         bucketsPerUnit_ = nBuckets / extentWidth;
-      }
-      else {
+      } else {
         bucketsPerUnit_ = 0;
       }
-    }
-    else {
+    } else {
       const double inferredResolution = resolution || radius / w;
-      if (inferredResolution == 0) {
+      if (inferredResolution == 0)
+      {
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
@@ -200,7 +210,8 @@ namespace nupic
       n_ = neededBuckets;
     }
 
-    if (w_ < 1 || w_ > n_) {
+    if (w_ < 1 || w_ > n_)
+    {
       NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
     }
   }
@@ -214,7 +225,8 @@ namespace nupic
   {
     Real64 scalar = extractScalar(input);
 
-    if (scalar < minValue_ || scalar >= maxValue_) {
+    if (scalar < minValue_ || scalar >= maxValue_)
+    {
       NTA_THROW << "input " << scalar << " not within range [" << minValue_ <<
         ", " << maxValue_ << ")";
     }
@@ -228,11 +240,13 @@ namespace nupic
 
     memset(output, 0, n_*sizeof(output[0]));
     output[middleBit] = 1;
-    for (int i = 1; i <= left; i++) {
+    for (int i = 1; i <= left; i++)
+    {
       const int index = middleBit - i;
       output[(index < 0) ? index + n_ : index] = 1;
     }
-    for (int i = 1; i <= right; i++) {
+    for (int i = 1; i <= right; i++)
+    {
       output[(middleBit + i) % n_] = 1;
     }
   }

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -80,6 +80,11 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
+    if (minValue > maxValue) {
+      NTA_THROW << "minValue must be <= maxValue. minValue=" << minValue <<
+        " maxValue=" << maxValue;
+    }
+
     const int extentWidth = maxValue - minValue;
 
     if (n != 0) {
@@ -107,6 +112,10 @@ namespace nupic
       const int neededBands = ceil(extentWidth * bucketsPerUnit_);
       const int neededBuckets =  neededBands + 1;
       n_ = neededBuckets + (w - 1);
+    }
+
+    if (w_ < 1 || w_ > n_) {
+      NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
     }
   }
 
@@ -161,6 +170,10 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
+    if (minValue > maxValue) {
+      NTA_THROW << "minValue must be <= maxValue.";
+    }
+
     const int extentWidth = maxValue - minValue;
 
     if (n != 0) {
@@ -185,6 +198,10 @@ namespace nupic
 
       const int neededBuckets = ceil((maxValue - minValue) * bucketsPerUnit_);
       n_ = neededBuckets;
+    }
+
+    if (w_ < 1 || w_ > n_) {
+      NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
     }
   }
 

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *
@@ -66,11 +66,11 @@ namespace nupic
   }
 
   ScalarEncoder::ScalarEncoder(
-    int w, double minval, double maxval, int n, double radius,
+    int w, double minValue, double maxValue, int n, double radius,
     double resolution, bool clipInput)
     :w_(w),
-     minval_(minval),
-     maxval_(maxval),
+     minValue_(minValue),
+     maxValue_(maxValue),
      clipInput_(clipInput)
   {
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
@@ -83,9 +83,9 @@ namespace nupic
     if (n != 0) {
       n_ = n;
       const int nBuckets = n - (w - 1);
-      // Distribute nBuckets points along the domain [minval, maxval], including
+      // Distribute nBuckets points along the domain [minValue, maxValue], including
       // the endpoints. The resolution is the distance between points.
-      resolution_ = (maxval - minval) / (nBuckets - 1);
+      resolution_ = (maxValue - minValue) / (nBuckets - 1);
     }
     else {
       if (resolution != 0) {
@@ -98,7 +98,7 @@ namespace nupic
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
-      const int neededBuckets = ceil((maxval - minval) / resolution_) + 1;
+      const int neededBuckets = ceil((maxValue - minValue) / resolution_) + 1;
       n_ = neededBuckets + (w - 1);
     }
   }
@@ -112,26 +112,26 @@ namespace nupic
   {
     Real64 scalar = extractScalar(input);
 
-    if (scalar < minval_) {
+    if (scalar < minValue_) {
       if (clipInput_) {
-        scalar = minval_;
+        scalar = minValue_;
       }
       else {
-        NTA_THROW << "input (" << scalar << ") less than range [" << minval_ <<
-          ", " << maxval_ << "]";
+        NTA_THROW << "input (" << scalar << ") less than range [" << minValue_ <<
+          ", " << maxValue_ << "]";
       }
     }
-    else if (scalar > maxval_) {
+    else if (scalar > maxValue_) {
       if (clipInput_) {
-        scalar = maxval_;
+        scalar = maxValue_;
       }
       else {
-        NTA_THROW << "input (" << scalar << ") greater than range [" << minval_ <<
-          ", " << maxval_ << "]";
+        NTA_THROW << "input (" << scalar << ") greater than range [" << minValue_ <<
+          ", " << maxValue_ << "]";
       }
     }
 
-    const int iBucket = round((scalar - minval_) / resolution_);
+    const int iBucket = round((scalar - minValue_) / resolution_);
 
     const int firstBit = iBucket;
 
@@ -142,10 +142,10 @@ namespace nupic
   }
 
   PeriodicScalarEncoder::PeriodicScalarEncoder(
-    int w, double minval, double maxval, int n, double radius, double resolution)
+    int w, double minValue, double maxValue, int n, double radius, double resolution)
     :w_(w),
-     minval_(minval),
-     maxval_(maxval)
+     minValue_(minValue),
+     maxValue_(maxValue)
   {
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
         (radius != 0 && (n != 0 || resolution != 0)) ||
@@ -157,9 +157,9 @@ namespace nupic
     if (n != 0) {
       n_ = n;
       const int nBuckets = n;
-      // Distribute nBuckets equal-width bands within the domain [minval, maxval].
+      // Distribute nBuckets equal-width bands within the domain [minValue, maxValue].
       // The resolution is the width of each band.
-      resolution_ = (maxval - minval) / nBuckets;
+      resolution_ = (maxValue - minValue) / nBuckets;
     }
     else {
       if (resolution != 0) {
@@ -172,7 +172,7 @@ namespace nupic
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
-      const int neededBuckets = ceil((maxval - minval) / resolution_);
+      const int neededBuckets = ceil((maxValue - minValue) / resolution_);
       n_ = neededBuckets;
     }
   }
@@ -186,12 +186,12 @@ namespace nupic
   {
     Real64 scalar = extractScalar(input);
 
-    if (scalar < minval_ || scalar >= maxval_) {
-      NTA_THROW << "input " << scalar << " not within range [" << minval_ <<
-        ", " << maxval_ << ")";
+    if (scalar < minValue_ || scalar >= maxValue_) {
+      NTA_THROW << "input " << scalar << " not within range [" << minValue_ <<
+        ", " << maxValue_ << ")";
     }
 
-    const int iBucket = (int)((scalar - minval_) / resolution_);
+    const int iBucket = (int)((scalar - minValue_) / resolution_);
 
     const int middleBit = iBucket;
     const double reach = (w_ - 1) / 2.0;

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -94,29 +94,27 @@ namespace nupic
     {
       n_ = n;
 
+      if (w_ < 1 || w_ >= n_)
+      {
+        NTA_THROW << "w must be within the range [1, n). w=" << w_ << " n=" << n_;
+      }
+
       // Distribute nBuckets points along the domain [minValue, maxValue],
       // including the endpoints. The resolution is the width of each band
       // between the points.
       const int nBuckets = n - (w - 1);
       const int nBands = nBuckets - 1;
-      bucketsPerUnit_ = nBands / extentWidth;
+      bucketWidth_ = extentWidth / nBands;
     } else {
-      const double inferredResolution = resolution || radius / w;
-      if (inferredResolution == 0)
+      bucketWidth_ = resolution || radius / w;
+      if (bucketWidth_ == 0)
       {
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
-      bucketsPerUnit_ = 1 / inferredResolution;
-
-      const int neededBands = ceil(extentWidth * bucketsPerUnit_);
+      const int neededBands = ceil(extentWidth / bucketWidth_);
       const int neededBuckets =  neededBands + 1;
       n_ = neededBuckets + (w - 1);
-    }
-
-    if (w_ < 1 || w_ > n_)
-    {
-      NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
     }
   }
 
@@ -148,7 +146,7 @@ namespace nupic
       }
     }
 
-    const int iBucket = round((scalar - minValue_) * bucketsPerUnit_);
+    const int iBucket = round((scalar - minValue_) / bucketWidth_);
 
     const int firstBit = iBucket;
 
@@ -184,26 +182,24 @@ namespace nupic
     {
       n_ = n;
 
+      if (w_ < 1 || w_ >= n_)
+      {
+        NTA_THROW << "w must be within the range [1, n). w=" << w_ << " n=" << n_;
+      }
+
       // Distribute nBuckets equal-width bands within the domain [minValue, maxValue].
       // The resolution is the width of each band.
       const int nBuckets = n;
-      bucketsPerUnit_ = nBuckets / extentWidth;
+      bucketWidth_ = extentWidth / nBuckets;
     } else {
-      const double inferredResolution = resolution || radius / w;
-      if (inferredResolution == 0)
+      bucketWidth_ = resolution || radius / w;
+      if (bucketWidth_ == 0)
       {
         NTA_THROW << "One of n/radius/resolution must be nonzero.";
       }
 
-      bucketsPerUnit_ = 1 / inferredResolution;
-
-      const int neededBuckets = ceil((maxValue - minValue) * bucketsPerUnit_);
-      n_ = neededBuckets;
-    }
-
-    if (w_ < 1 || w_ > n_)
-    {
-      NTA_THROW << "w must be within the range [1, n]. w=" << w_ << " n=" << n_;
+      const int neededBuckets = ceil((maxValue - minValue) / bucketWidth_);
+      n_ = (neededBuckets > w_) ? neededBuckets : w_ + 1;
     }
   }
 
@@ -222,7 +218,7 @@ namespace nupic
         ", " << maxValue_ << ")";
     }
 
-    const int iBucket = (int)((scalar - minValue_) * bucketsPerUnit_);
+    const int iBucket = (int)((scalar - minValue_) / bucketWidth_);
 
     const int middleBit = iBucket;
     const double reach = (w_ - 1) / 2.0;

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -89,8 +89,8 @@ namespace nupic
         scalar = minval_;
       }
       else {
-        NTA_THROW << "input (" << scalar << ") less than range (" << minval_ <<
-          " - " << maxval_ << ")";
+        NTA_THROW << "input (" << scalar << ") less than range [" << minval_ <<
+          ", " << maxval_ << "]";
       }
     }
     else if (scalar > maxval_) {
@@ -98,8 +98,8 @@ namespace nupic
         scalar = maxval_;
       }
       else {
-        NTA_THROW << "input (" << scalar << ") greater than range (" << minval_ <<
-          " - " << maxval_ << ")";
+        NTA_THROW << "input (" << scalar << ") greater than range [" << minval_ <<
+          ", " << maxval_ << "]";
       }
     }
 
@@ -157,9 +157,9 @@ namespace nupic
   {
     Real64 scalar = extractScalar(input);
 
-    if (scalar < minval_ || scalar > maxval_) {
-      NTA_THROW << "input (" << scalar << ") not within range (" << minval_ <<
-        " - " << maxval_ << ")";
+    if (scalar < minval_ || scalar >= maxval_) {
+      NTA_THROW << "input " << scalar << " not within range [" << minval_ <<
+        ", " << maxval_ << ")";
     }
 
     const int iBucket = (int)((scalar - minval_) / resolution_);

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -83,28 +83,23 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    if (minValue > maxValue)
+    const int extentWidth = maxValue - minValue;
+    if (extentWidth <= 0)
     {
-      NTA_THROW << "minValue must be <= maxValue. minValue=" << minValue <<
+      NTA_THROW << "minValue must be < maxValue. minValue=" << minValue <<
         " maxValue=" << maxValue;
     }
-
-    const int extentWidth = maxValue - minValue;
 
     if (n != 0)
     {
       n_ = n;
-      if (extentWidth != 0)
-      {
-        // Distribute nBuckets points along the domain [minValue, maxValue],
-        // including the endpoints. The resolution is the width of each band
-        // between the points.
-        const int nBuckets = n - (w - 1);
-        const int nBands = nBuckets - 1;
-        bucketsPerUnit_ = nBands / extentWidth;
-      } else {
-        bucketsPerUnit_ = 0;
-      }
+
+      // Distribute nBuckets points along the domain [minValue, maxValue],
+      // including the endpoints. The resolution is the width of each band
+      // between the points.
+      const int nBuckets = n - (w - 1);
+      const int nBands = nBuckets - 1;
+      bucketsPerUnit_ = nBands / extentWidth;
     } else {
       const double inferredResolution = resolution || radius / w;
       if (inferredResolution == 0)
@@ -178,25 +173,21 @@ namespace nupic
         "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
-    if (minValue > maxValue)
-    {
-      NTA_THROW << "minValue must be <= maxValue.";
-    }
-
     const int extentWidth = maxValue - minValue;
+    if (extentWidth <= 0)
+    {
+      NTA_THROW << "minValue must be < maxValue. minValue=" << minValue <<
+        " maxValue=" << maxValue;
+    }
 
     if (n != 0)
     {
       n_ = n;
-      if (extentWidth != 0)
-      {
-        // Distribute nBuckets equal-width bands within the domain [minValue, maxValue].
-        // The resolution is the width of each band.
-        const int nBuckets = n;
-        bucketsPerUnit_ = nBuckets / extentWidth;
-      } else {
-        bucketsPerUnit_ = 0;
-      }
+
+      // Distribute nBuckets equal-width bands within the domain [minValue, maxValue].
+      // The resolution is the width of each band.
+      const int nBuckets = n;
+      bucketsPerUnit_ = nBuckets / extentWidth;
     } else {
       const double inferredResolution = resolution || radius / w;
       if (inferredResolution == 0)

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -64,8 +64,9 @@ namespace nupic
     }
   }
 
-  ScalarEncoder::ScalarEncoder(int w, double minval, double maxval, int n,
-                               double radius, double resolution, bool clipInput)
+  ScalarEncoder::ScalarEncoder(
+    int w, double minval, double maxval, int n, double radius,
+    double resolution, bool clipInput)
     :w_(w),
      minval_(minval),
      maxval_(maxval),
@@ -74,7 +75,8 @@ namespace nupic
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
         (radius != 0 && (n != 0 || resolution != 0)) ||
         (resolution != 0 && (n != 0 || radius != 0))) {
-      NTA_THROW << "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
+      NTA_THROW <<
+        "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
     if (n != 0) {
@@ -104,8 +106,8 @@ namespace nupic
   {
   }
 
-  void ScalarEncoder::encodeIntoArray(const ArrayBase & input, UInt output[],
-                                      bool learn)
+  void ScalarEncoder::encodeIntoArray(
+      const ArrayBase & input, UInt output[], bool learn)
   {
     Real64 scalar = extractScalar(input);
 
@@ -138,8 +140,8 @@ namespace nupic
     }
   }
 
-  PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minval, double maxval,
-                                               int n, double radius, double resolution)
+  PeriodicScalarEncoder::PeriodicScalarEncoder(
+    int w, double minval, double maxval, int n, double radius, double resolution)
     :w_(w),
      minval_(minval),
      maxval_(maxval)
@@ -147,7 +149,8 @@ namespace nupic
     if ((n != 0 && (radius != 0 || resolution != 0)) ||
         (radius != 0 && (n != 0 || resolution != 0)) ||
         (resolution != 0 && (n != 0 || radius != 0))) {
-      NTA_THROW << "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
+      NTA_THROW <<
+        "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
     }
 
     if (n != 0) {
@@ -177,8 +180,8 @@ namespace nupic
   {
   }
 
-  void PeriodicScalarEncoder::encodeIntoArray(const ArrayBase & input, UInt output[],
-                                              bool learn)
+  void PeriodicScalarEncoder::encodeIntoArray(
+    const ArrayBase & input, UInt output[], bool learn)
   {
     Real64 scalar = extractScalar(input);
 
@@ -204,4 +207,4 @@ namespace nupic
       output[(middleBit + i) % n_] = 1;
     }
   }
-}
+} // end namespace nupic

--- a/src/nupic/encoders/Scalar.cpp
+++ b/src/nupic/encoders/Scalar.cpp
@@ -1,0 +1,173 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#include <math.h>
+#include <nupic/encoders/Scalar.hpp>
+#include <nupic/utils/Log.hpp>
+
+namespace nupic
+{
+  static Real64 extractScalar(const ArrayBase & input) {
+    Real64 scalar;
+    switch (input.getType()) {
+    case NTA_BasicType_Real64:
+      scalar = ((Real64*) input.getBuffer())[0];
+      break;
+    default:
+      NTA_THROW << "ScalarEncoder: Unsupported type " << input.getType();
+    }
+
+    return scalar;
+  }
+
+  ScalarEncoder::ScalarEncoder(int w, double minval, double maxval, int n,
+                               double radius, double resolution, bool clipInput)
+    :w_(w),
+     minval_(minval),
+     maxval_(maxval),
+     clipInput_(clipInput)
+  {
+    if ((n != 0 && (radius != 0 || resolution != 0)) ||
+        (radius != 0 && (n != 0 || resolution != 0)) ||
+        (resolution != 0 && (n != 0 || radius != 0))) {
+      NTA_THROW << "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
+    }
+
+    if (n != 0) {
+      n_ = n;
+      const int nBuckets = n - (w - 1);
+      // Distribute nBuckets points along the domain [minval, maxval], including
+      // the endpoints. The resolution is the distance between points.
+      resolution_ = (maxval - minval) / (nBuckets - 1);
+    }
+    else {
+      if (resolution != 0) {
+        resolution_ = resolution;
+      }
+      else if (radius != 0) {
+        resolution_ = radius / w;
+      }
+      else {
+        NTA_THROW << "One of n/radius/resolution must be nonzero.";
+      }
+
+      const int neededBuckets = ceil((maxval - minval) / resolution_) + 1;
+      n_ = neededBuckets + (w - 1);
+    }
+  }
+
+  ScalarEncoder::~ScalarEncoder()
+  {
+  }
+
+  void ScalarEncoder::encodeIntoArray(const ArrayBase & input, UInt output[],
+                                      bool learn)
+  {
+    Real64 scalar = extractScalar(input);
+
+    if (scalar < minval_) {
+      if (clipInput_) {
+        scalar = minval_;
+      }
+      else {
+        NTA_THROW << "input (" << scalar << ") less than range (" << minval_ <<
+          " - " << maxval_ << ")";
+      }
+    }
+    else if (scalar > maxval_) {
+      if (clipInput_) {
+        scalar = maxval_;
+      }
+      else {
+        NTA_THROW << "input (" << scalar << ") greater than range (" << minval_ <<
+          " - " << maxval_ << ")";
+      }
+    }
+
+    const int nBuckets = n_ - (w_ - 1);
+    const double progress = (scalar - minval_) / (maxval_ - minval_);
+    const int firstBit = (int)round(progress * (nBuckets - 1));
+
+    memset(output, 0, n_*sizeof(output[0]));
+    for (int i = 0; i < w_; i++) {
+      output[firstBit + i] = 1;
+    }
+  }
+
+  PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minval, double maxval,
+                                               int n, double radius, double resolution)
+    :w_(w),
+     minval_(minval),
+     maxval_(maxval)
+  {
+    if ((n != 0 && (radius != 0 || resolution != 0)) ||
+        (radius != 0 && (n != 0 || resolution != 0)) ||
+        (resolution != 0 && (n != 0 || radius != 0))) {
+      NTA_THROW << "Only one of n/radius/resolution can be specified for a ScalarEncoder.";
+    }
+
+    if (n != 0) {
+      n_ = n;
+      const int nBuckets = n;
+      // Distribute nBuckets equal-width bands within the domain [minval, maxval].
+      // The resolution is the width of each band.
+      resolution_ = (maxval - minval) / nBuckets;
+    }
+    else {
+      if (resolution != 0) {
+        resolution_ = resolution;
+      }
+      else if (radius != 0) {
+        resolution_ = radius / w;
+      }
+      else {
+        NTA_THROW << "One of n/radius/resolution must be nonzero.";
+      }
+
+      const int neededBuckets = ceil((maxval - minval) / resolution_);
+      n_ = neededBuckets;
+    }
+  }
+
+  PeriodicScalarEncoder::~PeriodicScalarEncoder()
+  {
+  }
+
+  void PeriodicScalarEncoder::encodeIntoArray(const ArrayBase & input, UInt output[],
+                                              bool learn)
+  {
+    Real64 scalar = extractScalar(input);
+
+    if (scalar < minval_ || scalar > maxval_) {
+      NTA_THROW << "input (" << scalar << ") not within range (" << minval_ <<
+        " - " << maxval_ << ")";
+    }
+
+    const int iBucket = (int)((scalar - minval_) / resolution_);
+    const int firstBit = (iBucket - (int)((w_-1)/2) + n_) % n_;
+
+    memset(output, 0, n_*sizeof(output[0]));
+    for (int i = 0; i < w_; i++) {
+      output[(firstBit + i) % n_] = 1;
+    }
+  }
+}

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -134,7 +134,7 @@ namespace nupic
      */
     PeriodicScalarEncoder(int w, double minValue, double maxValue, int n,
                           double radius, double resolution);
-    ~PeriodicScalarEncoder() override;
+    virtual ~PeriodicScalarEncoder() override;
 
     virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
                                  bool learn) override;

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -86,7 +86,7 @@ namespace nupic
     int n_;
     double minValue_;
     double maxValue_;
-    double resolution_;
+    double bucketsPerUnit_; // 1/resolution, guarding for divide-by-zero
     bool clipInput_;
   }; // end class ScalarEncoder
 
@@ -145,7 +145,7 @@ namespace nupic
     int n_;
     double minValue_;
     double maxValue_;
-    double resolution_;
+    double bucketsPerUnit_; // 1/resolution, guarding for divide-by-zero
   }; // end class PeriodicScalarEncoder
 } // end namespace nupic
 

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *
@@ -40,8 +40,8 @@ namespace nupic
    *
    * Conceptually, the set of possible outputs is a set of "buckets". If there
    * are m buckets, the ScalarEncoder distributes m points along the domain
-   * [minval, maxval], including the endpoints. To figure out the bucket index
-   * of an input, it rounds the input to the nearest of these points.
+   * [minValue, maxValue], including the endpoints. To figure out the bucket
+   * index of an input, it rounds the input to the nearest of these points.
    *
    * This approach is different from the PeriodicScalarEncoder because two
    * buckets, the first and last, are half as wide as the rest, since fewer
@@ -57,13 +57,13 @@ namespace nupic
      *
      * @param w The number of bits that are set to encode a single value -- the
      *   "width" of the output signal
-     * @param minval The minimum value of the input signal, inclusive.
-     * @param maxval The maximum value of the input signal, inclusive.
-     * @param clipInput Whether to allow input values outside the [minval, maxval] range.
-     *   If true, the input will be clipped to minval or maxval.
+     * @param minValue The minimum value of the input signal, inclusive.
+     * @param maxValue The maximum value of the input signal, inclusive.
+     * @param clipInput Whether to allow input values outside the [minValue, maxValue]
+     *   range.  If true, the input will be clipped to minValue or maxValue.
      *
-     * There are three mutually exclusive parameters that determine the overall size of
-     * of the output. Only one of these should be nonzero:
+     * There are three mutually exclusive parameters that determine the overall
+     * size of of the output. Only one of these should be nonzero:
      *
      * @param n The number of bits in the output. Must be greater than or equal to w.
      * @param radius Two inputs separated by more than the radius have
@@ -73,7 +73,7 @@ namespace nupic
      * @param resolution Two inputs separated by greater than, or equal to the
      *   resolution are guaranteed to have different representations.
      */
-    ScalarEncoder(int w, double minval, double maxval, int n, double radius,
+    ScalarEncoder(int w, double minValue, double maxValue, int n, double radius,
                   double resolution, bool clipInput);
     ~ScalarEncoder() override;
 
@@ -84,8 +84,8 @@ namespace nupic
   private:
     int w_;
     int n_;
-    double minval_;
-    double maxval_;
+    double minValue_;
+    double maxValue_;
     double resolution_;
     bool clipInput_;
   }; // end class ScalarEncoder
@@ -100,7 +100,7 @@ namespace nupic
    *
    * Conceptually, the set of possible outputs is a set of "buckets". If there
    * are m buckets, the PeriodicScalarEncoder plots m equal-width bands along
-   * the domain [minval, maxval]. The bucket index of an input is simply its
+   * the domain [minValue, maxValue]. The bucket index of an input is simply its
    * band index.
    *
    * Because of the equal-width buckets, the rounding differs from the
@@ -116,8 +116,8 @@ namespace nupic
      *
      * @param w The number of bits that are set to encode a single value -- the
      *   "width" of the output signal
-     * @param minval The minimum value of the input signal, inclusive.
-     * @param maxval The maximum value of the input signal, exclusive. All
+     * @param minValue The minimum value of the input signal, inclusive.
+     * @param maxValue The maximum value of the input signal, exclusive. All
      *   inputs will be strictly less than this value.
      *
      * There are three mutually exclusive parameters that determine the overall
@@ -132,7 +132,7 @@ namespace nupic
      * @param resolution Two inputs separated by greater than, or equal to the
      *   resolution are guaranteed to have different representations.
      */
-    PeriodicScalarEncoder(int w, double minval, double maxval, int n,
+    PeriodicScalarEncoder(int w, double minValue, double maxValue, int n,
                           double radius, double resolution);
     ~PeriodicScalarEncoder() override;
 
@@ -143,8 +143,8 @@ namespace nupic
   private:
     int w_;
     int n_;
-    double minval_;
-    double maxval_;
+    double minValue_;
+    double maxValue_;
     double resolution_;
   }; // end class PeriodicScalarEncoder
 } // end namespace nupic

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -20,6 +20,10 @@
  * ---------------------------------------------------------------------
  */
 
+/** @file
+ * Define the ScalarEncoder and PeriodicScalarEncoder
+ */
+
 #ifndef NTA_ENCODERS_SCALAR
 #define NTA_ENCODERS_SCALAR
 
@@ -27,9 +31,48 @@
 
 namespace nupic
 {
+  /** Encodes a floating point number as a contiguous block of 1s.
+   *
+   * @b Description
+   * A ScalarEncoder encodes a numeric (floating point) value into an array
+   * of bits. The output is 0's except for a contiguous block of 1's. The
+   * location of this contiguous block varies continuously with the input value.
+   *
+   * Conceptually, the set of possible outputs is a set of "buckets". If there
+   * are m buckets, the ScalarEncoder distributes m points along the domain
+   * [minval, maxval], including the endpoints. To figure out the bucket index
+   * of an input, it rounds the input to the nearest of these points.
+   *
+   * This approach is different from the PeriodicScalarEncoder because two
+   * buckets, the first and last, are half as wide as the rest, since fewer
+   * numbers in the input domain will round to these endpoints. This behavior
+   * makes sense because, for example, with the input space [1, 10] and 10
+   * buckets, 1.49 is in the first bucket and 1.51 is in the second.
+   */
   class ScalarEncoder : public Encoder
   {
   public:
+    /**
+     * Constructs a ScalarEncoder
+     *
+     * @param w The number of bits that are set to encode a single value -- the
+     *   "width" of the output signal
+     * @param minval The minimum value of the input signal, inclusive.
+     * @param maxval The maximum value of the input signal, inclusive.
+     * @param clipInput Whether to allow input values outside the [minval, maxval] range.
+     *   If true, the input will be clipped to minval or maxval.
+     *
+     * There are three mutually exclusive parameters that determine the overall size of
+     * of the output. Only one of these should be nonzero:
+     *
+     * @param n The number of bits in the output. Must be greater than or equal to w.
+     * @param radius Two inputs separated by more than the radius have
+     *   non-overlapping representations. Two inputs separated by less than the
+     *   radius will in general overlap in at least some of their bits. You can
+     *   think of this as the radius of the input.
+     * @param resolution Two inputs separated by greater than, or equal to the
+     *   resolution are guaranteed to have different representations.
+     */
     ScalarEncoder(int w, double minval, double maxval, int n, double radius,
                   double resolution, bool clipInput);
     ~ScalarEncoder() override;
@@ -44,11 +87,49 @@ namespace nupic
     double maxval_;
     double resolution_;
     bool clipInput_;
-  };
+  }; // end class ScalarEncoder
 
+  /** Encodes a floating point number as a block of 1s that might wrap around.
+   *
+   * @b Description
+   * A PeriodicScalarEncoder encodes a numeric (floating point) value into an
+   * array of bits. The output is 0's except for a contiguous block of 1's that
+   * may wrap around the edge. The location of this contiguous block varies
+   * continuously with the input value.
+   *
+   * Conceptually, the set of possible outputs is a set of "buckets". If there
+   * are m buckets, the PeriodicScalarEncoder plots m equal-width bands along
+   * the domain [minval, maxval]. The bucket index of an input is simply its
+   * band index.
+   *
+   * Because of the equal-width buckets, the rounding differs from the
+   * ScalarEncoder. In cases where the ScalarEncoder would put 1.49 in the first
+   * bucket and 1.51 in the second, the PeriodicScalarEncoder will put 1.99 in
+   * the first bucket and 2.0 in the second.
+   */
   class PeriodicScalarEncoder : public Encoder
   {
   public:
+    /**
+     * Constructs a PeriodicScalarEncoder
+     *
+     * @param w The number of bits that are set to encode a single value -- the
+     *   "width" of the output signal
+     * @param minval The minimum value of the input signal, inclusive.
+     * @param maxval The maximum value of the input signal, exclusive. All
+     *   inputs will be strictly less than this value.
+     *
+     * There are three mutually exclusive parameters that determine the overall size of
+     * of the output. Only one of these should be nonzero:
+     *
+     * @param n The number of bits in the output. Must be greater than or equal to w.
+     * @param radius Two inputs separated by more than the radius have
+     *   non-overlapping representations. Two inputs separated by less than the
+     *   radius will in general overlap in at least some of their bits. You can
+     *   think of this as the radius of the input.
+     * @param resolution Two inputs separated by greater than, or equal to the
+     *   resolution are guaranteed to have different representations.
+     */
     PeriodicScalarEncoder(int w, double minval, double maxval, int n,
                           double radius, double resolution);
     ~PeriodicScalarEncoder() override;
@@ -62,7 +143,7 @@ namespace nupic
     double minval_;
     double maxval_;
     double resolution_;
-  };
-}
+  }; // end class PeriodicScalarEncoder
+} // end namespace nta
 
 #endif // NTA_ENCODERS_SCALAR

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -77,7 +77,8 @@ namespace nupic
                   double resolution, bool clipInput);
     ~ScalarEncoder() override;
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) override;
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
+                                 bool learn) override;
     virtual int getWidth() const override { return n_; }
 
   private:
@@ -119,10 +120,11 @@ namespace nupic
      * @param maxval The maximum value of the input signal, exclusive. All
      *   inputs will be strictly less than this value.
      *
-     * There are three mutually exclusive parameters that determine the overall size of
-     * of the output. Only one of these should be nonzero:
+     * There are three mutually exclusive parameters that determine the overall
+     * size of the output. Only one of these should be nonzero:
      *
-     * @param n The number of bits in the output. Must be greater than or equal to w.
+     * @param n The number of bits in the output. Must be greater than or equal
+     *   to w.
      * @param radius Two inputs separated by more than the radius have
      *   non-overlapping representations. Two inputs separated by less than the
      *   radius will in general overlap in at least some of their bits. You can
@@ -134,7 +136,8 @@ namespace nupic
                           double radius, double resolution);
     ~PeriodicScalarEncoder() override;
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) override;
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
+                                 bool learn) override;
     virtual int getWidth() const override { return n_; }
 
   private:
@@ -144,6 +147,6 @@ namespace nupic
     double maxval_;
     double resolution_;
   }; // end class PeriodicScalarEncoder
-} // end namespace nta
+} // end namespace nupic
 
 #endif // NTA_ENCODERS_SCALAR

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -86,7 +86,7 @@ namespace nupic
     int n_;
     double minValue_;
     double maxValue_;
-    double bucketsPerUnit_; // 1/resolution, guarding for divide-by-zero
+    double bucketWidth_;
     bool clipInput_;
   }; // end class ScalarEncoder
 
@@ -145,7 +145,7 @@ namespace nupic
     int n_;
     double minValue_;
     double maxValue_;
-    double bucketsPerUnit_; // 1/resolution, guarding for divide-by-zero
+    double bucketWidth_;
   }; // end class PeriodicScalarEncoder
 } // end namespace nupic
 

--- a/src/nupic/encoders/Scalar.hpp
+++ b/src/nupic/encoders/Scalar.hpp
@@ -1,0 +1,68 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#ifndef NTA_ENCODERS_SCALAR
+#define NTA_ENCODERS_SCALAR
+
+#include <nupic/encoders/Base.hpp>
+
+namespace nupic
+{
+  class ScalarEncoder : public Encoder
+  {
+  public:
+    ScalarEncoder(int w, double minval, double maxval, int n, double radius,
+                  double resolution, bool clipInput);
+    ~ScalarEncoder() override;
+
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) override;
+    virtual int getWidth() const override { return n_; }
+
+  private:
+    int w_;
+    int n_;
+    double minval_;
+    double maxval_;
+    double resolution_;
+    bool clipInput_;
+  };
+
+  class PeriodicScalarEncoder : public Encoder
+  {
+  public:
+    PeriodicScalarEncoder(int w, double minval, double maxval, int n,
+                          double radius, double resolution);
+    ~PeriodicScalarEncoder() override;
+
+    virtual void encodeIntoArray(const ArrayBase & input, UInt output[], bool learn) override;
+    virtual int getWidth() const override { return n_; }
+
+  private:
+    int w_;
+    int n_;
+    double minval_;
+    double maxval_;
+    double resolution_;
+  };
+}
+
+#endif // NTA_ENCODERS_SCALAR

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -89,14 +89,14 @@ TEST(ScalarEncoder, ValidScalarInputs)
 {
   const int n = 10;
   const int w = 2;
-  const double minval = 10;
-  const double maxval = 20;
+  const double minValue = 10;
+  const double maxValue = 20;
   const double radius = 0;
   const double resolution = 0;
 
   {
     const bool clipInput = false;
-    ScalarEncoder encoder(w, minval, maxval, n, radius, resolution, clipInput);
+    ScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution, clipInput);
 
     EXPECT_THROW(getEncoding(encoder, 9.9), std::exception);
     EXPECT_NO_THROW(getEncoding(encoder, 10.0));
@@ -106,7 +106,7 @@ TEST(ScalarEncoder, ValidScalarInputs)
 
   {
     const bool clipInput = true;
-    ScalarEncoder encoder(w, minval, maxval, n, radius, resolution, clipInput);
+    ScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution, clipInput);
 
     EXPECT_NO_THROW(getEncoding(encoder, 9.9));
     EXPECT_NO_THROW(getEncoding(encoder, 20.1));
@@ -117,11 +117,11 @@ TEST(PeriodicScalarEncoder, ValidScalarInputs)
 {
   const int n = 10;
   const int w = 2;
-  const double minval = 10;
-  const double maxval = 20;
+  const double minValue = 10;
+  const double maxValue = 20;
   const double radius = 0;
   const double resolution = 0;
-  PeriodicScalarEncoder encoder(w, minval, maxval, n, radius, resolution);
+  PeriodicScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution);
 
   EXPECT_THROW(getEncoding(encoder, 9.9), std::exception);
   EXPECT_NO_THROW(getEncoding(encoder, 10.0));
@@ -133,12 +133,12 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution)
 {
   const int n_in = 0;
   const int w = 3;
-  const double minval = 10;
-  const double maxval = 20;
+  const double minValue = 10;
+  const double maxValue = 20;
   const double radius = 0;
   const double resolution = 1;
   const bool clipInput = false;
-  ScalarEncoder encoder(w, minval, maxval, n_in, radius, resolution, clipInput);
+  ScalarEncoder encoder(w, minValue, maxValue, n_in, radius, resolution, clipInput);
 
   const int n = 13;
   ASSERT_EQ(n, encoder.getWidth());
@@ -164,11 +164,11 @@ TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution)
 {
   const int n_in = 0;
   const int w = 3;
-  const double minval = 10;
-  const double maxval = 20;
+  const double minValue = 10;
+  const double maxValue = 20;
   const double radius = 0;
   const double resolution = 1;
-  PeriodicScalarEncoder encoder(w, minval, maxval, n_in, radius, resolution);
+  PeriodicScalarEncoder encoder(w, minValue, maxValue, n_in, radius, resolution);
 
   const int n = 10;
   ASSERT_EQ(n, encoder.getWidth());

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -1,0 +1,152 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#include <string>
+#include <vector>
+#include <nupic/ntypes/Array.hpp>
+#include <nupic/encoders/Scalar.hpp>
+#include "gtest/gtest.h"
+
+using namespace nupic;
+
+template <typename T>
+std::string vec2str(std::vector<T> vec) {
+  std::ostringstream oss("");
+  for (size_t i = 0; i < vec.size(); i++)
+    oss << vec[i];
+  return oss.str();
+}
+
+std::vector<UInt> getEncoding(Encoder& e, Real64 input) {
+  Array inputArray = Array(NTA_BasicType_Real64);
+  inputArray.allocateBuffer(1);
+  ((Real64*) inputArray.getBuffer())[0] = input;
+
+  auto actualOutput = std::vector<UInt>(e.getWidth());
+  e.encodeIntoArray(inputArray, &actualOutput[0], false);
+  return actualOutput;
+}
+
+typedef struct _SCALAR_VALUE_CASE {
+  Real64 input;
+  std::vector<UInt> expectedOutput;
+} SCALAR_VALUE_CASE;
+
+typedef struct _SCALAR_COMPARE_CASE {
+  Real64 a;
+  Real64 b;
+} SCALAR_COMPARE_CASE;
+
+TEST(PeriodicScalarEncoderTest, BottomUpEncodingPeriodicEncoder)
+{
+  int n = 14;
+  int w = 3;
+  double minval = 1;
+  double maxval = 8;
+  double radius = 0;
+  double resolution = 0;
+  PeriodicScalarEncoder encoder(w, minval, maxval, n, radius, resolution);
+
+  {
+    std::vector<SCALAR_VALUE_CASE> cases =
+      {{3,
+        {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
+       {3.5,
+        {0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0}},
+       {4,
+        {0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0}},
+       {1,
+        {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+       {1.5,
+        {1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+       {7,
+        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1}},
+       {7.5,
+        {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1}}};
+
+    for (auto c = cases.begin(); c != cases.end(); c++) {
+      auto actualOutput = getEncoding(encoder, c->input);
+      for (int i = 0; i < n; i++) {
+        ASSERT_EQ(c->expectedOutput[i], actualOutput[i])
+          << "For input " << c->input << " and index " << i << std::endl
+          << "EXPECTED:" << std::endl
+          << vec2str(c->expectedOutput) << std::endl
+          << "ACTUAL:" << std::endl
+          << vec2str(actualOutput);
+      }
+    }
+  }
+
+  {
+    std::vector<SCALAR_COMPARE_CASE> cases =
+      {{3.1, 3},
+       {3.6, 3.5},
+       {3.7, 3.5}};
+
+    for (auto c = cases.begin(); c != cases.end(); c++) {
+      auto outputA = getEncoding(encoder, c->a);
+      auto outputB = getEncoding(encoder, c->b);
+      for (int i = 0; i < n; i++) {
+        ASSERT_EQ(outputA[i], outputB[i])
+          << "For inputs " << c->a << " and " << c->b << std::endl
+          << "A:" << std::endl
+          << vec2str(outputA) << std::endl
+          << "B:" << std::endl
+          << vec2str(outputB);
+      }
+    }
+  }
+}
+
+TEST(ScalarEncoderTest, NonPeriodicBottomUp)
+{
+  int n = 14;
+  int w = 5;
+  double minval = 1;
+  double maxval = 10;
+  double radius = 0;
+  double resolution = 0;
+  bool clipInput = false;
+  ScalarEncoder encoder(w, minval, maxval, n, radius, resolution, clipInput);
+
+  {
+    std::vector<SCALAR_VALUE_CASE> cases =
+      {{1,
+        {1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+       {2,
+        {0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
+       {10,
+        {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1}},};
+
+    for (auto c = cases.begin(); c != cases.end(); c++) {
+      auto actualOutput = getEncoding(encoder, c->input);
+      for (int i = 0; i < n; i++) {
+        ASSERT_EQ(c->expectedOutput[i], actualOutput[i])
+          << "For input " << c->input << " and index " << i << std::endl
+          << "EXPECTED:" << std::endl
+          << vec2str(c->expectedOutput) << std::endl
+          << "ACTUAL:" << std::endl
+          << vec2str(actualOutput);
+      }
+    }
+  }
+}

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -33,14 +33,16 @@
 using namespace nupic;
 
 template <typename T>
-std::string vec2str(std::vector<T> vec) {
+std::string vec2str(std::vector<T> vec)
+{
   std::ostringstream oss("");
   for (size_t i = 0; i < vec.size(); i++)
     oss << vec[i];
   return oss.str();
 }
 
-std::vector<UInt> getEncoding(Encoder& e, Real64 input) {
+std::vector<UInt> getEncoding(Encoder& e, Real64 input)
+{
   Array inputArray = Array(NTA_BasicType_Real64);
   inputArray.allocateBuffer(1);
   ((Real64*) inputArray.getBuffer())[0] = input;
@@ -50,34 +52,41 @@ std::vector<UInt> getEncoding(Encoder& e, Real64 input) {
   return actualOutput;
 }
 
-typedef struct _SCALAR_VALUE_CASE {
+typedef struct _SCALAR_VALUE_CASE
+{
   Real64 input;
   std::vector<UInt> expectedOutput;
 } SCALAR_VALUE_CASE;
 
-std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ) {
+std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
+{
   auto v = std::vector<UInt>(n, 0);
-  for (auto it = patternNZ.begin(); it != patternNZ.end(); it++) {
-    v[*it] = 1;
-  }
+  for (auto it = patternNZ.begin(); it != patternNZ.end(); it++)
+    {
+      v[*it] = 1;
+    }
   return v;
 }
 
-void doScalarValueCases(Encoder& e, std::vector<SCALAR_VALUE_CASE> cases) {
-  for (auto c = cases.begin(); c != cases.end(); c++) {
-    auto actualOutput = getEncoding(e, c->input);
-    for (int i = 0; i < e.getWidth(); i++) {
-      EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
-        << "For input " << c->input << " and index " << i << std::endl
-        << "EXPECTED:" << std::endl
-        << vec2str(c->expectedOutput) << std::endl
-        << "ACTUAL:" << std::endl
-        << vec2str(actualOutput);
+void doScalarValueCases(Encoder& e, std::vector<SCALAR_VALUE_CASE> cases)
+{
+  for (auto c = cases.begin(); c != cases.end(); c++)
+    {
+      auto actualOutput = getEncoding(e, c->input);
+      for (int i = 0; i < e.getWidth(); i++)
+        {
+          EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
+            << "For input " << c->input << " and index " << i << std::endl
+            << "EXPECTED:" << std::endl
+            << vec2str(c->expectedOutput) << std::endl
+            << "ACTUAL:" << std::endl
+            << vec2str(actualOutput);
+        }
     }
-  }
 }
 
-TEST(ScalarEncoder, ValidScalarInputs) {
+TEST(ScalarEncoder, ValidScalarInputs)
+{
   const int n = 10;
   const int w = 2;
   const double minval = 10;
@@ -104,7 +113,8 @@ TEST(ScalarEncoder, ValidScalarInputs) {
   }
 }
 
-TEST(PeriodicScalarEncoder, ValidScalarInputs) {
+TEST(PeriodicScalarEncoder, ValidScalarInputs)
+{
   const int n = 10;
   const int w = 2;
   const double minval = 10;
@@ -119,7 +129,8 @@ TEST(PeriodicScalarEncoder, ValidScalarInputs) {
   EXPECT_THROW(getEncoding(encoder, 20.0), std::exception);
 }
 
-TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
+TEST(ScalarEncoder, RoundToNearestMultipleOfResolution)
+{
   const int n_in = 0;
   const int w = 3;
   const double minval = 10;
@@ -149,7 +160,8 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
   doScalarValueCases(encoder, cases);
 }
 
-TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution) {
+TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution)
+{
   const int n_in = 0;
   const int w = 3;
   const double minval = 10;

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -20,6 +20,10 @@
  * ---------------------------------------------------------------------
  */
 
+/** @file
+ * Unit tests for the ScalarEncoder and PeriodicScalarEncoder
+ */
+
 #include <string>
 #include <vector>
 #include <nupic/ntypes/Array.hpp>

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -56,6 +56,49 @@ typedef struct _SCALAR_COMPARE_CASE {
   Real64 b;
 } SCALAR_COMPARE_CASE;
 
+TEST(ScalarEncoder, ValidScalarInputs) {
+  const int n = 10;
+  const int w = 2;
+  const double minval = 10;
+  const double maxval = 20;
+  const double radius = 0;
+  const double resolution = 0;
+
+  {
+    const bool clipInput = false;
+    ScalarEncoder encoder(w, minval, maxval, n, radius, resolution, clipInput);
+
+    EXPECT_THROW(getEncoding(encoder, 9.9), std::exception);
+    EXPECT_NO_THROW(getEncoding(encoder, 10.0));
+    EXPECT_NO_THROW(getEncoding(encoder, 20.0));
+    EXPECT_THROW(getEncoding(encoder, 20.1), std::exception);
+  }
+
+  {
+    const bool clipInput = true;
+    ScalarEncoder encoder(w, minval, maxval, n, radius, resolution, clipInput);
+
+    EXPECT_NO_THROW(getEncoding(encoder, 9.9));
+    EXPECT_NO_THROW(getEncoding(encoder, 20.1));
+  }
+}
+
+
+TEST(PeriodicScalarEncoder, ValidScalarInputs) {
+  const int n = 10;
+  const int w = 2;
+  const double minval = 10;
+  const double maxval = 20;
+  const double radius = 0;
+  const double resolution = 0;
+  PeriodicScalarEncoder encoder(w, minval, maxval, n, radius, resolution);
+
+  EXPECT_THROW(getEncoding(encoder, 9.9), std::exception);
+  EXPECT_NO_THROW(getEncoding(encoder, 10.0));
+  EXPECT_NO_THROW(getEncoding(encoder, 19.9));
+  EXPECT_THROW(getEncoding(encoder, 20.0), std::exception);
+}
+
 TEST(PeriodicScalarEncoderTest, BottomUpEncodingPeriodicEncoder)
 {
   int n = 14;

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -52,11 +52,11 @@ std::vector<UInt> getEncoding(Encoder& e, Real64 input)
   return actualOutput;
 }
 
-typedef struct _SCALAR_VALUE_CASE
+struct ScalarValueCase
 {
   Real64 input;
   std::vector<UInt> expectedOutput;
-} SCALAR_VALUE_CASE;
+};
 
 std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
 {
@@ -68,7 +68,7 @@ std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
   return v;
 }
 
-void doScalarValueCases(Encoder& e, std::vector<SCALAR_VALUE_CASE> cases)
+void doScalarValueCases(Encoder& e, std::vector<ScalarValueCase> cases)
 {
   for (auto c = cases.begin(); c != cases.end(); c++)
     {
@@ -140,7 +140,7 @@ TEST(ScalarEncoder, NonIntegerBucketWidth)
   const bool clipInput = false;
   ScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution, clipInput);
 
-  std::vector<SCALAR_VALUE_CASE> cases =
+  std::vector<ScalarValueCase> cases =
     {{10.0, patternFromNZ(n, {0, 1, 2})},
      {20.0, patternFromNZ(n, {4, 5, 6})}};
 
@@ -157,7 +157,7 @@ TEST(PeriodicScalarEncoder, NonIntegerBucketWidth)
   const double resolution = 0;
   PeriodicScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution);
 
-  std::vector<SCALAR_VALUE_CASE> cases =
+  std::vector<ScalarValueCase> cases =
     {{10.0, patternFromNZ(n, {6, 0, 1})},
      {19.9, patternFromNZ(n, {5, 6, 0})}};
 
@@ -178,7 +178,7 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution)
   const int n = 13;
   ASSERT_EQ(n, encoder.getWidth());
 
-  std::vector<SCALAR_VALUE_CASE> cases =
+  std::vector<ScalarValueCase> cases =
     {{10.00, patternFromNZ(n, {0, 1, 2})},
      {10.49, patternFromNZ(n, {0, 1, 2})},
      {10.50, patternFromNZ(n, {1, 2, 3})},
@@ -208,7 +208,7 @@ TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution)
   const int n = 10;
   ASSERT_EQ(n, encoder.getWidth());
 
-  std::vector<SCALAR_VALUE_CASE> cases =
+  std::vector<ScalarValueCase> cases =
     {{10.00, patternFromNZ(n, {9, 0, 1})},
      {10.99, patternFromNZ(n, {9, 0, 1})},
      {11.00, patternFromNZ(n, {0, 1, 2})},

--- a/src/test/unit/encoders/ScalarTest.cpp
+++ b/src/test/unit/encoders/ScalarTest.cpp
@@ -129,6 +129,41 @@ TEST(PeriodicScalarEncoder, ValidScalarInputs)
   EXPECT_THROW(getEncoding(encoder, 20.0), std::exception);
 }
 
+TEST(ScalarEncoder, NonIntegerBucketWidth)
+{
+  const int n = 7;
+  const int w = 3;
+  const double minValue = 10;
+  const double maxValue = 20;
+  const double radius = 0;
+  const double resolution = 0;
+  const bool clipInput = false;
+  ScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution, clipInput);
+
+  std::vector<SCALAR_VALUE_CASE> cases =
+    {{10.0, patternFromNZ(n, {0, 1, 2})},
+     {20.0, patternFromNZ(n, {4, 5, 6})}};
+
+  doScalarValueCases(encoder, cases);
+}
+
+TEST(PeriodicScalarEncoder, NonIntegerBucketWidth)
+{
+  const int n = 7;
+  const int w = 3;
+  const double minValue = 10;
+  const double maxValue = 20;
+  const double radius = 0;
+  const double resolution = 0;
+  PeriodicScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution);
+
+  std::vector<SCALAR_VALUE_CASE> cases =
+    {{10.0, patternFromNZ(n, {6, 0, 1})},
+     {19.9, patternFromNZ(n, {5, 6, 0})}};
+
+  doScalarValueCases(encoder, cases);
+}
+
 TEST(ScalarEncoder, RoundToNearestMultipleOfResolution)
 {
   const int n_in = 0;


### PR DESCRIPTION
Fixes #533 

Also addresses part of #366 

The abstract encoder base is pretty bare. Eventually a few more methods might get added to it. The noteworthy part is the signature of the `encodeIntoArray` method. We pass in arbitrary types to the encoder via an `Array` or `ArrayRef`.

For the ScalarEncoder, I didn't just translate the Python version to C++. I looked at the Python version's behavior and tried to describe it in simple terms. I found that it actually took two simple explanations, one for `periodic=true` and one for `periodic=false`, so I split it into two classes: `ScalarEncoder` and `PeriodicScalarEncoder`. I explain how they work in `Scalar.hpp`.

I ported the Python tests that check the `encode` functionality, then I absorbed them into my own set.