### PR TITLE
Finish adding support for the Bool type

### DIFF
--- a/bindings/py/nupic/bindings/regions/TestNode.py
+++ b/bindings/py/nupic/bindings/regions/TestNode.py
@@ -112,6 +112,14 @@ class TestNode(PyRegion):
           defaultValue='64.1',
           accessMode='ReadWrite'
         ),
+        boolParam=dict(
+          description='bool parameter',
+          dataType='Bool',
+          count=1,
+          constraints='',
+          defaultValue='false',
+          accessMode='ReadWrite'
+        ),
         real32arrayParam=dict(
           description='Real32 array parameter',
           dataType='Real32',
@@ -123,6 +131,14 @@ class TestNode(PyRegion):
         int64arrayParam=dict(
           description='Int64 array parameter',
           dataType='Int64',
+          count=0, # array
+          constraints='',
+          defaultValue='',
+          accessMode='ReadWrite'
+        ),
+        boolArrayParam=dict(
+          description='bool array parameter',
+          dataType='Bool',
           count=0, # array
           constraints='',
           defaultValue='',
@@ -178,10 +194,12 @@ class TestNode(PyRegion):
       uint64Param=65,
       real32Param=32.1,
       real64Param=64.1,
+      boolParam=False,
       real32ArrayParam=numpy.arange(10).astype('float32'),
       real64ArrayParam=numpy.arange(10).astype('float64'),
       # Construct int64 array in the same way as in C++
       int64ArrayParam=numpy.arange(4).astype('int64'),
+      boolArrayParam=numpy.array([False]*4),
       stringParam="nodespec value")
 
     for key in kwargs:
@@ -322,12 +340,14 @@ class TestNode(PyRegion):
     regionImpl.uint64Param = self.getParameter("uint64Param", 0);
     regionImpl.real32Param = self.getParameter("real32Param", 0);
     regionImpl.real64Param = self.getParameter("real64Param", 0);
+    regionImpl.boolParam = self.getParameter("boolParam", 0);
     regionImpl.stringParam = self.getParameter("stringParam", 0);
     regionImpl.delta = self._delta
     regionImpl.iterations = self._iter
 
     self.writeArray(regionImpl, "int64ArrayParam", "Int64", lambda x: int(x))
     self.writeArray(regionImpl, "real32ArrayParam", "Float32", lambda x: float(x))
+    self.writeArray(regionImpl, "boolArrayParam", "Bool", lambda x: bool(x))
 
 
   def readArray(self, regionImpl, name, dtype):
@@ -350,11 +370,13 @@ class TestNode(PyRegion):
     instance.setParameter("uint64Param", 0, regionImpl.uint64Param)
     instance.setParameter("real32Param", 0, regionImpl.real32Param)
     instance.setParameter("real64Param", 0, regionImpl.real64Param)
+    instance.setParameter("boolParam", 0, regionImpl.boolParam)
     instance.setParameter("stringParam", 0, regionImpl.stringParam)
     instance._delta = regionImpl.delta
     instance._iter = regionImpl.iterations
 
     instance.readArray(regionImpl, "int64ArrayParam", "Int64")
     instance.readArray(regionImpl, "real32ArrayParam", "Float32")
+    instance.readArray(regionImpl, "boolArrayParam", "Bool")
 
     return instance

--- a/src/nupic/bindings/engine_internal.i
+++ b/src/nupic/bindings/engine_internal.i
@@ -165,6 +165,7 @@
 %template(UInt64Array) nupic::PyArray<nupic::UInt64>;
 %template(Real32Array) nupic::PyArray<nupic::Real32>;
 %template(Real64Array) nupic::PyArray<nupic::Real64>;
+%template(BoolArray) nupic::PyArray<bool>;
 
 %template(ByteArrayRef) nupic::PyArrayRef<nupic::Byte>;
 %template(Int16ArrayRef) nupic::PyArrayRef<nupic::Int16>;
@@ -174,7 +175,7 @@
 %template(Int64ArrayRef) nupic::PyArrayRef<nupic::Int64>;
 %template(UInt64ArrayRef) nupic::PyArrayRef<nupic::UInt64>;
 %template(Real32ArrayRef) nupic::PyArrayRef<nupic::Real32>;
-%template(Real64ArrayRef) nupic::PyArrayRef<nupic::Real64>;
+%template(BoolArrayRef) nupic::PyArrayRef<bool>;
 
 %extend nupic::Timer
 {

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -259,6 +259,17 @@ namespace nupic
     getParameterHandle(const std::string& name) const;
 
     /**
+     * Get a bool parameter.
+     *
+     * @param name
+     *        The name of the parameter
+     *
+     * @returns The value of the parameter
+     */
+    bool
+    getParameterBool(const std::string& name) const;
+
+    /**
      * Set the parameter to an Int32 value.
      *
      * @param name
@@ -341,6 +352,18 @@ namespace nupic
      */
     void
     setParameterHandle(const std::string& name, Handle value);
+
+    /**
+     * Set the parameter to a bool value.
+     *
+     * @param name
+     *        The name of the parameter
+     *
+     * @param value
+     *        The value of the parameter
+     */
+    void
+    setParameterBool(const std::string& name, bool value);
 
     /**
      * Get the parameter as an @c Array value.

--- a/src/nupic/engine/RegionImpl.cpp
+++ b/src/nupic/engine/RegionImpl.cpp
@@ -75,13 +75,13 @@ const NodeSet& RegionImpl::getEnabledNodes() const
 // templated methods can't be virtual and thus can't be
 // overridden by subclasses.
 
-#define getParameterT(Type) \
-Type RegionImpl::getParameter##Type(const std::string& name, Int64 index) \
+#define getParameterInternalT(MethodT,Type)                             \
+Type RegionImpl::getParameter##MethodT(const std::string& name, Int64 index) \
 {\
   if (! region_->getSpec()->parameters.contains(name))     \
     NTA_THROW << "getParameter" #Type ": parameter " << name << " does not exist in nodespec"; \
   ParameterSpec p = region_->getSpec()->parameters.getByName(name); \
-  if (p.dataType != NTA_BasicType_ ## Type) \
+  if (p.dataType != NTA_BasicType_ ## MethodT) \
     NTA_THROW << "getParameter" #Type ": parameter " << name << " is of type " \
               << BasicType::getName(p.dataType) << " not " #Type; \
   WriteBuffer wb; \
@@ -97,16 +97,20 @@ Type RegionImpl::getParameter##Type(const std::string& name, Int64 index) \
   return val; \
 }
 
+#define getParameterT(Type) getParameterInternalT(Type,Type)
+
 getParameterT(Int32);
 getParameterT(UInt32);
 getParameterT(Int64);
 getParameterT(UInt64)
 getParameterT(Real32);
 getParameterT(Real64);
+getParameterInternalT(Bool, bool);
 
 
-#define setParameterT(Type) \
-void RegionImpl::setParameter##Type(const std::string& name, Int64 index, Type value) \
+
+#define setParameterInternalT(MethodT, Type) \
+void RegionImpl::setParameter##MethodT(const std::string& name, Int64 index, Type value) \
 { \
   WriteBuffer wb; \
   wb.write((Type)value); \
@@ -114,12 +118,15 @@ void RegionImpl::setParameter##Type(const std::string& name, Int64 index, Type v
   setParameterFromBuffer(name, index, rb); \
 }
 
+#define setParameterT(Type) setParameterInternalT(Type,Type)
+
 setParameterT(Int32);
 setParameterT(UInt32);
 setParameterT(Int64);
 setParameterT(UInt64)
 setParameterT(Real32);
 setParameterT(Real64);
+setParameterInternalT(Bool, bool);
 
 // buffer mechanism can't handle Handles. RegionImpl must override these methods.
 Handle RegionImpl::getParameterHandle(const std::string& name, Int64 index)

--- a/src/nupic/engine/RegionImpl.hpp
+++ b/src/nupic/engine/RegionImpl.hpp
@@ -88,6 +88,7 @@ namespace nupic
     virtual Real32 getParameterReal32(const std::string& name, Int64 index);
     virtual Real64 getParameterReal64(const std::string& name, Int64 index);
     virtual Handle getParameterHandle(const std::string& name, Int64 index);
+    virtual bool getParameterBool(const std::string& name, Int64 index);
 
     virtual void setParameterInt32(const std::string& name, Int64 index, Int32 value);
     virtual void setParameterUInt32(const std::string& name, Int64 index, UInt32 value);
@@ -96,6 +97,7 @@ namespace nupic
     virtual void setParameterReal32(const std::string& name, Int64 index, Real32 value);
     virtual void setParameterReal64(const std::string& name, Int64 index, Real64 value);
     virtual void setParameterHandle(const std::string& name, Int64 index, Handle value);
+    virtual void setParameterBool(const std::string& name, Int64 index, bool value);
 
     virtual void getParameterArray(const std::string& name, Int64 index, Array & array);
     virtual void setParameterArray(const std::string& name, Int64 index, const Array & array);

--- a/src/nupic/engine/RegionParameters.cpp
+++ b/src/nupic/engine/RegionParameters.cpp
@@ -72,6 +72,11 @@ void Region::setParameterHandle(const std::string& name, Handle value)
   impl_->setParameterHandle(name, (Int64)-1, value);
 }
 
+void Region::setParameterBool(const std::string& name, bool value)
+{
+  impl_->setParameterBool(name, (Int64)-1, value);
+}
+
 
 // getParameter
 
@@ -109,6 +114,11 @@ Real64 Region::getParameterReal64(const std::string& name) const
 Handle Region::getParameterHandle(const std::string& name) const
 {
   return impl_->getParameterHandle(name, (Int64)-1);
+}
+
+bool Region::getParameterBool(const std::string& name) const
+{
+  return impl_->getParameterBool(name, (Int64)-1);
 }
 
 

--- a/src/nupic/engine/TestNode.hpp
+++ b/src/nupic/engine/TestNode.hpp
@@ -119,11 +119,13 @@ namespace nupic
     UInt64 uint64Param_;
     Real32 real32Param_;
     Real64 real64Param_;
+    bool boolParam_;
     std::string stringParam_;
     computeCallbackFunc computeCallback_;
 
     std::vector<Real32> real32ArrayParam_;
     std::vector<Int64> int64ArrayParam_;
+    std::vector<bool> boolArrayParam_;
 
     // read-only count of iterations since initialization
     UInt64 iter_;

--- a/src/nupic/ntypes/Buffer.cpp
+++ b/src/nupic/ntypes/Buffer.cpp
@@ -381,6 +381,16 @@ namespace nupic
     return readT(value, size);
   }
 
+  Int32 ReadBuffer::read(bool & value) const
+  {
+    return readT(value);
+  }
+
+  Int32 ReadBuffer::read(bool * value, Size size) const
+  {
+    return readT(value, size);
+  }
+
   inline Int32 findWithLeadingWhitespace(const ReadBuffer &r, char c, int maxSearch) 
   {
     char dummy;
@@ -763,6 +773,16 @@ namespace nupic
   }
 
   Int32 WriteBuffer::write(const Real64 * value, Size size)
+  {
+    return writeT(value, size);
+  }
+
+  Int32 WriteBuffer::write(bool value)
+  {
+    return writeT(value);
+  }
+
+  Int32 WriteBuffer::write(const bool * value, Size size)
   {
     return writeT(value, size);
   }

--- a/src/nupic/ntypes/Buffer.hpp
+++ b/src/nupic/ntypes/Buffer.hpp
@@ -95,6 +95,8 @@ namespace nupic
     Int32 read(Real32 * value, Size size) const override;
     Int32 read(Real64 & value) const override;
     Int32 read(Real64 * value, Size size) const override;
+    Int32 read(bool & value) const override;
+    Int32 read(bool * value, Size size) const override;
     Int32 readString(
         NTA_Byte * &value, 
         NTA_UInt32 &size,
@@ -206,6 +208,8 @@ namespace nupic
     Int32 write(const Real32 * value, Size size) override;
     Int32 write(Real64 value) override;  
     Int32 write(const Real64 * value, Size size) override;
+    Int32 write(bool value) override;
+    Int32 write(const bool * value, Size size) override;
     Int32 writeString(const Byte * value, Size size) override;
     
     Size getSize() override;

--- a/src/nupic/ntypes/ObjectModel.hpp
+++ b/src/nupic/ntypes/ObjectModel.hpp
@@ -153,9 +153,9 @@ namespace nupic
    /**
     * Read 'size' Int32 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
     * @param size    the size of the output buffer. Must be >0.
@@ -175,13 +175,12 @@ namespace nupic
    /**
     * Read 'size' UInt32 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
-    * @param size    the size of the output buffer. Must be >0. Receives
-    *                the actual number of elements read if success or 0
+    * @param size    the size of the output buffer. Must be >0.
     * @retval        0 for success, -1 for failure, 1 for EOF
     */    
     virtual Int32 read(UInt32 * value, Size size) const = 0;
@@ -198,13 +197,12 @@ namespace nupic
    /**
     * Read 'size' Int64 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
-    * @param size    the size of the output buffer. Must be >0. Receives
-    *                the actual number of elements read if success or 0
+    * @param size    the size of the output buffer. Must be >0.
     * @retval        0 for success, -1 for failure, 1 for EOF
     */    
     virtual Int32 read(Int64 * value, Size size) const = 0;
@@ -221,13 +219,12 @@ namespace nupic
    /**
     * Read 'size' UInt64 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
-    * @param size    the size of the output buffer. Must be >0. Receives
-    *                the actual number of elements read if success or 0
+    * @param size    the size of the output buffer. Must be >0.
     * @retval        0 for success, -1 for failure, 1 for EOF
     */    
     virtual Int32 read(UInt64 * value, Size size) const = 0;
@@ -245,13 +242,12 @@ namespace nupic
    /**
     * Read 'size' Real32 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
-    * @param size    the size of the output buffer. Must be >0. Receives
-    *                the actual number of elements read if success or 0
+    * @param size    the size of the output buffer. Must be >0.
     * @retval        0 for success, -1 for failure, 1 for EOF
     */    
     virtual Int32 read(Real32 * value, Size size) const = 0;
@@ -268,17 +264,37 @@ namespace nupic
    /**
     * Read 'size' Real64 elements into the 'value' array and advance 
     * the internal pointer.
-    * If the buffer contains less than 'size' bytes it will read 
-    * as much as possible and write the number of elements actually read
-    * into the 'size' argument.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
     *
     * @param value   the output buffer. Must not be NULL
-    * @param size    the size of the output buffer. Must be >0. Receives
-    *                the actual number of elements read if success or 0
+    * @param size    the size of the output buffer. Must be >0.
     * @retval        0 for success, -1 for failure, 1 for EOF
     */    
     virtual Int32 read(Real64 * value, Size size) const = 0;
-    
+
+    /**
+    * Read a single bool (size is compiler-defined) into 'value' and advance the
+    * internal pointer.
+    *
+    * @param value   the output bool.
+    * @retval        0 for success, -1 for failure, 1 for EOF
+    */
+    virtual Int32 read(bool & value) const = 0;
+
+   /**
+    * Read 'size' bool elements into the 'value' array and advance
+    * the internal pointer.
+    *
+    * If the remaining buffer isn't long enough to contain 'size' elements, read
+    * as much as possible.
+    *
+    * @param value   the output buffer. Must not be NULL
+    * @param size    the size of the output buffer. Must be >0.
+    * @retval        0 for success, -1 for failure, 1 for EOF
+    */
+    virtual Int32 read(bool * value, Size size) const = 0;
   };
 
   //--------------------------------------------------------------------------- 
@@ -484,7 +500,24 @@ namespace nupic
     * @retval        0 for success, -1 for failure
     */    
     virtual Int32 write(const Real64 * value, Size size) = 0;
-        
+
+   /**
+    * Write a bool (size is compiler-defined) into the internal buffer.
+    *
+    * @param value   the input bool.
+    * @retval        0 for success, -1 for failure
+    */
+    virtual Int32 write(bool value) = 0;
+
+   /**
+    * Write array of bool elements into the internal buffer.
+    *
+    * @param value   the input array.
+    * @param size    how many bytes to write
+    * @retval        0 for success, -1 for failure
+    */
+    virtual Int32 write(const bool * value, Size size) = 0;
+
    /**
     * Get the size in bytes of the contents of the internal 
     * buffer.

--- a/src/nupic/ntypes/Value.cpp
+++ b/src/nupic/ntypes/Value.cpp
@@ -320,6 +320,7 @@ namespace nupic
   template Real32 ValueMap::getScalarT(const std::string& key, Real32 defaultValue) const;
   template Real64 ValueMap::getScalarT(const std::string& key, Real64 defaultValue) const;
   template Handle ValueMap::getScalarT(const std::string& key, Handle defaultValue) const;
+  template bool ValueMap::getScalarT(const std::string& key, bool defaultValue) const;
 
   template Byte ValueMap::getScalarT(const std::string& key) const;
   template UInt16 ValueMap::getScalarT(const std::string& key) const;

--- a/src/nupic/proto/TestNodeProto.capnp
+++ b/src/nupic/proto/TestNodeProto.capnp
@@ -1,6 +1,6 @@
 @0xacbfb584b84b791c;
 
-# Next ID: 16
+# Next ID: 18
 struct TestNodeProto {
   int32Param @0 :Int32;
   uint32Param @1 :UInt32;
@@ -8,10 +8,12 @@ struct TestNodeProto {
   uint64Param @3 :UInt64;
   real32Param @4 :Float32;
   real64Param @5 :Float64;
+  boolParam @16 :Bool;
   stringParam @6 :Text;
 
   real32ArrayParam @7 :List(Float32);
   int64ArrayParam @8 :List(Int64);
+  boolArrayParam @17 :List(Bool);
 
   iterations @9 :UInt32;
   outputElementCount @10 :UInt32;

--- a/src/nupic/py_support/PyArray.cpp
+++ b/src/nupic/py_support/PyArray.cpp
@@ -53,6 +53,7 @@ namespace nupic
   NTA_BasicType getBasicType(NTA_UInt64) { return NTA_BasicType_UInt64; }
   NTA_BasicType getBasicType(NTA_Real32) { return NTA_BasicType_Real32; }
   NTA_BasicType getBasicType(NTA_Real64) { return NTA_BasicType_Real64; }
+  NTA_BasicType getBasicType(bool) { return NTA_BasicType_Bool; }
 
   // -------------------------------------
   //
@@ -103,7 +104,10 @@ namespace nupic
       break;      
     case NTA_BasicType_Real64: 
       dtype = NPY_FLOAT64;
-      break;      
+      break;
+    case NTA_BasicType_Bool:
+      dtype = NPY_BOOL;
+      break;
     default:
       NTA_THROW << "Unknown basic type: " << t;
     };
@@ -335,6 +339,7 @@ namespace nupic
   template class PyArray<NTA_UInt64>;
   template class PyArray<NTA_Real32>;
   template class PyArray<NTA_Real64>;
+  template class PyArray<bool>;
   
   template class PyArrayRef<NTA_Byte>;
   template class PyArrayRef<NTA_Int16>;
@@ -345,5 +350,6 @@ namespace nupic
   template class PyArrayRef<NTA_UInt64>;
   template class PyArrayRef<NTA_Real32>;
   template class PyArrayRef<NTA_Real64>;  
+  template class PyArrayRef<bool>;
 }
 

--- a/src/nupic/py_support/PyArray.hpp
+++ b/src/nupic/py_support/PyArray.hpp
@@ -58,6 +58,7 @@ NTA_BasicType getBasicType(NTA_Int64);
 NTA_BasicType getBasicType(NTA_UInt64);
 NTA_BasicType getBasicType(NTA_Real32);
 NTA_BasicType getBasicType(NTA_Real64);
+NTA_BasicType getBasicType(bool);
 
 // -------------------------------------
 //

--- a/src/nupic/py_support/PyHelpers.cpp
+++ b/src/nupic/py_support/PyHelpers.cpp
@@ -379,6 +379,37 @@ namespace nupic { namespace py
     return PyFloat_GetMin();
   }
 
+  // ---
+  // Implementation of Bool class
+  // ---
+
+  Bool::Bool(bool b) : Ptr(b ? Py_True : Py_False)
+  {
+  }
+
+  Bool::Bool(PyObject * p) : Ptr(p)
+  {
+    NTA_CHECK(PyBool_Check(p_));
+  }
+
+  Bool::operator bool()
+  {
+    NTA_CHECK(p_);
+
+    if (p_ == Py_True)
+    {
+      return true;
+    }
+    else if (p_ == Py_False)
+    {
+      return false;
+    }
+    else
+    {
+      NTA_THROW << "Invalid ptr";
+    }
+  }
+
   // --- 
   // Implementation of Tuple class
   // ---

--- a/src/nupic/py_support/PyHelpers.hpp
+++ b/src/nupic/py_support/PyHelpers.hpp
@@ -70,6 +70,9 @@
 //   to a Python float. It provides a constructor and conversion operator.
 //   Python has just one floating point type (not including numpy and 
 //   the complex type).
+//
+// Bool:
+//   A boolean class that maps a C bool to a Python bool.
 // 
 // String: 
 //   A string type that maps to the Python string and provides
@@ -217,6 +220,15 @@ namespace nupic { namespace py
     operator double();
     static double getMax();
     static double getMin();
+  };
+
+  // Bool
+  class Bool : public Ptr
+  {
+  public:
+    Bool(bool b);
+    Bool(PyObject * p);
+    operator bool();
   };
 
   // Tuple

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -734,6 +734,11 @@ Handle PyRegion::getParameterHandle(const std::string& name, Int64 index)
   return getParameterT<Handle, py::Ptr>(name, index);  
 }
 
+bool PyRegion::getParameterBool(const std::string& name, Int64 index)
+{
+  return getParameterT<bool, py::Bool>(name, index);
+}
+
 void PyRegion::setParameterByte(const std::string& name, Int64 index, Byte value)
 {
   setParameterT<Byte, py::Int>(name, index, value);   
@@ -772,6 +777,11 @@ void PyRegion::setParameterReal64(const std::string& name, Int64 index, Real64 v
 void PyRegion::setParameterHandle(const std::string& name, Int64 index, Handle value)
 {
   setParameterT<PyObject *, py::Ptr>(name, index, (PyObject *)value);   
+}
+
+void PyRegion::setParameterBool(const std::string& name, Int64 index, bool value)
+{
+  setParameterT<bool, py::Bool>(name, index, value);
 }
 
 void PyRegion::getParameterArray(const std::string& name, Int64 index, Array & a)

--- a/src/nupic/regions/PyRegion.hpp
+++ b/src/nupic/regions/PyRegion.hpp
@@ -114,6 +114,8 @@ namespace nupic
         override;
     virtual Handle getParameterHandle(const std::string& name, Int64 index)
         override;
+    virtual bool getParameterBool(const std::string& name, Int64 index)
+        override;
     virtual std::string getParameterString(
         const std::string& name, Int64 index) override;
 
@@ -133,6 +135,8 @@ namespace nupic
         const std::string& name, Int64 index, Real64 value) override;
     virtual void setParameterHandle(
         const std::string& name, Int64 index, Handle value) override;
+    virtual void setParameterBool(
+        const std::string& name, Int64 index, bool value) override;
     virtual void setParameterString(
         const std::string& name, Int64 index, const std::string& value)
         override;

--- a/src/nupic/types/BasicType.cpp
+++ b/src/nupic/types/BasicType.cpp
@@ -45,7 +45,7 @@ const char * BasicType::getName(NTA_BasicType t)
       "Real32", 
       "Real64",
       "Handle",
-      "bool",
+      "Bool",
     };
   
   if (!isValid(t))
@@ -219,7 +219,7 @@ NTA_BasicType BasicType::parse(const std::string & s)
     return NTA_BasicType_Real;
   else if (s == std::string("Handle"))
     return NTA_BasicType_Handle;
-  else if (s == std::string("bool"))
+  else if (s == std::string("Bool"))
     return NTA_BasicType_Bool;
   else
     throw Exception(__FILE__, __LINE__, std::string("Invalid basic type name: ") + s);

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -340,6 +340,7 @@ void testWriteRead()
   UInt64 uint64Param = 45;
   Real32 real32Param = 46;
   Real64 real64Param = 46;
+  bool boolParam = true;
   std::string stringParam = "hello";
 
   std::vector<Int64> int64ArrayParamBuff(4);
@@ -360,6 +361,15 @@ void testWriteRead()
                          &real32ArrayParamBuff[0],
                          real32ArrayParamBuff.size());
 
+  bool boolArrayParamBuff[4];
+  for (int i = 0; i < 4; i++)
+  {
+    boolArrayParamBuff[i] = (i % 2) == 1;
+  }
+  Array boolArrayParam(NTA_BasicType_Bool,
+                       boolArrayParamBuff,
+                       4);
+
   Network n1;
   Region* region1 = n1.addRegion("rw1", "py.TestNode", "");
   region1->setParameterInt32("int32Param", int32Param);
@@ -368,9 +378,11 @@ void testWriteRead()
   region1->setParameterUInt64("uint64Param", uint64Param);
   region1->setParameterReal32("real32Param", real32Param);
   region1->setParameterReal64("real64Param", real64Param);
+  region1->setParameterBool("boolParam", boolParam);
   region1->setParameterString("stringParam", stringParam.c_str());
   region1->setParameterArray("int64ArrayParam", int64ArrayParam);
   region1->setParameterArray("real32ArrayParam", real32ArrayParam);
+  region1->setParameterArray("boolArrayParam", boolArrayParam);
 
   Network n2;
 
@@ -388,6 +400,7 @@ void testWriteRead()
   NTA_CHECK(region2->getParameterUInt64("uint64Param") == uint64Param);
   NTA_CHECK(region2->getParameterReal32("real32Param") == real32Param);
   NTA_CHECK(region2->getParameterReal64("real64Param") == real64Param);
+  NTA_CHECK(region2->getParameterBool("boolParam") == boolParam);
   NTA_CHECK(region2->getParameterString("stringParam") == stringParam.c_str());
 
   Array int64Array(NTA_BasicType_Int64);
@@ -406,6 +419,15 @@ void testWriteRead()
   for (int i = 0; i < int(real32ArrayParam.getCount()); i++)
   {
     NTA_CHECK(real32ArrayBuff[i] == real32ArrayParamBuff[i]);
+  }
+
+  Array boolArray(NTA_BasicType_Bool);
+  region2->getParameterArray("boolArrayParam", boolArray);
+  bool * boolArrayBuff = (bool *)boolArray.getBuffer();
+  NTA_CHECK(boolArrayParam.getCount() == boolArray.getCount());
+  for (int i = 0; i < int(boolArrayParam.getCount()); i++)
+  {
+    NTA_CHECK(boolArrayBuff[i] == boolArrayParamBuff[i]);
   }
 }
 

--- a/src/test/unit/ntypes/ArrayTest.cpp
+++ b/src/test/unit/ntypes/ArrayTest.cpp
@@ -451,7 +451,7 @@ void ArrayTest::setupArrayTests()
   testCases_["NTA_BasicType_Real64"] =
     ArrayTestParameters(NTA_BasicType_Real64, 8, 10, "Real64", false);
   testCases_["NTA_BasicType_Bool"] =
-    ArrayTestParameters(NTA_BasicType_Bool, sizeof(bool), 10, "bool", false);
+    ArrayTestParameters(NTA_BasicType_Bool, sizeof(bool), 10, "Bool", false);
 #ifdef NTA_DOUBLE_PRECISION 
   testCases_["NTA_BasicType_Real"] =
     ArrayTestParameters(NTA_BasicType_Real, 8, 10, "Real64", false);

--- a/src/test/unit/types/BasicTypeTest.cpp
+++ b/src/test/unit/types/BasicTypeTest.cpp
@@ -87,7 +87,7 @@ TEST(BasicTypeTest, getName)
     ASSERT_TRUE(BasicType::getName(NTA_BasicType_Real) == std::string("Real32"));
   #endif      
   ASSERT_TRUE(BasicType::getName(NTA_BasicType_Handle) == std::string("Handle"));
-  ASSERT_TRUE(BasicType::getName(NTA_BasicType_Bool) == std::string("bool"));
+  ASSERT_TRUE(BasicType::getName(NTA_BasicType_Bool) == std::string("Bool"));
 }
 
 TEST(BasicTypeTest, parse)
@@ -103,5 +103,5 @@ TEST(BasicTypeTest, parse)
   ASSERT_TRUE(BasicType::parse("Real64") == NTA_BasicType_Real64);
   ASSERT_TRUE(BasicType::parse("Real") == NTA_BasicType_Real);
   ASSERT_TRUE(BasicType::parse("Handle") == NTA_BasicType_Handle);
-  ASSERT_TRUE(BasicType::parse("bool") == NTA_BasicType_Bool);
+  ASSERT_TRUE(BasicType::parse("Bool") == NTA_BasicType_Bool);
 }


### PR DESCRIPTION
Fixes #883 

Also switch to using "Bool" when referring to it as a string. Python code uses this string to assemble a method name, e.g. "setParameter" + "Bool".