### PR TITLE
Fix issues with destroySegment / destroySynapse

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -65,7 +65,7 @@ Segment Connections::createSegment(const Cell& cell)
   }
 
   CellData& cellData = cells_[cell.idx];
-  SegmentIdx segmentIdx;
+  SegmentIdx segmentIdx = (SegmentIdx)-1;
   if (cellData.numDestroyedSegments > 0)
   {
     bool found = false;
@@ -107,7 +107,7 @@ Synapse Connections::createSynapse(const Segment& segment,
   }
 
   SegmentData& segmentData = dataForSegment(segment);
-  SynapseIdx synapseIdx;
+  SynapseIdx synapseIdx = (SynapseIdx)-1;
   if (segmentData.numDestroyedSynapses > 0)
   {
     bool found = false;

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -146,10 +146,7 @@ void Connections::destroySegment(const Segment& segment)
 {
   SegmentData& segmentData = dataForSegment(segment);
 
-  if (segmentData.destroyed)
-  {
-    NTA_THROW << "Segment already destroyed.";
-  }
+  NTA_CHECK(!segmentData.destroyed);
 
   for (SynapseIdx i = 0; i < segmentData.synapses.size(); i++)
   {
@@ -184,10 +181,7 @@ void Connections::destroySynapse(const Synapse& synapse)
 {
   SynapseData& synapseData = dataForSynapse(synapse);
 
-  if (synapseData.destroyed)
-  {
-    NTA_THROW << "Synapse already destroyed.";
-  }
+  NTA_CHECK(!synapseData.destroyed);
 
   vector<Synapse>& presynapticSynapses =
     synapsesForPresynapticCell_.at(synapseData.presynapticCell);

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -324,7 +324,7 @@ namespace nupic
          *
          * @retval Segment data.
          */
-        SegmentData& dataForSegment(const Segment& segment);
+        SegmentData dataForSegment(const Segment& segment) const;
 
         /**
          * Gets the data for a synapse.
@@ -333,7 +333,7 @@ namespace nupic
          *
          * @retval Synapse data.
          */
-        SynapseData& dataForSynapse(const Synapse& synapse);
+        SynapseData dataForSynapse(const Synapse& synapse) const;
 
         /**
          * Returns the synapses for the source cell that they synapse on.
@@ -359,25 +359,6 @@ namespace nupic
                                        std::vector<Cell> input,
                                        SynapseIdx synapseThreshold,
                                        Segment& retSegment) const;
-
-        /**
-         * Gets the segment that was least recently used from among all the
-         * segments on the given cell.
-         *
-         * @param cell       Cell whose segments to consider.
-         *
-         * @retval The least recently used segment.
-         */
-        Segment leastRecentlyUsedSegment(const Cell& cell) const;
-
-         /**
-          * Gets the synapse with the lowest permanence on the segment.
-          *
-          * @param segment       Segment whose synapses to consider.
-          *
-          * @retval Synapse with the lowest permanence.
-          */
-        Synapse minPermanenceSynapse(const Segment& segment) const;
 
         /**
          * Forward-propagates input to synapses, dendrites, and cells, to
@@ -478,6 +459,45 @@ namespace nupic
          * Comparison operator.
          */
         bool operator==(const Connections &other) const;
+
+      protected:
+
+        /**
+         * Gets the segment that was least recently used from among all the
+         * segments on the given cell.
+         *
+         * @param cell Cell whose segments to consider.
+         *
+         * @retval The least recently used segment.
+         */
+        Segment leastRecentlyUsedSegment_(const Cell& cell) const;
+
+         /**
+          * Gets the synapse with the lowest permanence on the segment.
+          *
+          * @param segment Segment whose synapses to consider.
+          *
+          * @retval Synapse with the lowest permanence.
+          */
+        Synapse minPermanenceSynapse_(const Segment& segment) const;
+
+        /**
+         * Gets a reference to the data for a segment.
+         *
+         * @param segment Segment to get data for.
+         *
+         * @retval Editable segment data.
+         */
+        SegmentData& dataForSegment_(const Segment& segment);
+
+        /**
+         * Gets a reference to the data for a synapse.
+         *
+         * @param synapse Synapse to get data for.
+         *
+         * @retval Editable synapse data.
+         */
+        SynapseData& dataForSynapse_(const Synapse& synapse);
 
       private:
         std::vector<CellData> cells_;

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -160,6 +160,7 @@ namespace nupic
       struct SegmentData
       {
         std::vector<SynapseData> synapses;
+        UInt32 numDestroyedSynapses;
         bool destroyed;
         Iteration lastUsedIteration;
       };
@@ -177,6 +178,7 @@ namespace nupic
       struct CellData
       {
         std::vector<SegmentData> segments;
+        UInt32 numDestroyedSegments;
       };
 
       /**
@@ -322,7 +324,7 @@ namespace nupic
          *
          * @retval Segment data.
          */
-        SegmentData dataForSegment(const Segment& segment) const;
+        SegmentData& dataForSegment(const Segment& segment);
 
         /**
          * Gets the data for a synapse.
@@ -331,7 +333,7 @@ namespace nupic
          *
          * @retval Synapse data.
          */
-        SynapseData dataForSynapse(const Synapse& synapse) const;
+        SynapseData& dataForSynapse(const Synapse& synapse);
 
         /**
          * Returns the synapses for the source cell that they synapse on.
@@ -363,23 +365,19 @@ namespace nupic
          * segments on the given cell.
          *
          * @param cell       Cell whose segments to consider.
-         * @param retSegment Segment to return.
          *
-         * @retval False if cell has no segments.
+         * @retval The least recently used segment.
          */
-        bool leastRecentlyUsedSegment(const Cell& cell,
-                                      Segment& retSegment) const;
+        Segment leastRecentlyUsedSegment(const Cell& cell) const;
 
          /**
           * Gets the synapse with the lowest permanence on the segment.
           *
           * @param segment       Segment whose synapses to consider.
-          * @param retSynapse    Synapse with the lowest permanence.
           *
-          * @retval False if segment has no synapses.
+          * @retval Synapse with the lowest permanence.
           */
-         bool minPermanenceSynapse(const Segment& segment,
-                                   Synapse& retSynapse) const;
+        Synapse minPermanenceSynapse(const Segment& segment) const;
 
         /**
          * Forward-propagates input to synapses, dendrites, and cells, to
@@ -456,11 +454,25 @@ namespace nupic
         UInt numSegments() const;
 
         /**
+         * Gets the number of segments on a cell.
+         *
+         * @retval Number of segments.
+         */
+        UInt numSegments(const Cell& cell) const;
+
+        /**
          * Gets the number of synapses.
          *
          * @retval Number of synapses.
          */
         UInt numSynapses() const;
+
+        /**
+         * Gets the number of synapses on a segment.
+         *
+         * @retval Number of synapses.
+         */
+        UInt numSynapses(const Segment& segment) const;
 
         /**
          * Comparison operator.

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -227,16 +227,17 @@ namespace {
     // Add an additional synapse over the limit
     presynapticCell.idx = 52;
     synapse = connections.createSynapse(segment, presynapticCell, 0.52);
+    EXPECT_LT(synapse.idx, 2);
 
     // Verify that the lowest permanence synapse was removed
     synapses = connections.synapsesForSegment(segment);
     ASSERT_EQ(synapses.size(), 2);
     synapseData = connections.dataForSynapse(synapses[0]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 51);
-    ASSERT_NEAR(synapseData.permanence, (Permanence)0.48, EPSILON);
+    ASSERT_EQ(52, synapseData.presynapticCell.idx);
+    ASSERT_NEAR((Permanence)0.52, synapseData.permanence, EPSILON);
     synapseData = connections.dataForSynapse(synapses[1]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 52);
-    ASSERT_NEAR(synapseData.permanence, (Permanence)0.52, EPSILON);
+    ASSERT_EQ(51, synapseData.presynapticCell.idx);
+    ASSERT_NEAR((Permanence)0.48, synapseData.permanence, EPSILON);
   }
 
   /**
@@ -297,6 +298,162 @@ namespace {
 
     segment.cell.idx = 20; segment.idx = 0;
     ASSERT_EQ(activity.numActiveSynapsesForSegment[segment], 1);
+  }
+
+  /**
+   * Creates segments and synapses, then destroys segments and synapses on
+   * either side of them and verifies that existing Segment and Synapse
+   * instances still point to the same segment / synapse as before.
+   */
+  TEST(ConnectionsTest, PathsNotInvalidatedByOtherDestroys)
+  {
+    Connections connections(1024);
+
+    Segment segment1 = connections.createSegment(Cell(11));
+    /*      segment2*/ connections.createSegment(Cell(12));
+
+    Segment segment3 = connections.createSegment(Cell(13));
+    Synapse synapse1 = connections.createSynapse(segment3, Cell(201), 0.85);
+    /*      synapse2*/ connections.createSynapse(segment3, Cell(202), 0.85);
+    Synapse synapse3 = connections.createSynapse(segment3, Cell(203), 0.85);
+    /*      synapse4*/ connections.createSynapse(segment3, Cell(204), 0.85);
+    Synapse synapse5 = connections.createSynapse(segment3, Cell(205), 0.85);
+
+    /*      synapse5*/ connections.createSegment(Cell(14));
+    Segment segment5 = connections.createSegment(Cell(15));
+
+    ASSERT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    connections.destroySynapse(synapse1);
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    connections.destroySynapse(synapse5);
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+
+    connections.destroySegment(segment1);
+    EXPECT_EQ(3, connections.synapsesForSegment(segment3).size());
+    connections.destroySegment(segment5);
+    EXPECT_EQ(3, connections.synapsesForSegment(segment3).size());
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+  }
+
+  /**
+   * Destroy a segment that has a destroyed synapse and a non-destroyed synapse.
+   * Make sure nothing gets double-destroyed.
+   */
+  TEST(ConnectionsTest, DestroySegmentWithDestroyedSynapses)
+  {
+    Connections connections(1024);
+
+    Segment segment1 = connections.createSegment(Cell(11));
+    Segment segment2 = connections.createSegment(Cell(12));
+
+    /*      synapse1_1*/ connections.createSynapse(segment1, Cell(101), 0.85);
+    Synapse synapse2_1 = connections.createSynapse(segment2, Cell(201), 0.85);
+    /*      synapse2_2*/ connections.createSynapse(segment2, Cell(202), 0.85);
+
+    ASSERT_EQ(3, connections.numSynapses());
+
+    connections.destroySynapse(synapse2_1);
+
+    ASSERT_EQ(2, connections.numSegments());
+    ASSERT_EQ(2, connections.numSynapses());
+
+    connections.destroySegment(segment2);
+
+    EXPECT_EQ(1, connections.numSegments());
+    EXPECT_EQ(1, connections.numSynapses());
+  }
+
+  /**
+   * Destroy some segments then verify that the maxSegmentsPerCell is still
+   * correctly applied.
+   */
+  TEST(ConnectionsTest, DestroySegmentsThenReachLimit)
+  {
+    Connections connections(1024, 2, 2);
+
+    {
+      Segment segment1 = connections.createSegment(Cell(11));
+      Segment segment2 = connections.createSegment(Cell(11));
+      ASSERT_EQ(2, connections.numSegments());
+      connections.destroySegment(segment1);
+      connections.destroySegment(segment2);
+      ASSERT_EQ(0, connections.numSegments());
+    }
+
+    {
+      connections.createSegment(Cell(11));
+      EXPECT_EQ(1, connections.numSegments());
+      connections.createSegment(Cell(11));
+      EXPECT_EQ(2, connections.numSegments());
+      connections.createSegment(Cell(11));
+      EXPECT_EQ(2, connections.numSegments());
+    }
+  }
+
+  /**
+   * Destroy some synapses then verify that the maxSynapsesPerSegment is still
+   * correctly applied.
+   */
+  TEST(ConnectionsTest, DestroySynapsesThenReachLimit)
+  {
+    Connections connections(1024, 2, 2);
+
+    Segment segment = connections.createSegment(Cell(10));
+
+    {
+      Synapse synapse1 = connections.createSynapse(segment, Cell(201), 0.85);
+      Synapse synapse2 = connections.createSynapse(segment, Cell(202), 0.85);
+      ASSERT_EQ(2, connections.numSynapses());
+      connections.destroySynapse(synapse1);
+      connections.destroySynapse(synapse2);
+      ASSERT_EQ(0, connections.numSynapses());
+    }
+
+    {
+      connections.createSynapse(segment, Cell(201), 0.85);
+      EXPECT_EQ(1, connections.numSynapses());
+      connections.createSynapse(segment, Cell(202), 0.90);
+      EXPECT_EQ(2, connections.numSynapses());
+      connections.createSynapse(segment, Cell(203), 0.80);
+      EXPECT_EQ(2, connections.numSynapses());
+    }
+  }
+
+  /**
+   * Hit the maxSegmentsPerCell threshold multiple times. Make sure it works
+   * more than once.
+   */
+  TEST(ConnectionsTest, ReachSegmentLimitMultipleTimes)
+  {
+    Connections connections(1024, 2, 2);
+
+    connections.createSegment(Cell(10));
+    ASSERT_EQ(1, connections.numSegments());
+    connections.createSegment(Cell(10));
+    ASSERT_EQ(2, connections.numSegments());
+    connections.createSegment(Cell(10));
+    ASSERT_EQ(2, connections.numSegments());
+    connections.createSegment(Cell(10));
+    EXPECT_EQ(2, connections.numSegments());
+  }
+
+  /**
+   * Hit the maxSynapsesPerSegment threshold multiple times. Make sure it works
+   * more than once.
+   */
+  TEST(ConnectionsTest, ReachSynapseLimitMultipleTimes)
+  {
+    Connections connections(1024, 2, 2);
+
+    Segment segment = connections.createSegment(Cell(10));
+    connections.createSynapse(segment, Cell(201), 0.85);
+    ASSERT_EQ(1, connections.numSynapses());
+    connections.createSynapse(segment, Cell(202), 0.90);
+    ASSERT_EQ(2, connections.numSynapses());
+    connections.createSynapse(segment, Cell(203), 0.80);
+    ASSERT_EQ(2, connections.numSynapses());
+    connections.createSynapse(segment, Cell(204), 0.80);
+    EXPECT_EQ(2, connections.numSynapses());
   }
 
   /**
@@ -401,34 +558,30 @@ namespace {
   {
     Connections connections(1024);
     Cell cell;
-    Segment segment;
 
     setupSampleConnections(connections);
 
     cell.idx = 5;
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell, segment), false);
+    ASSERT_THROW(connections.leastRecentlyUsedSegment(cell), std::exception);
 
     cell.idx = 20;
 
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell, segment), true);
-    ASSERT_EQ(segment.idx, 0);
+    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
 
     computeSampleActivity(connections);
 
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell, segment), true);
-    ASSERT_EQ(segment.idx, 1);
+    Segment segment = connections.leastRecentlyUsedSegment(cell);
+    ASSERT_EQ(segment, Segment(1, cell));
 
     connections.destroySegment(segment);
 
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell, segment), true);
-    ASSERT_EQ(segment.idx, 0);
+    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
 
     computeSampleActivity(connections);
 
-    segment = connections.createSegment(cell);
+    connections.createSegment(cell);
 
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell, segment), true);
-    ASSERT_EQ(segment.idx, 0);
+    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
   }
 
   /**

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -319,7 +319,7 @@ namespace {
     /*      synapse4*/ connections.createSynapse(segment3, Cell(204), 0.85);
     Synapse synapse5 = connections.createSynapse(segment3, Cell(205), 0.85);
 
-    /*      synapse5*/ connections.createSegment(Cell(14));
+    /*      segment4*/ connections.createSegment(Cell(14));
     Segment segment5 = connections.createSegment(Cell(15));
 
     ASSERT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
@@ -385,7 +385,8 @@ namespace {
       EXPECT_EQ(1, connections.numSegments());
       connections.createSegment(Cell(11));
       EXPECT_EQ(2, connections.numSegments());
-      connections.createSegment(Cell(11));
+      Segment segment = connections.createSegment(Cell(11));
+      EXPECT_LT(segment.idx, 2);
       EXPECT_EQ(2, connections.numSegments());
     }
   }
@@ -414,7 +415,8 @@ namespace {
       EXPECT_EQ(1, connections.numSynapses());
       connections.createSynapse(segment, Cell(202), 0.90);
       EXPECT_EQ(2, connections.numSynapses());
-      connections.createSynapse(segment, Cell(203), 0.80);
+      Synapse synapse = connections.createSynapse(segment, Cell(203), 0.80);
+      EXPECT_LT(synapse.idx, 2);
       EXPECT_EQ(2, connections.numSynapses());
     }
   }
@@ -452,7 +454,8 @@ namespace {
     ASSERT_EQ(2, connections.numSynapses());
     connections.createSynapse(segment, Cell(203), 0.80);
     ASSERT_EQ(2, connections.numSynapses());
-    connections.createSynapse(segment, Cell(204), 0.80);
+    Synapse synapse = connections.createSynapse(segment, Cell(204), 0.80);
+    EXPECT_LT(synapse.idx, 2);
     EXPECT_EQ(2, connections.numSynapses());
   }
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -227,7 +227,7 @@ namespace {
     // Add an additional synapse over the limit
     presynapticCell.idx = 52;
     synapse = connections.createSynapse(segment, presynapticCell, 0.52);
-    EXPECT_LT(synapse.idx, 2);
+    EXPECT_EQ(0, synapse.idx);
 
     // Verify that the lowest permanence synapse was removed
     synapses = connections.synapsesForSegment(segment);

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -549,45 +549,6 @@ namespace {
   }
 
   /**
-   * Creates a sample set of connections, computes some activity for it,
-   * and checks that we can get the correct least recently used segment
-   * for a number of cells.
-   *
-   * Then, destroys the least recently used segment, computes more activity,
-   * creates another segment, and checks that the least recently used segment
-   * is not the newly created one.
-   */
-  TEST(ConnectionsTest, testLeastRecentlyUsedSegment)
-  {
-    Connections connections(1024);
-    Cell cell;
-
-    setupSampleConnections(connections);
-
-    cell.idx = 5;
-    ASSERT_THROW(connections.leastRecentlyUsedSegment(cell), std::exception);
-
-    cell.idx = 20;
-
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
-
-    computeSampleActivity(connections);
-
-    Segment segment = connections.leastRecentlyUsedSegment(cell);
-    ASSERT_EQ(segment, Segment(1, cell));
-
-    connections.destroySegment(segment);
-
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
-
-    computeSampleActivity(connections);
-
-    connections.createSegment(cell);
-
-    ASSERT_EQ(connections.leastRecentlyUsedSegment(cell), Segment(0, cell));
-  }
-
-  /**
    * Creates a sample set of connections, and makes sure that computing the
    * activity for a collection of cells with no activity returns the right
    * activity data.


### PR DESCRIPTION
Fixes #899 

Add tests for a set of potential bugs.

After my changes to the tests, in the current implementation these tests fail:
[  FAILED  ] ConnectionsTest.testSynapseReuse
[  FAILED  ] ConnectionsTest.DestroySegmentsThenReachLimit
[  FAILED  ] ConnectionsTest.DestroySynapsesThenReachLimit
[  FAILED  ] ConnectionsTest.ReachSynapseLimitMultipleTimes

Fix the bugs. These tests pass now.

I also did performance tweaks in functions that I touched. It's now 11% faster.

Here's the output for

~~~
python $NUPIC/scripts/temporal_memory_performance_benchmark.py
~~~

Reference:
TP10X2: 1.647582s

Before:
TM (C++): 2.782499s

After:
TM (C++): 2.50993s