### PR TITLE
Stop storing segment overlap counts in a map. Now 56% faster.

### DIFF
--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -155,6 +155,7 @@ namespace nupic
        * @param synapses          Data for synapses that this segment contains.
        * @param destroyed         Whether this segment has been destroyed.
        * @param lastUsedIteration The iteration that this segment was last used at.
+       * @param flatIdx           This segment's index in flattened lists of all segments
        *
        */
       struct SegmentData
@@ -163,6 +164,7 @@ namespace nupic
         UInt32 numDestroyedSynapses;
         bool destroyed;
         Iteration lastUsedIteration;
+        UInt32 flatIdx;
       };
 
       /**
@@ -193,7 +195,7 @@ namespace nupic
       struct Activity
       {
         std::map< Cell, std::vector<Segment> > activeSegmentsForCell;
-        std::map<Segment, SynapseIdx> numActiveSynapsesForSegment;
+        std::vector<UInt32> numActiveSynapsesForSegment;
       };
 
       /**
@@ -334,6 +336,15 @@ namespace nupic
          * @retval Synapse data.
          */
         SynapseData dataForSynapse(const Synapse& synapse) const;
+
+        /**
+         * Do a reverse-lookup of a segment from its flatIdx.
+         *
+         * @param flatIdx the flatIdx of the segment
+         *
+         * @retval Segment
+         */
+        Segment segmentForFlatIdx(UInt32 flatIdx) const;
 
         /**
          * Returns the synapses for the source cell that they synapse on.
@@ -505,6 +516,8 @@ namespace nupic
         std::map< Cell, std::vector<Synapse> > synapsesForPresynapticCell_;
         UInt numSegments_;
         UInt numSynapses_;
+        std::vector<Segment> segmentForFlatIdx_;
+        UInt nextFlatIdx_;
         SegmentIdx maxSegmentsPerCell_;
         SynapseIdx maxSynapsesPerSegment_;
         Iteration iteration_;

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -187,7 +187,7 @@ namespace nupic
     {
       sdr = randomSDR(numInputs, w);
       activity = connections.computeActivity(sdr, 0.5, 0);
-      winnerCells = computeSPWinnerCells(numWinners, activity);
+      winnerCells = computeSPWinnerCells(connections, numWinners, activity);
 
       for (Cell winnerCell : winnerCells)
       {
@@ -226,7 +226,7 @@ namespace nupic
     {
       sdr = randomSDR(numInputs, w);
       activity = connections.computeActivity(sdr, 0.5, 0);
-      winnerCells = computeSPWinnerCells(numWinners, activity);
+      winnerCells = computeSPWinnerCells(connections, numWinners, activity);
     }
 
     checkpoint(timer, label + ": initialize + learn + test");
@@ -271,24 +271,17 @@ namespace nupic
   }
 
   vector<Cell> ConnectionsPerformanceTest::computeSPWinnerCells(
-    UInt numCells, Activity& activity)
+    Connections& connections, UInt numCells, Activity& activity)
   {
-    vector< pair<Segment, SynapseIdx> > numActiveSynapsesList;
+    vector<UInt32> numActiveSynapsesList = activity.numActiveSynapsesForSegment;
     vector<Cell>winnerCells;
 
-    numActiveSynapsesList.assign(activity.numActiveSynapsesForSegment.begin(),
-                                 activity.numActiveSynapsesForSegment.end());
-
-    sort(numActiveSynapsesList.begin(), numActiveSynapsesList.end(),
-         [](const pair<Segment, SynapseIdx>& left,
-            const pair<Segment, SynapseIdx>& right)
-         {
-           return left.second > right.second;
-         });
+    std::sort(numActiveSynapsesList.begin(), numActiveSynapsesList.end(),
+              std::greater<int>());
 
     for (UInt j = 0; j < min(numCells, (UInt)numActiveSynapsesList.size()); j++)
     {
-      winnerCells.push_back(numActiveSynapsesList[j].first.cell);
+      winnerCells.push_back(connections.segmentForFlatIdx(j).cell);
     }
 
     return winnerCells;

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -82,7 +82,9 @@ namespace nupic
                 std::vector<algorithms::connections::Cell> sdr,
                 bool learn = true);
     std::vector<algorithms::connections::Cell> computeSPWinnerCells(
-      UInt numCells, algorithms::connections::Activity& activity);
+      Connections& connections,
+      UInt numCells,
+      algorithms::connections::Activity& activity);
 
   }; // end class ConnectionsPerformanceTest
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -264,7 +264,16 @@ namespace {
     Activity activity = computeSampleActivity(connections);
 
     ASSERT_EQ(activity.activeSegmentsForCell.size(), 0);
-    ASSERT_EQ(activity.numActiveSynapsesForSegment.size(), 2);
+
+    UInt32 numSegmentsWithActivesynapses = 0;
+    for (UInt32 numActiveSynapses : activity.numActiveSynapsesForSegment)
+    {
+      if (numActiveSynapses > 0)
+      {
+        numSegmentsWithActivesynapses++;
+      }
+    }
+    ASSERT_EQ(2, numSegmentsWithActivesynapses);
   }
 
   /**
@@ -296,8 +305,9 @@ namespace {
 
     ASSERT_EQ(activity.activeSegmentsForCell.size(), 0);
 
-    segment.cell.idx = 20; segment.idx = 0;
-    ASSERT_EQ(activity.numActiveSynapsesForSegment[segment], 1);
+    ASSERT_EQ(1, activity.numActiveSynapsesForSegment[
+                connections.dataForSegment(Segment(0, Cell(20))).flatIdx
+                ]);
   }
 
   /**
@@ -570,12 +580,18 @@ namespace {
     ASSERT_EQ(segment.cell.idx, 20);
 
     ASSERT_EQ(activity.numActiveSynapsesForSegment.size(), 3);
-    segment.cell.idx = 10; segment.idx = 0;
-    ASSERT_EQ(activity.numActiveSynapsesForSegment[segment], 1);
-    segment.cell.idx = 20; segment.idx = 0;
-    ASSERT_EQ(activity.numActiveSynapsesForSegment[segment], 2);
-    segment.cell.idx = 20; segment.idx = 1;
-    ASSERT_EQ(activity.numActiveSynapsesForSegment[segment], 1);
+    ASSERT_EQ(1,
+              activity.numActiveSynapsesForSegment[
+                connections.dataForSegment(Segment(0, Cell(10))).flatIdx
+                ]);
+    ASSERT_EQ(2,
+              activity.numActiveSynapsesForSegment[
+                connections.dataForSegment(Segment(0, Cell(20))).flatIdx
+                ]);
+    ASSERT_EQ(1,
+              activity.numActiveSynapsesForSegment[
+                connections.dataForSegment(Segment(1, Cell(20))).flatIdx
+                ]);
   }
 
   /**


### PR DESCRIPTION
Fixes #906 

Here's the output for:

~~~
python $NUPIC/scripts/temporal_memory_performance_benchmark.py
~~~

Reference:
TP10X2: 1.65675s

Before:
TM (C++): 2.607865s

After:
TM (C++): 1.670907s