### PR TITLE
Add a NTA_BasicType_Bool so that we can parse bools in YAML

### DIFF
--- a/src/nupic/engine/YAMLUtils.cpp
+++ b/src/nupic/engine/YAMLUtils.cpp
@@ -77,6 +77,9 @@ static void _toScalar(const YAML::Node& node, boost::shared_ptr<Scalar>& s)
   case NTA_BasicType_Real64:
     node >> s->value.real64;
     break;
+  case NTA_BasicType_Bool:
+    node >> s->value.boolean;
+    break;
   case NTA_BasicType_Handle:
     NTA_THROW << "Attempt to specify a YAML value for a scalar of type Handle";
     break;
@@ -128,6 +131,9 @@ static void _toArray(const YAML::Node& node, boost::shared_ptr<Array>& a)
       break;
     case NTA_BasicType_Real64:
       item.Read<Real64>(((Real64*)buffer)[i]);
+      break;
+    case NTA_BasicType_Bool:
+      item.Read<bool>(((bool*)buffer)[i]);
       break;
     default:
       // should not happen

--- a/src/nupic/ntypes/Scalar.cpp
+++ b/src/nupic/ntypes/Scalar.cpp
@@ -98,6 +98,11 @@ namespace nupic {
     NTA_CHECK(theType_ == NTA_BasicType_Real64);
     return value.real64;
   }
+  template <> bool Scalar::getValue<bool>() const
+  {
+    NTA_CHECK(theType_ == NTA_BasicType_Bool);
+    return value.boolean;
+  }
 }
 
 

--- a/src/nupic/ntypes/Scalar.hpp
+++ b/src/nupic/ntypes/Scalar.hpp
@@ -57,6 +57,7 @@ namespace nupic
       NTA_UInt64 uint64;
       NTA_Real32 real32;
       NTA_Real64 real64;
+      bool boolean;
     } value;
 
 

--- a/src/nupic/ntypes/Value.cpp
+++ b/src/nupic/ntypes/Value.cpp
@@ -177,6 +177,7 @@ namespace nupic
   template Real32 Value::getScalarT<Real32>() const;
   template Real64 Value::getScalarT<Real64>() const;
   template Handle Value::getScalarT<Handle>() const;
+  template bool Value::getScalarT<bool>() const;
 }
 
 ValueMap::ValueMap() 
@@ -330,5 +331,5 @@ namespace nupic
   template Real32 ValueMap::getScalarT(const std::string& key) const;
   template Real64 ValueMap::getScalarT(const std::string& key) const;
   template Handle ValueMap::getScalarT(const std::string& key) const;
+  template bool ValueMap::getScalarT(const std::string& key) const;
 }
-

--- a/src/nupic/types/BasicType.cpp
+++ b/src/nupic/types/BasicType.cpp
@@ -45,6 +45,7 @@ const char * BasicType::getName(NTA_BasicType t)
       "Real32", 
       "Real64",
       "Handle",
+      "bool",
     };
   
   if (!isValid(t))
@@ -108,6 +109,11 @@ namespace nupic
     return getName(NTA_BasicType_Handle);
   }
 
+  template <> const char* BasicType::getName<bool>()
+  {
+    return getName(NTA_BasicType_Bool);
+  }
+
 
   // getType<T>
   template <> NTA_BasicType BasicType::getType<Byte>()
@@ -159,6 +165,11 @@ namespace nupic
   {
     return NTA_BasicType_Handle;
   }
+
+  template <> NTA_BasicType BasicType::getType<bool>()
+  {
+    return NTA_BasicType_Bool;
+  }
 }      
 
 // Return the size in bits of a basic type
@@ -175,7 +186,8 @@ size_t BasicType::getSize(NTA_BasicType t)
       sizeof(NTA_UInt64), 
       sizeof(NTA_Real32),
       sizeof(NTA_Real64),
-      sizeof(NTA_Handle)
+      sizeof(NTA_Handle),
+      sizeof(bool),
     };
   
   if (!isValid(t))
@@ -193,8 +205,7 @@ NTA_BasicType BasicType::parse(const std::string & s)
     return NTA_BasicType_UInt16;
   else if (s == std::string("Int32") || s == std::string("int"))
     return NTA_BasicType_Int32;
