### PR TITLE
Cast arg to UInt32 to avoid call resolution ambiguity on the value.write() method on Win32 platform.

### DIFF
--- a/src/nupic/encoders/ScalarSensor.cpp
+++ b/src/nupic/encoders/ScalarSensor.cpp
@@ -232,7 +232,8 @@ namespace nupic
     }
     else if (name == "n")
     {
-      value.write(encoder_->getOutputWidth());
+      // Cast to UInt32 to avoid call resolution ambiguity on the write() method
+      value.write((UInt32)encoder_->getOutputWidth());
     }
     else
     {


### PR DESCRIPTION
CC @mrcslws @scottpurdy 

Indeed, this did the trick on my Win32 build on AWS instance.

The error on the win32 build looked like this:

```
C:\projects\nupic-core\src\nupic\encoders\ScalarSensor.cpp: In member function 'virtual void nupic::ScalarSensor::getParameterFromBuffer(const string&, nupic::Int64, nupic::IWriteBuffer&)':
C:\projects\nupic-core\src\nupic\encoders\ScalarSensor.cpp:235:45: error: call of overloaded 'write(int)' is ambiguous
       value.write(encoder_->getOutputWidth());
                                             ^
C:\projects\nupic-core\src\nupic\encoders\ScalarSensor.cpp:235:45: note: candidates are:
In file included from C:/projects/nupic-core/src/nupic/engine/RegionImpl.hpp:43:0,
                 from C:/projects/nupic-core/src/nupic/encoders/ScalarSensor.hpp:39,
                 from C:\projects\nupic-core\src\nupic\encoders\ScalarSensor.cpp:34:
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:364:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::Byte)
     virtual Int32 write(Byte value) = 0;
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:397:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::Int32)
     virtual Int32 write(Int32 value) = 0; 
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:416:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::UInt32)
     virtual Int32 write(UInt32 value) = 0; 
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:435:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::Int64)
     virtual Int32 write(Int64 value) = 0;
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:454:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::UInt64)
     virtual Int32 write(UInt64 value) = 0; 
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:473:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::Real32)
     virtual Int32 write(Real32 value) = 0;  
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:492:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(nupic::Real64)
     virtual Int32 write(Real64 value) = 0;  
                   ^
C:/projects/nupic-core/src/nupic/ntypes/ObjectModel.hpp:510:19: note: virtual nupic::Int32 nupic::IWriteBuffer::write(bool)
     virtual Int32 write(bool value) = 0;
                   ^
mingw32-make[2]: *** [src/CMakeFiles/nupic_core_solo.dir/nupic/encoders/ScalarSensor.cpp.obj] Error 1
mingw32-make[1]: *** [src/CMakeFiles/nupic_core_solo.dir/all] Error 2
mingw32-make: *** [all] Error 2

```