### PR TITLE
New encoder method signature, class hierarchy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,7 +418,7 @@ set(LIB_STATIC_NUPICCORE_SRCS
     nupic/algorithms/SpatialPooler.cpp
     nupic/algorithms/TemporalMemory.cpp
     nupic/algorithms/Svm.cpp
-    nupic/encoders/Scalar.cpp
+    nupic/encoders/ScalarEncoder.cpp
     nupic/engine/Collections.cpp
     nupic/engine/Input.cpp
     nupic/engine/Link.cpp
@@ -586,7 +586,7 @@ add_executable(${EXECUTABLE_GTESTS}
                test/unit/algorithms/SegmentTest.cpp
                test/unit/algorithms/SpatialPoolerTest.cpp
                test/unit/algorithms/TemporalMemoryTest.cpp
-               test/unit/encoders/ScalarTest.cpp
+               test/unit/encoders/ScalarEncoderTest.cpp
                test/unit/engine/InputTest.cpp
                test/unit/engine/NetworkTest.cpp
                test/unit/engine/UniformLinkPolicyTest.cpp

--- a/src/nupic/encoders/EncoderBase.hpp
+++ b/src/nupic/encoders/EncoderBase.hpp
@@ -51,7 +51,7 @@ namespace nupic
      * classifier.
      *
      * @param input The value to encode
-     * @param output Should have length of at least getOutputWidth().
+     * @param output Should have length of at least getOutputWidth()
      */
     virtual int encodeIntoArray(Real64 input, Real32 output[]) = 0;
 

--- a/src/nupic/encoders/EncoderBase.hpp
+++ b/src/nupic/encoders/EncoderBase.hpp
@@ -21,36 +21,44 @@
  */
 
 /** @file
- * Defines the abstract Encoder base class
+ * Defines the abstract Encoder base classes.
+ * An encoder converts a value to an array of bits.
  */
 
 #ifndef NTA_ENCODERS_BASE
 #define NTA_ENCODERS_BASE
 
-#include <nupic/ntypes/ArrayBase.hpp>
 #include <nupic/types/Types.hpp>
 
 namespace nupic
 {
-  /** An encoder converts a value to an array of bits.
-   *
+  /**
    * @b Description
-   * This is the base class for encoders.
-   *
-   * Methods that must be implemented by subclasses:
-   * - getWidth() - returns the output width, in bits
-   * - encodeIntoArray() - encodes input and puts the encoded value into the
-   *   output, which is an array of length returned by getWidth()
+   * Base class for encoders that encode a single floating point number.
    */
-  class Encoder
+  class FloatEncoder
   {
   public:
-    virtual ~Encoder()
-    {}
+    virtual ~FloatEncoder()
+      {}
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
-                                 bool learn) = 0;
-    virtual int getWidth() const = 0;
+    /**
+     * Encodes input, puts the encoded value into output, and returns the a
+     * bucket number for the encoding.
+     *
+     * The bucket number is essentially the input encoded into an integer rather
+     * than an array. A bucket number is easier to "decode" or to use inside a
+     * classifier.
+     *
+     * @param input The value to encode
+     * @param output Should have length of at least getOutputWidth().
+     */
+    virtual int encodeIntoArray(Real64 input, Real32 output[]) = 0;
+
+    /**
+     * Returns the output width, in bits.
+     */
+    virtual int getOutputWidth() const = 0;
   };
 } // end namespace nupic
 

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -27,7 +27,7 @@
 #ifndef NTA_ENCODERS_SCALAR
 #define NTA_ENCODERS_SCALAR
 
-#include <nupic/encoders/Base.hpp>
+#include <nupic/encoders/EncoderBase.hpp>
 
 namespace nupic
 {
@@ -49,7 +49,7 @@ namespace nupic
    * makes sense because, for example, with the input space [1, 10] and 10
    * buckets, 1.49 is in the first bucket and 1.51 is in the second.
    */
-  class ScalarEncoder : public Encoder
+  class ScalarEncoder : public FloatEncoder
   {
   public:
     /**
@@ -77,9 +77,8 @@ namespace nupic
                   double resolution, bool clipInput);
     ~ScalarEncoder() override;
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
-                                 bool learn) override;
-    virtual int getWidth() const override { return n_; }
+    virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
+    virtual int getOutputWidth() const override { return n_; }
 
   private:
     int w_;
@@ -108,7 +107,7 @@ namespace nupic
    * bucket and 1.51 in the second, the PeriodicScalarEncoder will put 1.99 in
    * the first bucket and 2.0 in the second.
    */
-  class PeriodicScalarEncoder : public Encoder
+  class PeriodicScalarEncoder : public FloatEncoder
   {
   public:
     /**
@@ -136,9 +135,8 @@ namespace nupic
                           double radius, double resolution);
     virtual ~PeriodicScalarEncoder() override;
 
-    virtual void encodeIntoArray(const ArrayBase & input, UInt output[],
-                                 bool learn) override;
-    virtual int getWidth() const override { return n_; }
+    virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
+    virtual int getOutputWidth() const override { return n_; }
 
   private:
     int w_;

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -26,8 +26,7 @@
 
 #include <string>
 #include <vector>
-#include <nupic/ntypes/Array.hpp>
-#include <nupic/encoders/Scalar.hpp>
+#include <nupic/encoders/ScalarEncoder.hpp>
 #include "gtest/gtest.h"
 
 using namespace nupic;
@@ -41,26 +40,22 @@ std::string vec2str(std::vector<T> vec)
   return oss.str();
 }
 
-std::vector<UInt> getEncoding(Encoder& e, Real64 input)
+std::vector<Real32> getEncoding(FloatEncoder& e, Real64 input)
 {
-  Array inputArray = Array(NTA_BasicType_Real64);
-  inputArray.allocateBuffer(1);
-  ((Real64*) inputArray.getBuffer())[0] = input;
-
-  auto actualOutput = std::vector<UInt>(e.getWidth());
-  e.encodeIntoArray(inputArray, &actualOutput[0], false);
+  auto actualOutput = std::vector<Real32>(e.getOutputWidth());
+  e.encodeIntoArray(input, &actualOutput[0]);
   return actualOutput;
 }
 
 struct ScalarValueCase
 {
   Real64 input;
-  std::vector<UInt> expectedOutput;
+  std::vector<Real32> expectedOutput;
 };
 
-std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
+std::vector<Real32> patternFromNZ(int n, std::vector<size_t> patternNZ)
 {
-  auto v = std::vector<UInt>(n, 0);
+  auto v = std::vector<Real32>(n, 0);
   for (auto it = patternNZ.begin(); it != patternNZ.end(); it++)
     {
       v[*it] = 1;
@@ -68,12 +63,12 @@ std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
   return v;
 }
 
-void doScalarValueCases(Encoder& e, std::vector<ScalarValueCase> cases)
+void doScalarValueCases(FloatEncoder& e, std::vector<ScalarValueCase> cases)
 {
   for (auto c = cases.begin(); c != cases.end(); c++)
     {
       auto actualOutput = getEncoding(e, c->input);
-      for (int i = 0; i < e.getWidth(); i++)
+      for (int i = 0; i < e.getOutputWidth(); i++)
         {
           EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
             << "For input " << c->input << " and index " << i << std::endl
@@ -176,7 +171,7 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution)
   ScalarEncoder encoder(w, minValue, maxValue, n_in, radius, resolution, clipInput);
 
   const int n = 13;
-  ASSERT_EQ(n, encoder.getWidth());
+  ASSERT_EQ(n, encoder.getOutputWidth());
 
   std::vector<ScalarValueCase> cases =
     {{10.00, patternFromNZ(n, {0, 1, 2})},
@@ -206,7 +201,7 @@ TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution)
   PeriodicScalarEncoder encoder(w, minValue, maxValue, n_in, radius, resolution);
 
   const int n = 10;
-  ASSERT_EQ(n, encoder.getWidth());
+  ASSERT_EQ(n, encoder.getOutputWidth());
 
   std::vector<ScalarValueCase> cases =
     {{10.00, patternFromNZ(n, {9, 0, 1})},


### PR DESCRIPTION
Fixes #870 

This change adjusts to the new upcoming design, where encoders are enclosed in type-aware Regions and hence don't need to use an ArrayBase.

It also begins to introduce the concept of the "bucket" into the interface. encodeIntoArray returns a bucket, and the comment explains what it's for.