-  else if (s == std::string("UInt32") || s == std::string("bool") || s == std::string("uint"))
-
+  else if (s == std::string("UInt32") || s == std::string("uint"))
     return NTA_BasicType_UInt32;
   else if (s == std::string("Int64"))
     return NTA_BasicType_Int64;
@@ -208,6 +219,8 @@ NTA_BasicType BasicType::parse(const std::string & s)
     return NTA_BasicType_Real;
   else if (s == std::string("Handle"))
     return NTA_BasicType_Handle;
+  else if (s == std::string("bool"))
+    return NTA_BasicType_Bool;
   else
     throw Exception(__FILE__, __LINE__, std::string("Invalid basic type name: ") + s);
 }

--- a/src/nupic/types/Types.h
+++ b/src/nupic/types/Types.h
@@ -98,7 +98,15 @@ typedef enum NTA_BasicType
      * Represents a opaque handle/pointer, same as `void *`
      */
     NTA_BasicType_Handle,
-    
+
+    /**
+     * Represents a boolean. The size is compiler-defined.
+     *
+     * There is no typedef'd "Bool" or "NTA_Bool". We just need a way to refer
+     * to bools with a NTA_BasicType.
+     */
+    NTA_BasicType_Bool,
+
     /** 
      * @note This is not an actual type, just a marker for validation purposes
      */

--- a/src/test/unit/engine/YAMLUtilsTest.cpp
+++ b/src/test/unit/engine/YAMLUtilsTest.cpp
@@ -75,6 +75,19 @@ TEST(YAMLUtilsTest, toValueTestByte)
   EXPECT_STREQ(s1, s.c_str());
 }
 
+TEST(YAMLUtilsTest, toValueTestBool)
+{
+  const char* s1 = "true";
+  Value v = YAMLUtils::toValue(s1, NTA_BasicType_Bool);
+  EXPECT_TRUE(v.isScalar()) << "assertion v.isScalar() failed at "
+                            << __FILE__ << ":" << __LINE__ ;
+  ASSERT_EQ(v.getType(), NTA_BasicType_Bool);
+  bool b = v.getScalarT<bool>();
+  ASSERT_EQ(true, b);
+  boost::shared_ptr<Scalar> s = v.getScalar();
+  b = s->value.boolean;
+  ASSERT_EQ(true, b);
+}
 
 TEST(YAMLUtilsTest, ParameterSpec)
 {
@@ -179,6 +192,16 @@ TEST(YAMLUtilsTest, ParameterSpec)
       "default value", 
       ParameterSpec::ReadWriteAccess));
 
+  ps.add(
+    "boolParam",
+    ParameterSpec(
+      "bool parameter",
+      NTA_BasicType_Bool,
+      1,
+      "",
+      "false",
+      ParameterSpec::ReadWriteAccess));
+
   NTA_DEBUG << "ps count: " << ps.getCount();
 
   ValueMap vm = YAMLUtils::toValueMap("", ps);
@@ -186,6 +209,11 @@ TEST(YAMLUtilsTest, ParameterSpec)
     << "assertion vm.contains(\"int32Param\") failed at "
     << __FILE__ << ":" << __LINE__ ;
   ASSERT_EQ((Int32)32, vm.getScalarT<Int32>("int32Param"));
+
+  EXPECT_TRUE(vm.contains("boolParam"))
+    << "assertion vm.contains(\"boolParam\") failed at "
+    << __FILE__ << ":" << __LINE__ ;
+  ASSERT_EQ(false, vm.getScalarT<bool>("boolParam"));
 
   // disabled until we fix default string params
   // TEST(vm.contains("stringParam"));

--- a/src/test/unit/ntypes/ArrayTest.cpp
+++ b/src/test/unit/ntypes/ArrayTest.cpp
@@ -449,7 +449,9 @@ void ArrayTest::setupArrayTests()
   testCases_["NTA_BasicType_Real32"] =
     ArrayTestParameters(NTA_BasicType_Real32, 4, 10, "Real32", false);
   testCases_["NTA_BasicType_Real64"] =
