### PR TITLE
Stop computing overlaps twice per timestep. 4% faster.

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -372,12 +372,18 @@ Synapse Connections::minPermanenceSynapse_(const Segment& segment) const
 }
 
 Activity Connections::computeActivity(const vector<Cell>& input,
-                                      Permanence permanenceThreshold,
-                                      SynapseIdx synapseThreshold,
+                                      Permanence activePermanenceThreshold,
+                                      SynapseIdx activeSynapseThreshold,
+                                      Permanence matchingPermanenceThreshold,
+                                      SynapseIdx matchingSynapseThreshold,
                                       bool recordIteration)
 {
   Activity activity = {map< Cell, std::vector<Segment> >(),
+                       vector<UInt32>(nextFlatIdx_, 0),
+                       map< Cell, std::vector<Segment> >(),
                        vector<UInt32>(nextFlatIdx_, 0)};
+
+  NTA_CHECK(matchingPermanenceThreshold <= activePermanenceThreshold);
 
   for (const Cell& cell : input)
   {
@@ -387,20 +393,33 @@ Activity Connections::computeActivity(const vector<Cell>& input,
     {
       const SynapseData& synapseData = dataForSynapse_(synapse);
 
-      if (synapseData.permanence >= permanenceThreshold &&
-          synapseData.permanence > 0)
+      NTA_ASSERT(synapseData.permanence > 0);
+
+      if (synapseData.permanence >= matchingPermanenceThreshold)
       {
         const SegmentData& segmentData = dataForSegment_(synapse.segment);
-        const auto numActiveSynapses =
-          ++activity.numActiveSynapsesForSegment[segmentData.flatIdx];
 
-        if (numActiveSynapses == synapseThreshold)
+        const auto numMatchingSynapses =
+          ++activity.numMatchingSynapsesForSegment[segmentData.flatIdx];
+        if (numMatchingSynapses == matchingSynapseThreshold)
         {
-          activity.activeSegmentsForCell[synapse.segment.cell].push_back(synapse.segment);
+          activity.matchingSegmentsForCell[synapse.segment.cell]
+            .push_back(synapse.segment);
+        }
 
-          if (recordIteration)
+        if (synapseData.permanence >= activePermanenceThreshold)
+        {
+          const auto numActiveSynapses =
+            ++activity.numActiveSynapsesForSegment[segmentData.flatIdx];
+          if (numActiveSynapses == activeSynapseThreshold)
           {
-            dataForSegment_(synapse.segment).lastUsedIteration++;
+            activity.activeSegmentsForCell[synapse.segment.cell]
+              .push_back(synapse.segment);
+
+            if (recordIteration)
+            {
+              dataForSegment_(synapse.segment).lastUsedIteration++;
+            }
           }
         }
       }
@@ -418,6 +437,7 @@ Activity Connections::computeActivity(const vector<Cell>& input,
 vector<Segment> Connections::activeSegments(const Activity& activity)
 {
   vector<Segment> segments;
+  segments.reserve(activity.activeSegmentsForCell.size()); // lower bound
 
   for (auto i : activity.activeSegmentsForCell)
   {
@@ -430,8 +450,35 @@ vector<Segment> Connections::activeSegments(const Activity& activity)
 vector<Cell> Connections::activeCells(const Activity& activity)
 {
   vector<Cell> cells;
+  cells.reserve(activity.activeSegmentsForCell.size());
 
   for (auto i : activity.activeSegmentsForCell)
+  {
+    cells.push_back(i.first);
+  }
+
+  return cells;
+}
+
+vector<Segment> Connections::matchingSegments(const Activity& activity)
+{
+  vector<Segment> segments;
+  segments.reserve(activity.matchingSegmentsForCell.size()); // lower bound
+
+  for (auto i : activity.matchingSegmentsForCell)
+  {
+    segments.insert(segments.end(), i.second.begin(), i.second.end());
+  }
+
+  return segments;
+}
+
+vector<Cell> Connections::matchingCells(const Activity& activity)
+{
+  vector<Cell> cells;
+  cells.reserve(activity.matchingSegmentsForCell.size());
+
+  for (auto i : activity.matchingSegmentsForCell)
   {
     cells.push_back(i.first);
   }

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -103,6 +103,7 @@ Synapse Connections::createSynapse(const Segment& segment,
                                    Permanence permanence)
 {
   NTA_CHECK(maxSynapsesPerSegment_ > 0);
+  NTA_CHECK(permanence > 0);
   while (numSynapses(segment) >= maxSynapsesPerSegment_)
   {
     destroySynapse(minPermanenceSynapse_(segment));

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -196,6 +196,8 @@ namespace nupic
       {
         std::map< Cell, std::vector<Segment> > activeSegmentsForCell;
         std::vector<UInt32> numActiveSynapsesForSegment;
+        std::map< Cell, std::vector<Segment> > matchingSegmentsForCell;
+        std::vector<UInt32> numMatchingSynapsesForSegment;
       };
 
       /**
@@ -375,15 +377,28 @@ namespace nupic
          * Forward-propagates input to synapses, dendrites, and cells, to
          * compute their activity.
          *
-         * @param input               Active cells in the input.
-         * @param permanenceThreshold Only consider synapses with permanences greater than this threshold.
-         * @param synapseThreshold    Only consider segments with number of active synapses greater than this threshold.
+         * @param input
+         * Active cells in the input.
+         *
+         * @param activePermanenceThreshold
+         * Minimum permanence for a synapse to contribute to an active segment
+         *
+         * @param activeSynapseThreshold
+         * Minimum number of synapses to mark a segment as "active"
+         *
+         * @param matchingPermanenceThreshold
+         * Minimum permanence for a synapse to contribute to an matching segment
+         *
+         * @param matchingSynapseThreshold
+         * Minimum number of synapses to mark a segment as "matching"
          *
          * @retval Activity to return.
          */
         Activity computeActivity(const std::vector<Cell>& input,
-                                 Permanence permanenceThreshold,
-                                 SynapseIdx synapseThreshold,
+                                 Permanence activePermanenceThreshold,
+                                 SynapseIdx activeSynapseThreshold,
+                                 Permanence matchingPermanenceThreshold,
+                                 SynapseIdx matchingSynapseThreshold,
                                  bool recordIteration=true);
 
         /**
@@ -403,6 +418,24 @@ namespace nupic
          * @retval Active cells.
          */
         std::vector<Cell> activeCells(const Activity& activity);
+
+        /**
+         * Gets the matching segments from activity.
+         *
+         * @param activity Activity.
+         *
+         * @retval Matching segments.
+         */
+        std::vector<Segment> matchingSegments(const Activity& activity);
+
+        /**
+         * Gets the matching cells from activity.
+         *
+         * @param activity Activity.
+         *
+         * @retval Matching cells.
+         */
+        std::vector<Cell> matchingCells(const Activity& activity);
 
         // Serialization
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -445,16 +445,16 @@ TemporalMemory::computePredictiveCells(
   map<Segment, int> numActiveSynapsesForSegment;
   vector<Cell> activeCells(_activeCells.begin(), _activeCells.end());
 
-  Activity activity = _connections.computeActivity(activeCells, connectedPermanence_, activationThreshold_);
+  Activity activity = _connections.computeActivity(activeCells,
+                                                   connectedPermanence_, activationThreshold_,
+                                                   0.0, minThreshold_);
 
   vector<Segment> _activeSegments = _connections.activeSegments(activity);
   vector<Cell> predictiveCellsVec = _connections.activeCells(activity);
   set<Cell> _predictiveCells(predictiveCellsVec.begin(), predictiveCellsVec.end());
 
-  Activity matchingActivity = _connections.computeActivity(activeCells, 0.0, minThreshold_, false);
-
-  vector<Segment> _matchingSegments = _connections.activeSegments(matchingActivity);
-  vector<Cell> matchingCellsVec = _connections.activeCells(matchingActivity);
+  vector<Segment> _matchingSegments = _connections.matchingSegments(activity);
+  vector<Cell> matchingCellsVec = _connections.matchingCells(activity);
   set<Cell> _matchingCells(matchingCellsVec.begin(), matchingCellsVec.end());
 
   return make_tuple(_activeSegments, _predictiveCells, 

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -40,6 +40,7 @@ using namespace nupic::algorithms::temporal_memory;
 using namespace nupic::algorithms::connections;
 
 #define SEED 42
+#define EPSILON 0.000001
 
 namespace nupic
 {
@@ -171,7 +172,9 @@ namespace nupic
 
       for (UInt i = 0; i < numInputs; i++)
       {
-        connections.createSynapse(segment, i, (Permanence)(rand()+1)/RAND_MAX);
+        const Permanence permanence = max((Permanence)EPSILON,
+                                          (Permanence)rand()/RAND_MAX);
+        connections.createSynapse(segment, i, permanence);
       }
     }
 

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -211,9 +211,14 @@ namespace nupic
           permanence = max(permanence, (Permanence)0);
           permanence = min(permanence, (Permanence)1);
 
-          // TODO (Question): Remove synapses with 0 permanence?
-
-          connections.updateSynapsePermanence(synapse, permanence);
+          if (permanence == 0)
+          {
+            connections.destroySynapse(synapse);
+          }
+          else
+          {
+            connections.updateSynapsePermanence(synapse, permanence);
+          }
         }
       }
     }

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -186,7 +186,7 @@ namespace nupic
     for (int i = 0; i < 500; i++)
     {
       sdr = randomSDR(numInputs, w);
-      activity = connections.computeActivity(sdr, 0.5, 0);
+      activity = connections.computeActivity(sdr, 0.5, 0, 0.25, 0);
       winnerCells = computeSPWinnerCells(connections, numWinners, activity);
 
       for (Cell winnerCell : winnerCells)
@@ -225,7 +225,7 @@ namespace nupic
     for (int i = 0; i < 500; i++)
     {
       sdr = randomSDR(numInputs, w);
-      activity = connections.computeActivity(sdr, 0.5, 0);
+      activity = connections.computeActivity(sdr, 0.5, 0, 0.25, 0);
       winnerCells = computeSPWinnerCells(connections, numWinners, activity);
     }
 

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -40,7 +40,6 @@ using namespace nupic::algorithms::temporal_memory;
 using namespace nupic::algorithms::connections;
 
 #define SEED 42
-#define EPSILON 0.000001
 
 namespace nupic
 {
@@ -172,7 +171,7 @@ namespace nupic
 
       for (UInt i = 0; i < numInputs; i++)
       {
-        const Permanence permanence = max((Permanence)EPSILON,
+        const Permanence permanence = max((Permanence)0.000001,
                                           (Permanence)rand()/RAND_MAX);
         connections.createSynapse(segment, i, permanence);
       }

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -171,7 +171,7 @@ namespace nupic
 
       for (UInt i = 0; i < numInputs; i++)
       {
-        connections.createSynapse(segment, i, (Permanence)rand()/RAND_MAX);
+        connections.createSynapse(segment, i, (Permanence)(rand()+1)/RAND_MAX);
       }
     }
 


### PR DESCRIPTION
Fixes #910 

Here's the output for:

~~~
python $NUPIC/scripts/temporal_memory_performance_benchmark.py
~~~

Reference:
TP10X2: 1.625308s

Before:
TM (C++): 1.613453s

After:
TM (C++): 1.550195s