-    ArrayTestParameters(NTA_BasicType_Real64, 8, 10, "Real64", false);  
+    ArrayTestParameters(NTA_BasicType_Real64, 8, 10, "Real64", false);
+  testCases_["NTA_BasicType_Bool"] =
+    ArrayTestParameters(NTA_BasicType_Bool, sizeof(bool), 10, "bool", false);
 #ifdef NTA_DOUBLE_PRECISION 
   testCases_["NTA_BasicType_Real"] =
     ArrayTestParameters(NTA_BasicType_Real, 8, 10, "Real64", false);
@@ -460,4 +462,3 @@ void ArrayTest::setupArrayTests()
   testCases_["Non-existent NTA_BasicType"] =
     ArrayTestParameters((NTA_BasicType) -1, 0, 10, "N/A", true);
 }
-

--- a/src/test/unit/ntypes/ScalarTest.cpp
+++ b/src/test/unit/ntypes/ScalarTest.cpp
@@ -119,4 +119,14 @@ TEST(ScalarTest, All)
   ASSERT_EQ('a', a.getValue<Byte>());
   a.value.byte++;
   ASSERT_EQ('b', a.getValue<Byte>());
+
+  //Test Bool
+  a = Scalar(NTA_BasicType_Bool);
+  ASSERT_ANY_THROW(a.getValue<UInt64>());
+  ASSERT_EQ(false, a.getValue<bool>());
+  ASSERT_EQ(NTA_BasicType_Bool, a.getType());
+  a.value.boolean = true;
+  ASSERT_EQ(true, a.getValue<bool>());
+  a.value.boolean = false;
+  ASSERT_EQ(false, a.getValue<bool>());
 }

--- a/src/test/unit/types/BasicTypeTest.cpp
+++ b/src/test/unit/types/BasicTypeTest.cpp
@@ -42,6 +42,7 @@ TEST(BasicTypeTest, isValid)
   ASSERT_TRUE(BasicType::isValid(NTA_BasicType_Real64));
   ASSERT_TRUE(BasicType::isValid(NTA_BasicType_Real));
   ASSERT_TRUE(BasicType::isValid(NTA_BasicType_Handle));
+  ASSERT_TRUE(BasicType::isValid(NTA_BasicType_Bool));
 
   
   ASSERT_TRUE(!BasicType::isValid(NTA_BasicType_Last));
@@ -59,7 +60,8 @@ TEST(BasicTypeTest, getSize)
   ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Int64) == 8);
   ASSERT_TRUE(BasicType::getSize(NTA_BasicType_UInt64) == 8);
   ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Real32) == 4);
-  ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Real64) == 8);        
+  ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Real64) == 8);
+  ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Bool) == sizeof(bool));
   #ifdef NTA_DOUBLE_PRECISION
     ASSERT_TRUE(BasicType::getSize(NTA_BasicType_Real) == 8); // Real64
   #else
@@ -85,6 +87,7 @@ TEST(BasicTypeTest, getName)
     ASSERT_TRUE(BasicType::getName(NTA_BasicType_Real) == std::string("Real32"));
   #endif      
   ASSERT_TRUE(BasicType::getName(NTA_BasicType_Handle) == std::string("Handle"));
+  ASSERT_TRUE(BasicType::getName(NTA_BasicType_Bool) == std::string("bool"));
 }
 
 TEST(BasicTypeTest, parse)
@@ -100,5 +103,5 @@ TEST(BasicTypeTest, parse)
   ASSERT_TRUE(BasicType::parse("Real64") == NTA_BasicType_Real64);
   ASSERT_TRUE(BasicType::parse("Real") == NTA_BasicType_Real);
   ASSERT_TRUE(BasicType::parse("Handle") == NTA_BasicType_Handle);
+  ASSERT_TRUE(BasicType::parse("bool") == NTA_BasicType_Bool);
 }
-


### PR DESCRIPTION
Fixes #488 

In an upcoming change, encoder params are now sent to regions as YAML, and we want to be able to use bools in encoder params since they're very user-facing.

In this change I avoided cargo-culting. As mentioned in the comment above the NTA_BasicType_Bool declaration,  I didn't create a typedef's `Bool` or `NTA_Bool`. I don't see a reason for those to exist in this case, but I might be oblivious to something. (Otherwise I don't want to plague the codebase with "Should this be a `Bool` or a `bool`?" ambiguity.)