### PR TITLE
TemporalMemory: replace phases with "columnSegmentWalk". Much faster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ This option is for developers that would like the ability to do incremental buil
 
     mkdir -p $NUPIC_CORE/build/scripts
     cd $NUPIC_CORE/build/scripts
-    cmake $NUPIC_CORE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../release -DPY_EXTENSIONS_DIR=$NUPIC_CORE/bindings/py/nupic/bindings
+    cmake $NUPIC_CORE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release -DPY_EXTENSIONS_DIR=$NUPIC_CORE/bindings/py/nupic/bindings
 
 Notes:
 
-- This will generate Debug build files. For a release build, change `-DCMAKE_BUILD_TYPE` to `Release`.
+- This will generate Release build files. For a debug build, change `-DCMAKE_BUILD_TYPE` to `Debug`.
 - If you have dependencies precompiled but not in standard system locations then you can specify where to find them with `-DCMAKE_PREFIX_PATH` (for bin/lib) and `-DCMAKE_INCLUDE_PATH` (for header files).
 - The `-DCMAKE_INSTALL_PREFIX=../release` option shown above is optional, and specifies the location where `nupic.core` should be installed. If omitted, `nupic.core` will be installed in a system location. Using this option is useful when testing versions of `nupic.core` with `nupic` (see [NuPIC's Dependency on nupic.core](https://github.com/numenta/nupic/wiki/NuPIC's-Dependency-on-nupic.core)).
 - Setting `-DPY_EXTENSIONS_DIR` copies the Python exension files to the specified directory. If the extensions aren't present when the Python build/installation is invoked then the setup.py file will run the cmake/make process to generate them. Make sure to include this flag if you want to do incremental builds of the Python extensions.

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2014, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2014-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -71,6 +71,7 @@ namespace nupic
         Cell() {}
 
         bool operator==(const Cell &other) const;
+        bool operator!=(const Cell &other) const;
         bool operator<=(const Cell &other) const;
         bool operator<(const Cell &other) const;
         bool operator>=(const Cell &other) const;
@@ -184,20 +185,17 @@ namespace nupic
       };
 
       /**
-       * Activity class used in Connections.
+       * A segment + overlap pair.
        *
        * @b Description
-       * The Activity class is a data structure that represents the
-       * activity of a collection of cells, as computed by propagating
-       * input through connections.
-       *
+       * The "overlap" describes the number of active synapses on the segment.
+       * Depending on the use case, these synapses may have a permanence below
+       * the connected threshold.
        */
-      struct Activity
+      struct SegmentOverlap
       {
-        std::map< Cell, std::vector<Segment> > activeSegmentsForCell;
-        std::vector<UInt32> numActiveSynapsesForSegment;
-        std::map< Cell, std::vector<Segment> > matchingSegmentsForCell;
-        std::vector<UInt32> numMatchingSynapsesForSegment;
+        Segment segment;
+        UInt32 overlap;
       };
 
       /**
@@ -392,50 +390,22 @@ namespace nupic
          * @param matchingSynapseThreshold
          * Minimum number of synapses to mark a segment as "matching"
          *
-         * @retval Activity to return.
+         * @param outActiveSegments
+         * An output vector.
+         * On return, filled with active segments and overlaps.
+         *
+         * @param outActiveSegments
+         * An output vector.
+         * On return, filled with matching segments and overlaps.
          */
-        Activity computeActivity(const std::vector<Cell>& input,
-                                 Permanence activePermanenceThreshold,
-                                 SynapseIdx activeSynapseThreshold,
-                                 Permanence matchingPermanenceThreshold,
-                                 SynapseIdx matchingSynapseThreshold,
-                                 bool recordIteration=true);
-
-        /**
-         * Gets the active segments from activity.
-         *
-         * @param activity Activity.
-         *
-         * @retval Active segments.
-         */
-        std::vector<Segment> activeSegments(const Activity& activity);
-
-        /**
-         * Gets the active cells from activity.
-         *
-         * @param activity Activity.
-         *
-         * @retval Active cells.
-         */
-        std::vector<Cell> activeCells(const Activity& activity);
-
-        /**
-         * Gets the matching segments from activity.
-         *
-         * @param activity Activity.
-         *
-         * @retval Matching segments.
-         */
-        std::vector<Segment> matchingSegments(const Activity& activity);
-
-        /**
-         * Gets the matching cells from activity.
-         *
-         * @param activity Activity.
-         *
-         * @retval Matching cells.
-         */
-        std::vector<Cell> matchingCells(const Activity& activity);
+        void computeActivity(const std::vector<Cell>& input,
+                             Permanence activePermanenceThreshold,
+                             SynapseIdx activeSynapseThreshold,
+                             Permanence matchingPermanenceThreshold,
+                             SynapseIdx matchingSynapseThreshold,
+                             std::vector<SegmentOverlap>& outActiveSegments,
+                             std::vector<SegmentOverlap>& outMatchingSegments,
+                             bool recordIteration=true);
 
         // Serialization
 

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2014, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2014-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -210,28 +210,28 @@ static void columnSegmentWalk(
     const Cell lastInColumn = Cell((activeColumn+1)*cellsPerColumn - 1);
 
     // Report segments before this active column.
-    const auto wrongActiveBegin = active;
-    const auto wrongMatchingBegin = matching;
-
-    while (active != activeSegments.end() &&
-           active->segment.cell < firstInColumn)
     {
-      active++;
+      const auto wrongActiveBegin = active;
+      const auto wrongMatchingBegin = matching;
+
+      while (active != activeSegments.end() &&
+             active->segment.cell < firstInColumn)
+      {
+        active++;
+      }
+
+      while (matching != matchingSegments.end() &&
+             matching->segment.cell < firstInColumn)
+      {
+        matching++;
+      }
+
+      onPredictedColumnsInactive(wrongActiveBegin, active,
+                                 wrongMatchingBegin, matching);
     }
 
-    while (matching != matchingSegments.end() &&
-           matching->segment.cell < firstInColumn)
+    // Report segments within this active column.
     {
-      matching++;
-    }
-
-    onPredictedColumnsInactive(wrongActiveBegin, active,
-                               wrongMatchingBegin, matching);
-
-    if (active != activeSegments.end() &&
-        active->segment.cell <= lastInColumn)
-    {
-      // Column has one or more predicted cell.
       const auto correctActiveBegin = active;
       const auto correctMatchingBegin = matching;
 
@@ -247,22 +247,18 @@ static void columnSegmentWalk(
         matching++;
       }
 
-      onPredictedColumnActive(activeColumn,
-                              correctActiveBegin, active,
-                              correctMatchingBegin, matching);
-    }
-    else
-    {
-      // Column has no predicted cells.
-      const auto correctMatchingBegin = matching;
-
-      while (matching != matchingSegments.end() &&
-             matching->segment.cell <= lastInColumn)
+      if (correctActiveBegin != active)
       {
-        matching++;
+        // Column has one or more predicted cell.
+        onPredictedColumnActive(activeColumn,
+                                correctActiveBegin, active,
+                                correctMatchingBegin, matching);
       }
-
-      onUnpredictedColumnActive(activeColumn, correctMatchingBegin, matching);
+      else
+      {
+        // Column has no predicted cells.
+        onUnpredictedColumnActive(activeColumn, correctMatchingBegin, matching);
+      }
     }
   }
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -201,6 +201,18 @@ static void columnSegmentWalk(
   FuncB onUnpredictedColumnActive,
   FuncC onPredictedColumnsInactive)
 {
+  NTA_ASSERT(std::is_sorted(activeColumns.begin(), activeColumns.end()));
+  NTA_ASSERT(std::is_sorted(activeSegments.begin(), activeSegments.end(),
+                            [](const SegmentOverlap& a, const SegmentOverlap& b)
+                            {
+                              return a.segment < b.segment;
+                            }));
+  NTA_ASSERT(std::is_sorted(matchingSegments.begin(), matchingSegments.end(),
+                            [](const SegmentOverlap& a, const SegmentOverlap& b)
+                            {
+                              return a.segment < b.segment;
+                            }));
+
   auto active = activeSegments.begin();
   auto matching = matchingSegments.begin();
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -317,13 +317,13 @@ public:
 
   Iterator end()
   {
-    return  Iterator(activeColumns_.end(),
-                     activeColumns_.end(),
-                     activeSegments_.end(),
-                     activeSegments_.end(),
-                     matchingSegments_.end(),
-                     matchingSegments_.end(),
-                     cellsPerColumn_);
+    return Iterator(activeColumns_.end(),
+                    activeColumns_.end(),
+                    activeSegments_.end(),
+                    activeSegments_.end(),
+                    matchingSegments_.end(),
+                    matchingSegments_.end(),
+                    cellsPerColumn_);
   }
 
 private:
@@ -333,9 +333,10 @@ private:
   const vector<SegmentOverlap>& matchingSegments_;
 };
 
-void TemporalMemory::compute(UInt activeColumnsSize,
-                             const UInt activeColumnsUnsorted[],
-                             bool learn)
+void TemporalMemory::compute(
+  UInt activeColumnsSize,
+  const UInt activeColumnsUnsorted[],
+  bool learn)
 {
   const vector<Cell> prevActiveCells = activeCells;
   const vector<Cell> prevWinnerCells = winnerCells;
@@ -373,7 +374,8 @@ void TemporalMemory::compute(UInt activeColumnsSize,
                             permanenceIncrement_, permanenceDecrement_);
             }
             active++;
-          } while (active != excitedColumn.activeSegmentsEnd && active->segment.cell == cell);
+          } while (active != excitedColumn.activeSegmentsEnd &&
+                   active->segment.cell == cell);
         }
       }
       else
@@ -386,10 +388,12 @@ void TemporalMemory::compute(UInt activeColumnsSize,
           activeCells.push_back(Cell(i));
         }
 
-        if (excitedColumn.matchingSegmentsBegin != excitedColumn.matchingSegmentsEnd)
+        if (excitedColumn.matchingSegmentsBegin !=
+            excitedColumn.matchingSegmentsEnd)
         {
           auto bestMatch = std::max_element(
-            excitedColumn.matchingSegmentsBegin, excitedColumn.matchingSegmentsEnd,
+            excitedColumn.matchingSegmentsBegin,
+            excitedColumn.matchingSegmentsEnd,
             [](const SegmentOverlap& a, const SegmentOverlap& b)
             {
               return a.overlap < b.overlap;
@@ -402,7 +406,8 @@ void TemporalMemory::compute(UInt activeColumnsSize,
             adaptSegment_(bestMatch->segment, prevActiveCells,
                           permanenceIncrement_, permanenceDecrement_);
 
-            const UInt32 nGrowDesired = maxNewSynapseCount_ - bestMatch->overlap;
+            const UInt32 nGrowDesired =
+              maxNewSynapseCount_ - bestMatch->overlap;
             if (nGrowDesired > 0)
             {
               growSynapses_(bestMatch->segment, prevWinnerCells, nGrowDesired);

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -411,20 +411,6 @@ namespace nupic {
         void printState(vector<Real> &state);
 
       protected:
-
-        Cell getLeastUsedCell_(UInt column);
-
-        void adaptSegment_(
-          Segment segment,
-          const vector<Cell>& prevActiveCells,
-          Permanence permanenceIncrement,
-          Permanence permanenceDecrement);
-
-        void growSynapses_(
-          Segment segment,
-          const vector<Cell>& prevWinnerCells,
-          UInt32 nDesiredNewSynapses);
-
         UInt numColumns_;
         vector<UInt> columnDimensions_;
         UInt cellsPerColumn_;

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -248,6 +248,9 @@ namespace nupic {
         */
         vector<CellIdx> getMatchingCells() const;
 
+        vector<Segment> getActiveSegments() const;
+        vector<Segment> getMatchingSegments() const;
+
         /**
          * Returns the dimensions of the columns in the region.
          *
@@ -423,14 +426,15 @@ namespace nupic {
         Permanence permanenceDecrement_;
         Permanence predictedSegmentDecrement_;
 
+        vector<Cell> activeCells_;
+        vector<Cell> winnerCells_;
+        vector<SegmentOverlap> activeSegments_;
+        vector<SegmentOverlap> matchingSegments_;
+
         UInt version_;
-        Random _rng;
+        Random rng_;
 
       public:
-        vector<Cell> activeCells;
-        vector<Cell> winnerCells;
-        vector<SegmentOverlap> activeSegments;
-        vector<SegmentOverlap> matchingSegments;
         Connections connections;
       };
 

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -61,7 +61,7 @@ namespace nupic {
        *        <get input vector, streaming spatiotemporal information>
        *        sp.compute(inputVector, learn, activeColumns)
        *        tm.compute(number of activeColumns, activeColumns, learn)
-       *        <do something with output, e.g. add classifiers>
+       *        <do something with output, e.g. classify it>
        *     }
        *
        */
@@ -72,17 +72,45 @@ namespace nupic {
         /**
          * Initialize the temporal memory (TM) using the given parameters.
          *
-         * @param columnDimensions     Dimensions of the column space
-         * @param cellsPerColumn       Number of cells per column
-         * @param activationThreshold  If the number of active connected synapses on a segment is at least this threshold, the segment is said to be active.
-         * @param initialPermanence    Initial permanence of a new synapse.
-         * @param connectedPermanence  If the permanence value for a synapse is greater than this value, it is said to be connected.
-         * @param minThreshold         If the number of synapses active on a segment is at least this threshold, it is selected as the best matching cell in a bursting column.
-         * @param maxNewSynapseCount   The maximum number of synapses added to a segment during learning.
-         * @param permanenceIncrement  Amount by which permanences of synapses are incremented during learning.
-         * @param permanenceDecrement  Amount by which permanences of synapses are decremented during learning.
-         * @param predictedSegmentDecrement Amount by which active permanences of synapses of previously predicted but inactive segments are decremented.
-         * @param seed                 Seed for the random number generator.
+         * @param columnDimensions
+         * Dimensions of the column space
+         *
+         * @param cellsPerColumn
+         * Number of cells per column
+         *
+         * @param activationThreshold
+         * If the number of active connected synapses on a segment is at least
+         * this threshold, the segment is said to be active.
+         *
+         * @param initialPermanence
+         * Initial permanence of a new synapse.
+         *
+         * @param connectedPermanence
+         * If the permanence value for a synapse is greater than this value, it
+         * is said to be connected.
+         *
+         * @param minThreshold
+         * If the number of synapses active on a segment is at least this
+         * threshold, it is selected as the best matching cell in a bursting
+         * column.
+         *
+         * @param maxNewSynapseCount
+         * The maximum number of synapses added to a segment during learning.
+         *
+         * @param permanenceIncrement
+         * Amount by which permanences of synapses are incremented during
+         * learning.
+         *
+         * @param permanenceDecrement
+         * Amount by which permanences of synapses are decremented during
+         * learning.
+         *
+         * @param predictedSegmentDecrement
+         * Amount by which active permanences of synapses of previously
+         * predicted but inactive segments are decremented.
+         *
+         * @param seed
+         * Seed for the random number generator.
          *
          * Notes:
          *
@@ -157,281 +185,18 @@ namespace nupic {
          * @param learn             Whether or not learning is enabled
          *
          * Updates member variables:
-         * - `activeCells`       (set)
-         * - `winnerCells`       (set)
-         * - `activeSegments`    (set)
-         * - `predictiveCells`   (set)
-         * - `predictedColumns`  (set)
-         * - `matchingSegments`  (set)
-         * - `matchingCells`     (set)
+         * - `activeCells`
+         * - `winnerCells`
+         * - `activeSegments`
+         * - `matchingSegments`
          */
         virtual void compute(
-          UInt activeColumnsSize, UInt activeColumns[], bool learn = true);
-
-
-        // ==============================
-        //  Phases
-        // ==============================
-
-        /**
-         * Phase 1 : Activate the correctly predictive cells.
-         *
-         * Pseudocode :
-         *
-         * - for each prev predictive cell
-         *   - if in active column
-         *     - mark it as active
-         *     - mark it as winner cell
-         *  	 - mark column as predicted
-         *
-         * - if orphan decay active
-         *   - for each prev matching cell
-         *     - if not in active column
-         *       - mark it as an predicted but inactive cell
-         *
-         * @param prevPredictiveCells   Indices of predictive cells in `t-1`
-         * @param prevMatchingCells     Indices of matching cells in `t-1`
-         * @param activeColumns         Indices of active columns in `t`
-         *
-         * @return (tuple)Contains:
-         *  `activeCells`               (set),
-         *  `winnerCells`               (set),
-         *  `predictedColumns`          (set),
-         *  `predictedInactiveCells`    (set)
-         */
-        virtual tuple<set<Cell>, set<Cell>, set<UInt>, set<Cell>>
-          activateCorrectlyPredictiveCells(
-            set<Cell>& prevPredictiveCells,
-            set<Cell>& prevMatchingCells,
-            set<UInt>& activeColumns);
-
-        /**
-         * Phase 2 : Burst unpredicted columns.
-         *
-         * Pseudocode :
-         *
-         * - for each unpredicted active column
-         *   - mark all cells as active
-         *   - mark the best matching cell as winner cell
-         *     - (learning)
-         *       - if it has no matching segment
-         *         - (optimization) if there are prev winner cells
-         *           - add a segment to it
-         *       - mark the segment as learning
-         *
-         * @param activeColumns(set)       Indices of active columns in `t`
-         * @param predictedColumns(set)    Indices of predicted columns in `t`
-         * @param prevActiveCells(set)     Indices of active cells in `t-1`
-         * @param prevWinnerCells(set)     Indices of winner cells in `t-1`
-         * @param connections(Connections) Connectivity of layer
-         *
-         * @return (tuple)Contains:
-         *  `activeCells`      (set),
-         *  `winnerCells`      (set),
-         *  `learningSegments` (set)
-         */
-        virtual tuple<set<Cell>, set<Cell>, vector<Segment>> burstColumns(
-          set<UInt>& activeColumns,
-          set<UInt>& predictedColumns,
-          set<Cell>& prevActiveCells,
-          set<Cell>& prevWinnerCells,
-          Connections& connections);
-
-        /**
-         * Phase 3 : Perform learning by adapting segments.
-         *
-         * Pseudocode:
-         *
-         *   - (learning) for each prev active or learning segment
-         *     - if learning segment or from winner cell
-         *       - strengthen active synapses
-         *       - weaken inactive synapses
-         *     - if learning segment
-         *       - add some synapses to the segment
-         *         - subsample from prev winner cells
-         *
-         *   - if predictedSegmentDecrement > 0
-         *     - for each previously matching segment
-         *       - if cell is a predicted inactive cell
-         *         - weaken active synapses but don't touch inactive synapses
-         *
-         * @param prevActiveSegments(set)   Indices of active segments in `t-1`
-         * @param learningSegments(set)     Indices of learning segments in `t`
-         * @param prevActiveCells(set)      Indices of active cells in `t-1`
-         * @param winnerCells(set)          Indices of winner cells in `t`
-         * @param prevWinnerCells(set)      Indices of winner cells in `t-1`
-         * @param connections(Connections)  Connectivity of layer
-         * @param predictedInactiveCells    Indices of predicted inactive cells
-         * @param prevMatchingSegments      Indices of matching segments in `t-1`
-         */
-        virtual void learnOnSegments(
-          vector<Segment>& prevActiveSegments,
-          vector<Segment>& learningSegments,
-          set<Cell>& prevActiveCells,
-          set<Cell>& winnerCells,
-          set<Cell>& prevWinnerCells,
-          Connections& _connections,
-          set<Cell>& predictedInactiveCells,
-          vector<Segment>& prevMatchingSegments);
-
-        /**
-         * Phase 4 : Compute predictive cells due to lateral input
-         * on distal dendrites.
-         *
-         * Pseudocode:
-         *
-         *   - for each distal dendrite segment with activity >= activationThreshold
-         *     - mark the segment as active
-         *     - mark the cell as predictive
-         *
-         *   - if predictedSegmentDecrement > 0
-         *     - for each distal dendrite segment with unconnected
-         *       activity >=  minThreshold
-         *       - mark the segment as matching
-         *       - mark the cell as matching
-         *
-         * Forward propagates activity from active cells to the synapses
-         * that touch them, to determine which synapses are active.
-         *
-         *  @param activeCells(set)         Indices of active cells in `t`
-         *  @param connections(Connections) Connectivity of layer
-         *
-         *  @return (tuple)Contains:
-         *   `activeSegments`   (set),
-         *   `predictiveCells`  (set),
-         *   `matchingSegments` (set),
-         *   `matchingCells`    (set)
-         */
-        virtual tuple<vector<Segment>, set<Cell>, vector<Segment>, set<Cell>>
-          computePredictiveCells(
-            set<Cell>& activeCells, Connections& connections);
+          UInt activeColumnsSize, const UInt activeColumns[], bool learn = true);
 
 
         // ==============================
         //  Helper functions
         // ==============================
-
-        /**
-         * Gets the cell with the best matching segment
-         * (see `TM.bestMatchingSegment`) that has the
-         * largest number of active synapses of all
-         * best matching segments.
-         *
-         * If none were found, pick the least used cell
-         * (see `TM.leastUsedCell`)
-         *
-         * @param cells        Indices of cells
-         * @param activeCells  Indices of active cells
-         * @param connections  Connectivity of layer
-         *
-         * @return (tuple)Contains:
-         *   `foundCell`    (bool),
-         *   `bestCell`     (int),
-         *   `foundSegment` (bool),
-         *   `bestSegment`  (int)
-         */
-        tuple<bool, Cell, bool, Segment> bestMatchingCell(
-          vector<Cell>& cells,
-          set<Cell>& activeCells,
-          Connections& connections);
-
-        /**
-         * Gets the segment on a cell with the largest number of activate
-         * synapses, including all synapses with non - zero permanences.
-         *
-         * @param cell          Cell index
-         * @param activeCells   Indices of active cells
-         * @param connections   Connectivity of layer
-         *
-         * @return (tuple)Contains:
-         *  `segment`                 (int),
-         *  `connectedActiveSynapses` (set)
-         */
-        tuple<bool, Segment, Int> bestMatchingSegment(
-          Cell& cell,
-          set<Cell>& activeCells,
-          Connections& connections);
-
-        /**
-         * Gets the cell with the smallest number of segments.
-         * Break ties randomly.
-         *
-         * @param cells         Indices of cells
-         * @param connections   Connectivity of layer
-         *
-         * @return (int) Cell index
-         */
-        Cell leastUsedCell(
-          vector<Cell>& cells,
-          Connections& connections);
-
-        /**
-         * Returns the synapses on a segment that are active due to
-         * lateral input from active cells.
-         *
-         * @param segment       Segment index
-         * @param activeCells   Indices of active cells
-         * @param connections   Connectivity of layer
-         *
-         * @return (set) Indices of active synapses on segment
-         */
-        vector<Synapse> activeSynapsesForSegment(
-          Segment& segment,
-          set<Cell>& activeCells,
-          Connections& connections);
-
-        /**
-         * Updates synapses on segment.
-         * Strengthens active synapses; weakens inactive synapses.
-         *
-         * @param segment               Segment index
-         * @param activeSynapses        Indices of active synapses
-         * @param connections           Connectivity of layer
-         * @param permanenceIncrement   Amount to increment active synapses
-         *@param permanenceDecrement   Amount to decrement inactive synapses
-         */
-        void adaptSegment(
-          Segment& segment,
-          vector<Synapse>& activeSynapses,
-          Connections& connections,
-          Permanence permanenceIncrement,
-          Permanence permanenceDecrement);
-
-        /**
-         * Pick cells to form distal connections to.
-         *
-         * TODO : Respect topology and learningRadius
-         *
-         * @param n             Number of cells to pick
-         * @param segment       Segment index
-         * @param winnerCells   Indices of winner cells in `t`
-         * @param connections   Connectivity of layer
-         *
-         * @return (set) Indices of cells picked
-         */
-        set<Cell> pickCellsToLearnOn(
-          Int n,
-          Segment& segment,
-          set<Cell>& winnerCells,
-          Connections& connections);
-
-        /**
-         * Returns the index of the column that a cell belongs to.
-         *
-         * @param cell Cell index
-         *
-         * @return (int) Column index
-         */
-        Int columnForCell(Cell& cell);
-
-       /**
-        * Returns the Cell objects that belong to a column.
-        *
-        * @param column Column index
-        *
-        * @return (vector<Cell>) Cell objects
-        */
-       vector<Cell> cellsForColumnCell(Int column);
 
         /**
          * Returns the indices of cells that belong to a column.
@@ -476,15 +241,6 @@ namespace nupic {
         * @returns (std::vector<CellIdx>) Vector of indices of matching cells.
         */
         vector<CellIdx> getMatchingCells() const;
-
-        /**
-         * Maps cells to the columns they belong to
-         *
-         * @param cells Cells
-         *
-         * @return (dict) Mapping from columns to their cells in `cells`
-         */
-        map<Int, set<Cell>> mapCellsToColumns(set<Cell>& cells);
 
         /**
          * Returns the dimensions of the columns in the region.
@@ -583,32 +339,11 @@ namespace nupic {
         vector<CellIdx> _cellsToIndices(const Iterable &cellSet) const;
 
         /**
-         * Raises an error if column index is invalid.
-         *
-         * @param column Column index
-         */
-        bool _validateColumn(UInt column);
-
-        /**
          * Raises an error if cell index is invalid.
          *
          * @param cell Cell index
          */
         bool _validateCell(Cell& cell);
-
-        /**
-         * Raises an error if segment is invalid.
-         *
-         * @param segment segment index
-         */
-        bool _validateSegment(Segment& segment);
-
-        /**
-         * Raises an error if segment is invalid.
-         *
-         * @param permanence (float) Permanence
-         */
-        bool _validatePermanence(Real permanence);
 
         /**
          * Save (serialize) the current state of the spatial pooler to the
@@ -651,6 +386,15 @@ namespace nupic {
         void printParameters();
 
         /**
+         * Returns the index of the column that a cell belongs to.
+         *
+         * @param cell Cell index
+         *
+         * @return (int) Column index
+         */
+        Int columnForCell(Cell& cell);
+
+        /**
          * Print the given UInt array in a nice format
          */
         void printState(vector<UInt> &state);
@@ -661,6 +405,20 @@ namespace nupic {
         void printState(vector<Real> &state);
 
       protected:
+
+        Cell getLeastUsedCell_(UInt column);
+
+        void adaptSegment_(
+          Segment segment,
+          const vector<Cell>& prevActiveCells,
+          Permanence permanenceIncrement,
+          Permanence permanenceDecrement);
+
+        void growSynapses_(
+          Segment segment,
+          const vector<Cell>& prevWinnerCells,
+          UInt32 n);
+
         UInt numColumns_;
         vector<UInt> columnDimensions_;
         UInt cellsPerColumn_;
@@ -677,13 +435,10 @@ namespace nupic {
         Random _rng;
 
       public:
-        set<Cell> activeCells;
-        set<Cell> winnerCells;
-        vector<Segment> activeSegments;
-        vector<Cell> predictiveCells;
-        set<UInt> predictedColumns;
-        vector<Segment> matchingSegments;
-        vector<Cell> matchingCells;
+        vector<Cell> activeCells;
+        vector<Cell> winnerCells;
+        vector<SegmentOverlap> activeSegments;
+        vector<SegmentOverlap> matchingSegments;
         Connections connections;
       };
 
@@ -692,4 +447,3 @@ namespace nupic {
 } // end namespace nta
 
 #endif // NTA_TEMPORAL_MEMORY_HPP
-

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -112,6 +112,12 @@ namespace nupic {
          * @param seed
          * Seed for the random number generator.
          *
+         * @param maxSegmentsPerCell
+         * The maximum number of segments per cell.
+         *
+         * @param maxSynapsesPerSegment
+         * The maximum number of synapses per segment.
+         *
          * Notes:
          *
          * predictedSegmentDecrement: A good value is just a bit larger than
@@ -417,7 +423,7 @@ namespace nupic {
         void growSynapses_(
           Segment segment,
           const vector<Cell>& prevWinnerCells,
-          UInt32 n);
+          UInt32 nDesiredNewSynapses);
 
         UInt numColumns_;
         vector<UInt> columnDimensions_;

--- a/src/nupic/proto/ConnectionsProto.capnp
+++ b/src/nupic/proto/ConnectionsProto.capnp
@@ -22,6 +22,13 @@ struct ConnectionsProto {
     segments @0 :List(SegmentProto);
   }
 
+  # Next ID: 3
+  struct SegmentOverlapProto {
+    cell @0 :UInt32;
+    segment @1 :UInt32;
+    overlap @2 :UInt32;
+  }
+
   cells @0 :List(CellProto);
   maxSegmentsPerCell @1 :UInt16;
   iteration @2 :UInt64;

--- a/src/nupic/proto/TemporalMemoryProto.capnp
+++ b/src/nupic/proto/TemporalMemoryProto.capnp
@@ -2,9 +2,10 @@
 
 # TODO: Use absolute path
 using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto;
+using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto.SegmentOverlapProto;
 using import "/nupic/proto/RandomProto.capnp".RandomProto;
 
-# Next ID: 19
+# Next ID: 21
 struct TemporalMemoryProto {
 
   columnDimensions @0 :List(UInt32);
@@ -23,10 +24,22 @@ struct TemporalMemoryProto {
 
   # Lists of indices
   activeCells @12 :List(UInt32);
+
+  # Obsolete, information contained in activeSegmentOverlaps
   predictiveCells @13 :List(UInt32);
+
+  # Obsolete, replaced by activeSegmentOverlaps
   activeSegments @14 :List(UInt32);
+
   winnerCells @15 :List(UInt32);
+
+  # Obsolete, replaced by matchingSegmentOverlaps
   matchingSegments @16 :List(UInt32);
+
+  # Obsolete, information contained in matchingSegmentOverlaps
   matchingCells @17 :List(UInt32);
+
   predictedSegmentDecrement @18 :Float32;
+  activeSegmentOverlaps @19 :List(SegmentOverlapProto);
+  matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
 }

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2015-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -45,7 +45,7 @@ namespace nupic
 
     namespace connections
     {
-      struct Activity;
+      struct SegmentOverlap;
       struct Cell;
     }
   }
@@ -84,7 +84,7 @@ namespace nupic
     std::vector<algorithms::connections::Cell> computeSPWinnerCells(
       Connections& connections,
       UInt numCells,
-      algorithms::connections::Activity& activity);
+      vector<algorithms::connections::SegmentOverlap> activeSegments);
 
   }; // end class ConnectionsPerformanceTest
 

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2015-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -41,7 +41,7 @@ namespace {
   {
     // Cell with 1 segment.
     // Segment with:
-    // - 1 active synapse
+    // - 1 connected synapse: active
     // - 2 matching synapses
     const Segment segment1_1 = connections.createSegment(Cell(10));
     connections.createSynapse(segment1_1, Cell(150), 0.85);
@@ -49,8 +49,8 @@ namespace {
 
     // Cell with 2 segments.
     // Segment with:
-    // - 2 active synapses
-    // - 3 matching synapses
+    // - 2 connected synapses: 2 active
+    // - 3 matching synapses: 3 active
     const Segment segment2_1 = connections.createSegment(Cell(20));
     connections.createSynapse(segment2_1, Cell(80), 0.85);
     connections.createSynapse(segment2_1, Cell(81), 0.85);
@@ -58,9 +58,9 @@ namespace {
     connections.updateSynapsePermanence(synapse, 0.15);
 
     // Segment with:
-    // - 2 active synapses (1 inactive)
-    // - 3 matching synapses (1 inactive)
-    // - 1 non-matching synapse
+    // - 2 connected synapses: 1 active, 1 inactive
+    // - 3 matching synapses: 2 active, 1 inactive
+    // - 1 non-matching synapse: 1 active
     const Segment segment2_2 = connections.createSegment(Cell(20));
     connections.createSynapse(segment2_2, Cell(50), 0.85);
     connections.createSynapse(segment2_2, Cell(51), 0.85);
@@ -69,28 +69,22 @@ namespace {
 
     // Cell with one segment.
     // Segment with:
-    // - 1 non-matching synapse
+    // - 1 non-matching synapse: 1 active
     const Segment segment3_1 = connections.createSegment(Cell(30));
     connections.createSynapse(segment3_1, Cell(53), 0.05);
   }
 
-  Activity computeSampleActivity(Connections &connections)
+  void computeSampleActivity(Connections &connections)
   {
-    vector<Cell> input;
+    vector<Cell> input = {{50}, {52}, {53},
+                          {80}, {81}, {82},
+                          {150}, {151}};
 
-    input.push_back(Cell(150));
-    input.push_back(Cell(151));
-    input.push_back(Cell(50));
-    input.push_back(Cell(52));
-    input.push_back(Cell(53));
-    input.push_back(Cell(80));
-    input.push_back(Cell(81));
-    input.push_back(Cell(82));
-
-    Activity activity = connections.computeActivity(input,
-                                                    0.50, 2,
-                                                    0.10, 1);
-    return activity;
+    vector<SegmentOverlap> activeSegments;
+    vector<SegmentOverlap> matchingSegments;
+    connections.computeActivity(input,
+                                0.5, 2, 0.10, 1,
+                                activeSegments, matchingSegments);
   }
 
   /**
@@ -134,7 +128,7 @@ namespace {
     setupSampleConnections(connections);
 
     auto numSegments = connections.numSegments();
-    Activity activity = computeSampleActivity(connections);
+    computeSampleActivity(connections);
 
     cell.idx = 20;
 
@@ -251,33 +245,33 @@ namespace {
   TEST(ConnectionsTest, testDestroySegment)
   {
     Connections connections(1024);
-    Cell cell;
-    Segment segment;
 
-    setupSampleConnections(connections);
-    auto numSegments = connections.numSegments();
+    /*      segment1*/ connections.createSegment(Cell(10));
+    Segment segment2 = connections.createSegment(Cell(20));
+    /*      segment3*/ connections.createSegment(Cell(20));
+    /*      segment4*/ connections.createSegment(Cell(30));
 
-    cell.idx = 20;
-    segment.cell = cell;
-    segment.idx = 0;
-    connections.destroySegment(segment);
+    connections.createSynapse(segment2, Cell(80), 0.85);
+    connections.createSynapse(segment2, Cell(81), 0.85);
+    connections.createSynapse(segment2, Cell(82), 0.15);
 
-    ASSERT_EQ(connections.numSegments(), numSegments-1);
-    ASSERT_THROW(connections.synapsesForSegment(segment);, runtime_error);
+    ASSERT_EQ(4, connections.numSegments());
+    ASSERT_EQ(3, connections.numSynapses());
 
-    Activity activity = computeSampleActivity(connections);
+    connections.destroySegment(segment2);
 
-    ASSERT_EQ(activity.activeSegmentsForCell.size(), 0);
+    ASSERT_EQ(3, connections.numSegments());
+    ASSERT_EQ(0, connections.numSynapses());
+    ASSERT_THROW(connections.synapsesForSegment(segment2);, runtime_error);
 
-    UInt32 numSegmentsWithActivesynapses = 0;
-    for (UInt32 numActiveSynapses : activity.numActiveSynapsesForSegment)
-    {
-      if (numActiveSynapses > 0)
-      {
-        numSegmentsWithActivesynapses++;
-      }
-    }
-    ASSERT_EQ(2, numSegmentsWithActivesynapses);
+    vector<SegmentOverlap> activeSegments;
+    vector<SegmentOverlap> matchingSegments;
+    connections.computeActivity({{80}, {81}, {82}},
+                                0.5, 2, 0.0, 1,
+                                activeSegments, matchingSegments);
+
+    ASSERT_EQ(0, activeSegments.size());
+    ASSERT_EQ(0, matchingSegments.size());
   }
 
   /**
@@ -287,31 +281,28 @@ namespace {
   TEST(ConnectionsTest, testDestroySynapse)
   {
     Connections connections(1024);
-    Cell cell;
-    Segment segment;
-    Synapse synapse;
 
-    setupSampleConnections(connections);
-    auto numSynapses = connections.numSynapses();
+    Segment segment = connections.createSegment(Cell(20));
+    /*      synapse1*/ connections.createSynapse(segment, Cell(80), 0.85);
+    Synapse synapse2 = connections.createSynapse(segment, Cell(81), 0.85);
+    /*      synapse3*/ connections.createSynapse(segment, Cell(82), 0.15);
 
-    cell.idx = 20;
-    segment.cell = cell;
-    segment.idx = 0;
-    synapse.segment = segment;
-    synapse.idx = 0;
-    connections.destroySynapse(synapse);
+    ASSERT_EQ(3, connections.numSynapses());
 
-    ASSERT_EQ(connections.numSynapses(), numSynapses-1);
-    vector<Synapse> synapses = connections.synapsesForSegment(segment);
-    ASSERT_EQ(synapses.size(), 2);
+    connections.destroySynapse(synapse2);
 
-    Activity activity = computeSampleActivity(connections);
+    ASSERT_EQ(2, connections.numSynapses());
+    ASSERT_EQ(2, connections.synapsesForSegment(segment).size());
 
-    ASSERT_EQ(activity.activeSegmentsForCell.size(), 0);
+    vector<SegmentOverlap> activeSegments;
+    vector<SegmentOverlap> matchingSegments;
+    connections.computeActivity({{80}, {81}, {82}},
+                                0.5, 2, 0.0, 1,
+                                activeSegments, matchingSegments);
 
-    ASSERT_EQ(1, activity.numActiveSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(20))).flatIdx
-                ]);
+    ASSERT_EQ(0, activeSegments.size());
+    ASSERT_EQ(1, matchingSegments.size());
+    ASSERT_EQ(2, matchingSegments[0].overlap);
   }
 
   /**
@@ -570,89 +561,62 @@ namespace {
   TEST(ConnectionsTest, testComputeActivity)
   {
     Connections connections(1024);
-    Cell cell;
-    Segment segment;
 
-    setupSampleConnections(connections);
-    Activity activity = computeSampleActivity(connections);
+    // Cell with 1 segment.
+    // Segment with:
+    // - 1 connected synapse: active
+    // - 2 matching synapses
+    const Segment segment1_1 = connections.createSegment(Cell(10));
+    connections.createSynapse(segment1_1, Cell(150), 0.85);
+    connections.createSynapse(segment1_1, Cell(151), 0.15);
 
-    ASSERT_EQ(activity.activeSegmentsForCell.size(), 1);
-    cell.idx = 20;
-    ASSERT_EQ(activity.activeSegmentsForCell[cell].size(), 1);
-    segment = activity.activeSegmentsForCell[cell][0];
-    ASSERT_EQ(segment.idx, 0);
-    ASSERT_EQ(segment.cell.idx, 20);
+    // Cell with 2 segments.
+    // Segment with:
+    // - 2 connected synapses: 2 active
+    // - 3 matching synapses: 3 active
+    const Segment segment2_1 = connections.createSegment(Cell(20));
+    connections.createSynapse(segment2_1, Cell(80), 0.85);
+    connections.createSynapse(segment2_1, Cell(81), 0.85);
+    Synapse synapse = connections.createSynapse(segment2_1, Cell(82), 0.85);
+    connections.updateSynapsePermanence(synapse, 0.15);
 
-    ASSERT_EQ(activity.numActiveSynapsesForSegment.size(), 4);
-    ASSERT_EQ(activity.numMatchingSynapsesForSegment.size(), 4);
-    ASSERT_EQ(1,
-              activity.numActiveSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(10))).flatIdx
-                ]);
-    ASSERT_EQ(2,
-              activity.numActiveSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(20))).flatIdx
-                ]);
-    ASSERT_EQ(3,
-              activity.numMatchingSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(20))).flatIdx
-                ]);
-    ASSERT_EQ(1,
-              activity.numActiveSynapsesForSegment[
-                connections.dataForSegment(Segment(1, Cell(20))).flatIdx
-                ]);
-    ASSERT_EQ(2,
-              activity.numMatchingSynapsesForSegment[
-                connections.dataForSegment(Segment(1, Cell(20))).flatIdx
-                ]);
-    ASSERT_EQ(0,
-              activity.numActiveSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(30))).flatIdx
-                ]);
-    ASSERT_EQ(0,
-              activity.numMatchingSynapsesForSegment[
-                connections.dataForSegment(Segment(0, Cell(30))).flatIdx
-                ]);
-  }
+    // Segment with:
+    // - 2 connected synapses: 1 active, 1 inactive
+    // - 3 matching synapses: 2 active, 1 inactive
+    // - 1 non-matching synapse: 1 active
+    const Segment segment2_2 = connections.createSegment(Cell(20));
+    connections.createSynapse(segment2_2, Cell(50), 0.85);
+    connections.createSynapse(segment2_2, Cell(51), 0.85);
+    connections.createSynapse(segment2_2, Cell(52), 0.15);
+    connections.createSynapse(segment2_2, Cell(53), 0.05);
 
-  /**
-   * Creates a sample set of connections, and makes sure that we can get the
-   * active segments from the computed activity.
-   */
-  TEST(ConnectionsTest, testActiveSegments)
-  {
-    Connections connections(1024);
-    Cell cell;
-    Segment segment;
+    // Cell with one segment.
+    // Segment with:
+    // - 1 non-matching synapse: 1 active
+    const Segment segment3_1 = connections.createSegment(Cell(30));
+    connections.createSynapse(segment3_1, Cell(53), 0.05);
 
-    setupSampleConnections(connections);
-    Activity activity = computeSampleActivity(connections);
+    vector<Cell> input = {{50}, {52}, {53},
+                          {80}, {81}, {82},
+                          {150}, {151}};
 
-    vector<Segment> activeSegments = connections.activeSegments(activity);
+    vector<SegmentOverlap> activeSegments;
+    vector<SegmentOverlap> matchingSegments;
+    connections.computeActivity(input,
+                                0.5, 2, 0.10, 1,
+                                activeSegments, matchingSegments);
 
-    ASSERT_EQ(activeSegments.size(), 1);
-    segment = activeSegments[0];
-    ASSERT_EQ(segment.idx, 0);
-    ASSERT_EQ(segment.cell.idx, 20);
-  }
+    ASSERT_EQ(1, activeSegments.size());
+    ASSERT_EQ(segment2_1, activeSegments[0].segment);
+    ASSERT_EQ(2, activeSegments[0].overlap);
 
-  /**
-   * Creates a sample set of connections, and makes sure that we can get the
-   * active cells from the computed activity.
-   */
-  TEST(ConnectionsTest, testActiveCells)
-  {
-    Connections connections(1024);
-    Cell cell;
-    Segment segment;
-
-    setupSampleConnections(connections);
-    Activity activity = computeSampleActivity(connections);
-
-    vector<Cell> activeCells = connections.activeCells(activity);
-
-    ASSERT_EQ(activeCells.size(), 1);
-    ASSERT_EQ(activeCells[0].idx, 20);
+    ASSERT_EQ(3, matchingSegments.size());
+    ASSERT_EQ(segment1_1, matchingSegments[0].segment);
+    ASSERT_EQ(2, matchingSegments[0].overlap);
+    ASSERT_EQ(segment2_1, matchingSegments[1].segment);
+    ASSERT_EQ(3, matchingSegments[1].overlap);
+    ASSERT_EQ(segment2_2, matchingSegments[2].segment);
+    ASSERT_EQ(2, matchingSegments[2].overlap);
   }
 
   /**

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2014, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2014-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
  * with Numenta, Inc., for a separate license for this software code, the
  * following terms and conditions apply:
  *

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -1313,29 +1313,18 @@ namespace {
 
     tm1.compute(sequence[0].size(), sequence[0].data());
     tm2.compute(sequence[0].size(), sequence[0].data());
-    ASSERT_EQ(tm1.activeCells, tm2.activeCells);
-    ASSERT_EQ(tm1.winnerCells, tm2.winnerCells);
+    ASSERT_EQ(tm1.getActiveCells(), tm2.getActiveCells());
+    ASSERT_EQ(tm1.getWinnerCells(), tm2.getWinnerCells());
     ASSERT_EQ(tm1.connections, tm2.connections);
 
     tm1.compute(sequence[3].size(), sequence[3].data());
     tm2.compute(sequence[3].size(), sequence[3].data());
-    ASSERT_EQ(tm1.activeCells, tm2.activeCells);
+    ASSERT_EQ(tm1.getActiveCells(), tm2.getActiveCells());
 
-    ASSERT_EQ(tm1.activeSegments.size(), tm2.activeSegments.size());
-    for (size_t i = 0; i < tm1.activeSegments.size(); i++)
-    {
-      ASSERT_EQ(tm1.activeSegments[i].segment, tm2.activeSegments[i].segment);
-      ASSERT_EQ(tm1.activeSegments[i].overlap, tm2.activeSegments[i].overlap);
-    }
+    ASSERT_EQ(tm1.getActiveSegments(), tm2.getActiveSegments());
+    ASSERT_EQ(tm1.getMatchingSegments(), tm2.getMatchingSegments());
 
-    ASSERT_EQ(tm1.matchingSegments.size(), tm2.matchingSegments.size());
-    for (size_t i = 0; i < tm1.matchingSegments.size(); i++)
-    {
-      ASSERT_EQ(tm1.matchingSegments[i].segment, tm2.matchingSegments[i].segment);
-      ASSERT_EQ(tm1.matchingSegments[i].overlap, tm2.matchingSegments[i].overlap);
-    }
-
-    ASSERT_EQ(tm1.winnerCells, tm2.winnerCells);
+    ASSERT_EQ(tm1.getWinnerCells(), tm2.getWinnerCells());
     ASSERT_EQ(tm1.connections, tm2.connections);
 
     check_tm_eq(tm1, tm2);

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -37,43 +37,35 @@
 using namespace nupic::algorithms::temporal_memory;
 using namespace std;
 
+#define EPSILON 0.0000001
+
 namespace {
-  TemporalMemory tm;
-
-  // Forward declarations
-  bool check_vector_eq(vector<Cell>& vec1, vector<Cell>& vec2);
-  bool check_vector_eq(vector<Segment>& vec1, vector<Segment>& vec2);
-  bool check_set_eq(set<UInt>& vec1, set<UInt>& vec2);
-  bool check_set_eq(set<Cell>& vec1, set<Cell>& vec2);
-
-  void check_spatial_eq(
-    const TemporalMemory& tm1, 
-    const TemporalMemory& tm2);
-
-  void check_spatial_eq(const TemporalMemory& tm1, const TemporalMemory& tm2)
+  void check_tm_eq(const TemporalMemory& tm1, const TemporalMemory& tm2)
   {
-    ASSERT_TRUE(tm1.numberOfColumns() == tm2.numberOfColumns());
-    ASSERT_TRUE(tm1.getCellsPerColumn() == tm2.getCellsPerColumn());
-    ASSERT_TRUE(tm1.getActivationThreshold() == tm2.getActivationThreshold());
-    ASSERT_TRUE(tm1.getMinThreshold() == tm2.getMinThreshold());
-    ASSERT_TRUE(tm1.getMaxNewSynapseCount() == tm2.getMaxNewSynapseCount());
-    ASSERT_TRUE(nupic::nearlyEqual(tm1.getInitialPermanence(), tm2.getInitialPermanence()));
-    ASSERT_TRUE(nupic::nearlyEqual(tm1.getConnectedPermanence(), tm2.getConnectedPermanence()));
-    ASSERT_TRUE(nupic::nearlyEqual(tm1.getPermanenceIncrement(), tm2.getPermanenceIncrement()));
-    ASSERT_TRUE(nupic::nearlyEqual(tm1.getPermanenceDecrement(), tm2.getPermanenceDecrement()));
+    ASSERT_EQ(tm1.numberOfColumns(), tm2.numberOfColumns());
+    ASSERT_EQ(tm1.getCellsPerColumn(), tm2.getCellsPerColumn());
+    ASSERT_EQ(tm1.getActivationThreshold(), tm2.getActivationThreshold());
+    ASSERT_EQ(tm1.getMinThreshold(), tm2.getMinThreshold());
+    ASSERT_EQ(tm1.getMaxNewSynapseCount(), tm2.getMaxNewSynapseCount());
+    ASSERT_NEAR(tm1.getInitialPermanence(), tm2.getInitialPermanence(), EPSILON);
+    ASSERT_NEAR(tm1.getConnectedPermanence(), tm2.getConnectedPermanence(), EPSILON);
+    ASSERT_NEAR(tm1.getPermanenceIncrement(), tm2.getPermanenceIncrement(), EPSILON);
+    ASSERT_NEAR(tm1.getPermanenceDecrement(), tm2.getPermanenceDecrement(), EPSILON);
   }
 
-  void setup(TemporalMemory& tm, UInt numColumns)
+  vector<Cell> cellsForColumnCell(TemporalMemory& tm, UInt32 column)
   {
-    vector<UInt> columnDim;
-    columnDim.push_back(numColumns);
-    tm.initialize(columnDim);
+    vector<Cell> cellsInColumn;
+    for (CellIdx cell : tm.cellsForColumn(column))
+    {
+      cellsInColumn.push_back(Cell(cell));
+    }
+
+    return cellsInColumn;
   }
 
   TEST(TemporalMemoryTest, testInitInvalidParams)
   {
-    setup(tm, 2048);
-    
     // Invalid columnDimensions
     vector<UInt> columnDim = {};
     TemporalMemory tm1;
@@ -84,573 +76,452 @@ namespace {
     EXPECT_THROW(tm1.initialize(columnDim, 0), exception);
   }
 
-  TEST(TemporalMemoryTest, testActivateCorrectlyPredictiveCells)
+  TEST(TemporalMemoryTest, ActivateCorrectlyPredictiveCells)
   {
-    set<Cell> prevPredictiveCells = { Cell(0), Cell(237), Cell(1026), Cell(26337), Cell(26339), Cell(55536) };
-    set<Cell> prevMatchingCells;
-    set<UInt> activeColumns = { 32, 47, 823 };
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42
+      );
 
-    set<Cell> activeCells;
-    set<Cell> winnerCells;
-    set<UInt> predictedColumns;
-    set<Cell> predictedInactiveCells;
+    const UInt numActiveColumns = 4;
+    const UInt columns_a[4] = {0, 8, 16, 24};
+    const UInt columns_b[4] = {1, 9, 17, 25};
+    const vector<CellIdx> winners_a = {0, 33, 66, 98};
+    const vector<CellIdx> predicted_b = {4, 37, 70, 102};
 
-    tie(activeCells, winnerCells, predictedColumns, predictedInactiveCells) =
-      tm.activateCorrectlyPredictiveCells(
-        prevPredictiveCells, prevMatchingCells, activeColumns);
-
-    set<Cell> expectedCells = { Cell(1026), Cell(26337), Cell(26339) };
-    set<UInt> expectedCols = { 32, 823 };
-    set<Cell> expectedInactiveCells;
-    ASSERT_TRUE(check_set_eq(activeCells, expectedCells));
-    ASSERT_TRUE(check_set_eq(winnerCells, expectedCells));
-    ASSERT_TRUE(check_set_eq(predictedColumns, expectedCols));
-    ASSERT_TRUE(check_set_eq(predictedInactiveCells, expectedInactiveCells));
-  }
-
-  TEST(TemporalMemoryTest, testActivateCorrectlyPredictiveCellsEmpty)
-  {
+    for (CellIdx postsynaptic : predicted_b)
     {
-      set<Cell> prevPredictiveCells;
-      set<Cell> prevMatchingCells;
-      set<UInt> activeColumns;
-
-      set<Cell> activeCells;
-      set<Cell> winnerCells;
-      set<UInt> predictedColumns;
-      set<Cell> predictedInactiveCells;
-
-      tie(activeCells, winnerCells, predictedColumns, predictedInactiveCells) =
-        tm.activateCorrectlyPredictiveCells(
-          prevPredictiveCells, prevMatchingCells, activeColumns);
-
-      set<Cell> expectedCells;
-      set<UInt> expectedCols;
-      set<Cell> expectedInactiveCells;
-      ASSERT_TRUE(check_set_eq(activeCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(winnerCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(predictedColumns, expectedCols));
-      ASSERT_TRUE(check_set_eq(predictedInactiveCells, expectedInactiveCells));
+      Segment segment = tm.connections.createSegment(Cell(postsynaptic));
+      for (CellIdx presynaptic : winners_a)
+      {
+        tm.connections.createSynapse(segment, Cell(presynaptic), 0.5);
+      }
     }
 
-    // No previous predictive cells, with active columns
+    tm.compute(numActiveColumns, columns_a, false);
 
+    ASSERT_EQ(predicted_b, tm.getPredictiveCells());
+
+    tm.compute(numActiveColumns, columns_b, false);
+
+    EXPECT_EQ(predicted_b, tm.getActiveCells());
+  }
+
+  TEST(TemporalMemoryTest, BurstUnpredictedColumns)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 4;
+    const UInt columns_a[4] = {0, 8, 16, 24};
+    const vector<CellIdx> bursting_a = {0, 1, 2, 3,
+                                        32, 33, 34, 35,
+                                        64, 65, 66, 67,
+                                        96, 97, 98, 99};
+
+    tm.compute(numActiveColumns, columns_a, false);
+
+    EXPECT_EQ(bursting_a, tm.getActiveCells());
+  }
+
+  TEST(TemporalMemoryTest, BurstingAndNonBursting)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 4;
+    const UInt columns_a[4] = {0, 8, 16, 24};
+    const UInt columns_actual_b[4] = {1, 9, 20, 30};
+    const vector<CellIdx> winners_a = {0, 33, 66, 98};
+    const vector<CellIdx> predicted_b = {4, 37, 70, 102}; // columns {1, 9, 17, 25}
+    const vector<CellIdx> actual_b = {4,
+                                      37,
+                                      80, 81, 82, 83,
+                                      120, 121, 122, 123};
+
+    for (CellIdx postsynaptic : predicted_b)
     {
-      set<Cell> prevPredictiveCells;
-      set<Cell> prevMatchingCells;
-      set<UInt> activeColumns = { 32, 47, 823 };
-
-      set<Cell> activeCells;
-      set<Cell> winnerCells;
-      set<UInt> predictedColumns;
-      set<Cell> predictedInactiveCells;
-
-      tie(activeCells, winnerCells, predictedColumns, predictedInactiveCells) =
-        tm.activateCorrectlyPredictiveCells(
-          prevPredictiveCells, prevMatchingCells, activeColumns);
-
-      set<Cell> expectedCells;
-      set<UInt> expectedCols;
-      set<Cell> expectedInactiveCells;
-      ASSERT_TRUE(check_set_eq(activeCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(winnerCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(predictedColumns, expectedCols));
-      ASSERT_TRUE(check_set_eq(predictedInactiveCells, expectedInactiveCells));
+      Segment segment = tm.connections.createSegment(Cell(postsynaptic));
+      for (CellIdx presynaptic : winners_a)
+      {
+        tm.connections.createSynapse(segment, Cell(presynaptic), 0.5);
+      }
     }
 
-    // No active columns, with previously predictive cells
+    tm.compute(numActiveColumns, columns_a, false);
 
+    ASSERT_EQ(predicted_b, tm.getPredictiveCells());
+
+    tm.compute(numActiveColumns, columns_actual_b, false);
+
+    EXPECT_EQ(actual_b, tm.getActiveCells());
+  }
+
+  TEST(TemporalMemoryTest, ZeroActiveColumns)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*seed*/ 42
+      );
+
+    const UInt zeroColumns[0] = {};
+    const vector<CellIdx> zeroCells = {};
+
+    tm.compute(0, zeroColumns, true);
+
+    EXPECT_EQ(zeroCells, tm.getActiveCells());
+    EXPECT_EQ(zeroCells, tm.getPredictiveCells());
+
+    // Now make some cells predictive.
+
+    const UInt numActiveColumns = 4;
+    const UInt columns_a[4] = {0, 8, 16, 24};
+    const vector<CellIdx> winners_a = {0, 33, 66, 98};
+    const vector<CellIdx> predicted_b = {4, 37, 70, 102};
+
+    for (CellIdx postsynaptic : predicted_b)
     {
-      set<Cell> prevPredictiveCells = { Cell(0), Cell(237), Cell(1026), Cell(26337), Cell(26339), Cell(55536) };
-      set<Cell> prevMatchingCells;
-      set<UInt> activeColumns;
-
-      set<Cell> activeCells;
-      set<Cell> winnerCells;
-      set<UInt> predictedColumns;
-      set<Cell> predictedInactiveCells;
-
-      tie(activeCells, winnerCells, predictedColumns, predictedInactiveCells) =
-        tm.activateCorrectlyPredictiveCells(
-          prevPredictiveCells, prevMatchingCells, activeColumns);
-
-      set<Cell> expectedCells;
-      set<UInt> expectedCols;
-      set<Cell> expectedInactiveCells;
-      ASSERT_TRUE(check_set_eq(activeCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(winnerCells, expectedCells));
-      ASSERT_TRUE(check_set_eq(predictedColumns, expectedCols));
-      ASSERT_TRUE(check_set_eq(predictedInactiveCells, expectedInactiveCells));
+      Segment segment = tm.connections.createSegment(Cell(postsynaptic));
+      for (CellIdx presynaptic : winners_a)
+      {
+        tm.connections.createSynapse(segment, Cell(presynaptic), 0.5);
+      }
     }
+
+    tm.compute(numActiveColumns, columns_a, false);
+
+    ASSERT_EQ(predicted_b, tm.getPredictiveCells());
+
+    tm.compute(0, zeroColumns, true);
+
+    EXPECT_EQ(zeroCells, tm.getActiveCells());
+    EXPECT_EQ(zeroCells, tm.getPredictiveCells());
   }
 
-  TEST(TemporalMemoryTest, testActivateCorrectlyPredictiveCellsOrphan)
+  vector<Permanence> getPermanences(TemporalMemory& tm, Segment segment)
   {
-    TemporalMemory tm;
-    tm.initialize();
-    tm.setPredictedSegmentDecrement(0.001);
-
-    set<Cell> prevPredictiveCells;
-    set<UInt> activeColumns = { 32, 47, 823 };
-    set<Cell> prevMatchingCells = { 32, 47 };
-
-    set<Cell> activeCells;
-    set<Cell> winnerCells;
-    set<UInt> predictedColumns;
-    set<Cell> predictedInactiveCells;
-
-    tie(activeCells, winnerCells, predictedColumns, predictedInactiveCells) =
-      tm.activateCorrectlyPredictiveCells(
-        prevPredictiveCells,
-        prevMatchingCells,
-        activeColumns);
-
-    set<Cell> expectedCells;
-    set<UInt> expectedCols;
-    set<Cell> expectedInactiveCells = { 32, 47 };
-    ASSERT_TRUE(check_set_eq(activeCells, expectedCells));
-    ASSERT_TRUE(check_set_eq(winnerCells, expectedCells));
-    ASSERT_TRUE(check_set_eq(predictedColumns, expectedCols));
-    ASSERT_TRUE(check_set_eq(predictedInactiveCells, expectedInactiveCells));
-  }
-
-  TEST(TemporalMemoryTest, testBurstColumns)
-  {
-    TemporalMemory tm;
-    tm.initialize(vector<UInt>{2048}, 4);
-    tm.setConnectedPermanence(0.50);
-    tm.setMinThreshold(1);
-
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.6);
-    connections.createSynapse(segment, Cell(37), 0.4);
-    connections.createSynapse(segment, Cell(477), 0.9);
-
-    segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(49), 0.9);
-    connections.createSynapse(segment, Cell(3), 0.8);
-
-    segment = connections.createSegment(Cell(1));
-    connections.createSynapse(segment, Cell(733), 0.7);
-
-    segment = connections.createSegment(Cell(108));
-    connections.createSynapse(segment, Cell(486), 0.9);
-
-    set<UInt> activeColumns = { 0, 1, 26 };
-    set<UInt> predictiveCols = { 26 };
-    set<Cell> prevActiveCells = { Cell(23), Cell(37), Cell(49), Cell(733) };
-    set<Cell> prevWinnerCells = { Cell(23), Cell(37), Cell(49), Cell(733) };
-
-    set<Cell> activeCells;
-    set<Cell> winnerCells;
-    vector<Segment> learningSegments;
-
-    tie(activeCells, winnerCells, learningSegments) =
-      tm.burstColumns(activeColumns, predictiveCols, prevActiveCells, prevWinnerCells, connections);
-
-    set<Cell> expectedActiveCells = { Cell(0), Cell(1), Cell(2), Cell(3), Cell(4), Cell(5), Cell(6), Cell(7) };
-    set<Cell> expectedWinnerCells = { Cell(0), Cell(4) }; // 4 is randomly chosen cell
-    vector<Segment> expectedLearningSegments = { Segment(0, Cell(0)), Segment(0, Cell(4)) };
-    ASSERT_TRUE(check_set_eq(activeCells, expectedActiveCells));
-    ASSERT_TRUE(check_set_eq(winnerCells, expectedWinnerCells));
-    ASSERT_TRUE(check_vector_eq(learningSegments, expectedLearningSegments));
-
-    // Check that new segment was added to winner cell(4) in column 1
-    vector<Segment> segments = connections.segmentsForCell(4);
-    vector<Segment> expectedSegments = { Segment(0, Cell(4)) };
-    ASSERT_TRUE(check_vector_eq(segments, expectedSegments));
-  }
-
-  TEST(TemporalMemoryTest, testBurstColumnsEmpty)
-  {
-    set<UInt> activeColumns;
-    set<UInt> predictiveCols;
-    set<Cell> prevActiveCells;
-    set<Cell> prevWinnerCells;
-    Connections connections = tm.connections;
-
-    set<Cell> activeCells;
-    set<Cell> winnerCells;
-    vector<Segment> learningSegments;
-
-    tie(activeCells, winnerCells, learningSegments) =
-      tm.burstColumns(activeColumns, predictiveCols, prevActiveCells, prevWinnerCells, connections);
-
-    set<Cell> expectedActiveCells;
-    set<Cell> expectedWinnerCells;
-    vector<Segment> expectedLearningSegments;
-    ASSERT_TRUE(check_set_eq(activeCells, expectedActiveCells));
-    ASSERT_TRUE(check_set_eq(winnerCells, expectedWinnerCells));
-    ASSERT_TRUE(check_vector_eq(learningSegments, expectedLearningSegments));
-  }
-
-  TEST(TemporalMemoryTest, testLearnOnSegments)
-  {
-    vector<Synapse> synapses;
-    bool eq;
-
-    TemporalMemory tm;
-    setup(tm, 2048);
-    tm.setMaxNewSynapseCount(2);
-
-    Connections connections = tm.connections;
-    Segment segment0 = connections.createSegment(Cell(0));
-    connections.createSynapse(segment0, Cell(23), 0.6);
-    connections.createSynapse(segment0, Cell(37), 0.4);
-    connections.createSynapse(segment0, Cell(477), 0.9);
-
-    Segment segment1 = connections.createSegment(Cell(1));
-    connections.createSynapse(segment1, Cell(733), 0.7);
-
-    Segment segment2 = connections.createSegment(Cell(8));
-    connections.createSynapse(segment2, Cell(486), 0.9);
-
-    Segment segment3 = connections.createSegment(Cell(100));
-
-    vector<Segment> prevActiveSegments = { segment0, segment2 };
-    vector<Segment> learningSegments = { segment1, segment3 };
-    set<Cell> prevActiveCells = { Cell(23), Cell(37), Cell(733) };
-    set<Cell> winnerCells = { Cell(0) };
-    set<Cell> prevWinnerCells = { Cell(10), Cell(11), Cell(12), Cell(13), Cell(14) };
-    vector<Segment> prevMatchingSegments;
-    set<Cell> predictedInactiveCells;
-
-    tm.learnOnSegments(
-      prevActiveSegments,
-      learningSegments,
-      prevActiveCells,
-      winnerCells,
-      prevWinnerCells,
-      connections,
-      predictedInactiveCells,
-      prevMatchingSegments);
-
-    // Check segment 0
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment0)).permanence, Permanence(0.7));
-    EXPECT_TRUE(eq);
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(1, segment0)).permanence, Permanence(0.5));
-    EXPECT_TRUE(eq);
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(2, segment0)).permanence, Permanence(0.8));
-    EXPECT_TRUE(eq);
-
-    // Check segment 1
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment1)).permanence, Permanence(0.8));
-    EXPECT_TRUE(eq);
-    synapses = connections.synapsesForSegment(segment1);
-    ASSERT_EQ(synapses.size(), 2);
-
-    // Check segment 2
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment2)).permanence, Permanence(0.9));
-    EXPECT_TRUE(eq);
-    synapses = connections.synapsesForSegment(segment2);
-    ASSERT_EQ(synapses.size(), 1);
-
-    // Check segment 3
-    synapses = connections.synapsesForSegment(segment3);
-    ASSERT_EQ(synapses.size(), 2);
-  }
-
-  TEST(TemporalMemoryTest, testComputePredictiveCells)
-  {
-    TemporalMemory tm;
-    setup(tm, 2048);
-    tm.setActivationThreshold(2);
-    tm.setMinThreshold(2);
-    tm.setPredictedSegmentDecrement(0.004);
-
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.6);
-    connections.createSynapse(segment, Cell(37), 0.5);
-    connections.createSynapse(segment, Cell(477), 0.9);
-
-    segment = connections.createSegment(Cell(1));
-    connections.createSynapse(segment, Cell(733), 0.7);
-    connections.createSynapse(segment, Cell(733), 0.4);
-
-    segment = connections.createSegment(Cell(1));
-    connections.createSynapse(segment, Cell(974), 0.9);
-
-    segment = connections.createSegment(Cell(8));
-    connections.createSynapse(segment, Cell(486), 0.9);
-
-    segment = connections.createSegment(Cell(100));
-
-    set<Cell> activeCells = { Cell(23), Cell(37), Cell(733), Cell(974) };
-
-    vector<Segment> activeSegments;
-    set<Cell> predictiveCells;
-
-    vector<Segment> matchingSegments;
-    set<Cell> matchingCells;
-
-    tie(activeSegments, predictiveCells, matchingSegments, matchingCells) =
-      tm.computePredictiveCells(activeCells, connections);
-
-    vector<Segment> expectedActiveSegments = { Segment(0, Cell(0)) };
-    set<Cell> expectedPredictiveCells = { Cell(0) };
-    vector<Segment> expectedMatchingSegments = { Segment(0, Cell(0)), Segment(0, Cell(1)) };
-    set<Cell> expectedMatchingCells = { Cell(0), Cell(1) };
-    ASSERT_TRUE(check_vector_eq(activeSegments, expectedActiveSegments));
-    ASSERT_TRUE(check_set_eq(predictiveCells, expectedPredictiveCells));
-    ASSERT_TRUE(check_vector_eq(matchingSegments, expectedMatchingSegments));
-    ASSERT_TRUE(check_set_eq(matchingCells, expectedMatchingCells));
-  }
-
-  TEST(TemporalMemoryTest, testBestMatchingCell)
-  {
-    bool foundCell, foundSegment;
-    Cell bestCell;
-    Segment bestSegment;
-
-    TemporalMemory tm;
-    setup(tm, 2048);
-    tm.setConnectedPermanence(0.50);
-    tm.setMinThreshold(1);
-    tm.seed_(42);
-
-    Connections connections = tm.connections;
-
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.6);
-    connections.createSynapse(segment, Cell(37), 0.4);
-    connections.createSynapse(segment, Cell(477), 0.9);
-
-    segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(49), 0.9);
-    connections.createSynapse(segment, Cell(3), 0.8);
-
-    segment = connections.createSegment(Cell(1));
-    connections.createSynapse(segment, Cell(733), 0.7);
-
-    segment = connections.createSegment(Cell(108));
-    connections.createSynapse(segment, Cell(486), 0.9);
-
-    set<Cell> activeCells = { Cell(23), Cell(37), Cell(49), Cell(733) };
-    vector<Cell> cellsForColumn = tm.cellsForColumnCell(0);
-
-    tie(foundCell, bestCell, foundSegment, bestSegment) =
-      tm.bestMatchingCell(cellsForColumn, activeCells, connections);
-
-    ASSERT_EQ(bestCell, Cell(0));
-    ASSERT_EQ(bestSegment, Segment(0, Cell(0)));
-
-    cellsForColumn = tm.cellsForColumnCell(3);
-    tie(foundCell, bestCell, foundSegment, bestSegment) =
-      tm.bestMatchingCell(cellsForColumn, activeCells, connections);
-    ASSERT_EQ(bestCell, Cell(103)); // Random cell from column
-
-    cellsForColumn = tm.cellsForColumnCell(999);
-    tie(foundCell, bestCell, foundSegment, bestSegment) =
-      tm.bestMatchingCell(cellsForColumn, activeCells, connections);
-
-    ASSERT_EQ(bestCell, Cell(31979)); // Random cell from column
-  }
-
-  TEST(TemporalMemoryTest, testBestMatchingCellFewestSegments)
-  {
-    bool foundCell, foundSegment;
-    Cell cell;
-    Segment segment;
-
-    TemporalMemory tm;
-    tm.initialize(vector<UInt>{2}, 2);
-    tm.setConnectedPermanence(0.50);
-    tm.setMinThreshold(1);
-    tm.seed_(42);
-
-    Connections connections = tm.connections;
-    connections.createSynapse(connections.createSegment(Cell(0)), 3, 0.3);
-
-    set<Cell> activeSynapsesForSegment;
-
-    for (int i = 0; i < 100; i++)
+    vector<Permanence> perms;
+    for (Synapse synapse : tm.connections.synapsesForSegment(segment))
     {
-      // Never pick cell 0, always pick cell 1
-      vector<Cell> cellsForColumn = tm.cellsForColumnCell(0);
-      tie(foundCell, cell, foundSegment, segment) =
-        tm.bestMatchingCell(cellsForColumn, activeSynapsesForSegment, connections);
-      ASSERT_EQ(cell, Cell(1));
+      perms.push_back(tm.connections.dataForSynapse(synapse).permanence);
     }
+    return perms;
   }
 
-  TEST(TemporalMemoryTest, testBestMatchingSegment)
+  TEST(TemporalMemoryTest, ReinforceCorrectlyActiveSegments)
   {
-    Int numActiveSynapses;
-    Segment bestSegment;
-    bool found;
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*seed*/ 42
+      );
 
-    TemporalMemory tm;
-    setup(tm, 2048);
-    tm.setMinThreshold(1);
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> activeCells = {5};
+    const Cell activeCell = {5};
 
-    Connections connections = tm.connections;
+    Segment activeSegment1 = tm.connections.createSegment(activeCell);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[2], 0.5);
+    tm.connections.createSynapse(activeSegment1, Cell(81), 0.5);
+    tm.connections.createSynapse(activeSegment1, Cell(82), 0.01);
 
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.6);
-    connections.createSynapse(segment, Cell(37), 0.4);
-    connections.createSynapse(segment, Cell(477), 0.9);
+    // Verifies:
+    // - Active synapses reinforced
+    // - Inactive synapses punished
+    //   - 1 destroyed
+    // - No growth happens, despite the fact that there's another previous
+    //   active cell available
+    const vector<Permanence> activeSegment1_result = {0.60, 0.60, 0.60, 0.40};
 
-    segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(49), 0.9);
-    connections.createSynapse(segment, Cell(3), 0.8);
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
 
-    segment = connections.createSegment(Cell(1));
-    connections.createSynapse(segment, Cell(733), 0.7);
+    ASSERT_EQ(activeCells, tm.getActiveCells());
 
-    segment = connections.createSegment(Cell(8));
-    connections.createSynapse(segment, Cell(486), 0.9);
-
-    set<Cell> activeCells = { Cell(23), Cell(37), Cell(49), Cell(733) };
-
-    Cell cell;
-    cell.idx = 0;
-
-    tie(found, bestSegment, numActiveSynapses) = tm.bestMatchingSegment(cell, activeCells, connections);
-    if (found) ASSERT_EQ(bestSegment, Segment(0, Cell(0)));
-    ASSERT_EQ(numActiveSynapses, 2);
-
-    cell.idx = 1;
-    tie(found, bestSegment, numActiveSynapses) = tm.bestMatchingSegment(cell, activeCells, connections);
-    if (found) ASSERT_EQ(bestSegment, Segment(0, Cell(1)));
-    ASSERT_EQ(numActiveSynapses, 1);
-
-    cell.idx = 8;
-    tie(found, bestSegment, numActiveSynapses) = tm.bestMatchingSegment(cell, activeCells, connections);
-    ASSERT_EQ(found, false);
-
-    cell.idx = 100;
-    tie(found, bestSegment, numActiveSynapses) = tm.bestMatchingSegment(cell, activeCells, connections);
-    ASSERT_EQ(found, false);
+    EXPECT_EQ(activeSegment1_result, getPermanences(tm, activeSegment1));
   }
 
-  TEST(TemporalMemoryTest, testLeastUsedCell)
+  TEST(TemporalMemoryTest, SometimesReinforceCorrectlyMatchingSegments)
   {
-    TemporalMemory tm;
-    tm.initialize(vector<UInt>{2}, 2);
-    tm.seed_(42);
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*seed*/ 42
+      );
 
-    Connections connections = tm.connections;
-    connections.createSynapse(connections.createSegment(Cell(0)), 3, 0.3);
+    const UInt numActiveColumns = 2;
+    const UInt previousActiveColumns[2] = {0, 4};
+    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3},
+                                              {16}, {17}, {18}, {19}};
+    const UInt activeColumns[2] = {1, 5};
+    const vector<CellIdx> activeCells = {5,
+                                         20, 21, 22, 23};
+    const Cell previousInactiveCell = {81};
+    const Cell correctlyPredictedCell = {5};
 
-    set<Cell> cells;
-    Segment segment;
-    Cell cell;
-    bool foundCell, foundSegment;
+    // Create 4 segments:
+    // - 1 that predicts a column
+    // - 1 that matches the same cell
+    // - 1 that matches a cell in a bursting column, selected
+    // - 1 that matches a cell in a bursting column, not selected
 
-    for (int i = 0; i < 100; i++)
+    // Keep one of the columns from bursting
+    Segment correctlyActiveSegment =
+      tm.connections.createSegment(correctlyPredictedCell);
+    for (Cell cell : previousActiveCells)
     {
-      // Never pick cell 0, always pick cell 1
-      vector<Cell> cellsForColumn = tm.cellsForColumnCell(0);
-      tie(foundCell, cell, foundSegment, segment) =
-        tm.bestMatchingCell(cellsForColumn, cells, connections);
-      ASSERT_EQ(cell, Cell(1));
+      tm.connections.createSynapse(correctlyActiveSegment, cell, 0.5);
     }
+
+    // Matching segment on a cell that was predicted by another segment
+    Segment matchingSegment1 =
+      tm.connections.createSegment(correctlyPredictedCell);
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(matchingSegment1, previousInactiveCell, 0.80);
+    const vector<Permanence> matchingSegment1_result = {0.5, 0.5, 0.80};
+
+    // Matching segment in a bursting column: selected
+    Segment matchingSegment2 =
+      tm.connections.createSegment(Cell(21));
+    tm.connections.createSynapse(matchingSegment2, previousActiveCells[0], 0.4);
+    tm.connections.createSynapse(matchingSegment2, previousActiveCells[1], 0.4);
+    tm.connections.createSynapse(matchingSegment2, previousActiveCells[2], 0.4);
+    tm.connections.createSynapse(matchingSegment2, Cell(81), 0.8);
+    tm.connections.createSynapse(matchingSegment2, Cell(82), 0.01);
+
+    // Verifies:
+    // - Active synapses reinforced
+    // - New synapses grown
+    // - Inactive synapses punished
+    //   - 1 destroyed
+    const vector<Permanence> matchingSegment2_result = {0.5, 0.5, 0.5, 0.7, 0.2};
+
+    // Matching segment in a bursting column: not selected
+    Segment matchingSegment3 =
+      tm.connections.createSegment(Cell(22));
+    tm.connections.createSynapse(matchingSegment3, previousActiveCells[0], 0.4);
+    tm.connections.createSynapse(matchingSegment3, previousActiveCells[1], 0.4);
+    tm.connections.createSynapse(matchingSegment3, Cell(81), 0.8);
+    tm.connections.createSynapse(matchingSegment3, Cell(82), 0.01);
+    const vector<Permanence> matchingSegment3_result = {0.4, 0.4, 0.8, 0.01};
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    ASSERT_EQ(activeCells, tm.getActiveCells());
+
+    EXPECT_EQ(matchingSegment1_result, getPermanences(tm, matchingSegment1));
+    EXPECT_EQ(matchingSegment2_result, getPermanences(tm, matchingSegment2));
+    EXPECT_EQ(matchingSegment3_result, getPermanences(tm, matchingSegment3));
   }
 
-  TEST(TemporalMemoryTest, testAdaptSegment)
+  TEST(TemporalMemoryTest, PunishSegmentsInInactiveColumns)
   {
-    vector<Synapse> synapses;
-    bool eq;
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*seed*/ 42
+      );
 
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.6);
-    connections.createSynapse(segment, Cell(37), 0.4);
-    connections.createSynapse(segment, Cell(477), 0.9);
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> activeCells = {5};
+    const Cell previousInactiveCell = {81};
+    const Cell activeCell = {5};
 
-    synapses = vector<Synapse>{ Synapse(0, segment), Synapse(1, segment) };
+    // Predict the active column so that it's not bursting.
+    Segment correctlyActiveSegment = tm.connections.createSegment(activeCell);
+    for (Cell cell : previousActiveCells)
+    {
+      tm.connections.createSynapse(correctlyActiveSegment, cell, 0.5);
+    }
 
-    tm.adaptSegment(
-      segment, synapses, connections,  tm.getPermanenceIncrement(), tm.getPermanenceDecrement());
+    // Active segment on inactive cell
+    Segment activeSegment1 = tm.connections.createSegment(Cell(42));
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[2], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[3], 0.01);
+    tm.connections.createSynapse(activeSegment1, previousInactiveCell, 0.80);
+    const vector<Permanence> activeSegment1_result = {0.48, 0.48, 0.48, 0.80};
 
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment)).permanence, Permanence(0.7));
-    EXPECT_TRUE(eq);
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(1, segment)).permanence, Permanence(0.5));
-    EXPECT_TRUE(eq);
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(2, segment)).permanence, Permanence(0.8));
-    EXPECT_TRUE(eq);
+    // Matching segment on an inactive cell in an active column
+    Segment matchingSegment1 = tm.connections.createSegment(Cell(6));
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[0], 0.4);
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[1], 0.4);
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[2], 0.4);
+    tm.connections.createSynapse(matchingSegment1, previousActiveCells[3], 0.01);
+    tm.connections.createSynapse(matchingSegment1, previousInactiveCell, 0.80);
+    const vector<Permanence> matchingSegment1_result = {0.4, 0.4, 0.4, 0.01, 0.80};
+
+    // Matching segment on an inactive cell in an inactive column
+    Segment matchingSegment2 = tm.connections.createSegment(Cell(50));
+    tm.connections.createSynapse(matchingSegment2, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(matchingSegment2, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(matchingSegment2, previousInactiveCell, 0.80);
+    const vector<Permanence> matchingSegment2_result = {0.48, 0.48, 0.80};
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    ASSERT_EQ(activeCells, tm.getActiveCells());
+
+    EXPECT_EQ(activeSegment1_result, getPermanences(tm, activeSegment1));
+    EXPECT_EQ(matchingSegment1_result, getPermanences(tm, matchingSegment1));
+    EXPECT_EQ(matchingSegment2_result, getPermanences(tm, matchingSegment2));
   }
 
-  TEST(TemporalMemoryTest, testAdaptSegmentToMax)
+  TEST(TemporalMemoryTest, AddSegmentToCellWithFewestSegments)
   {
-    vector<Synapse> synapses;
-    bool eq;
+    bool grewOnCell1 = false;
+    bool grewOnCell2 = false;
+    for (UInt seed = 0; seed < 100; seed++)
+    {
+      TemporalMemory tm(
+        /*columnDimensions*/ {32},
+        /*cellsPerColumn*/ 4,
+        /*activationThreshold*/ 3,
+        /*initialPermanence*/ 0.2,
+        /*connectedPermanence*/ 0.50,
+        /*minThreshold*/ 2,
+        /*maxNewSynapseCount*/ 4,
+        /*permanenceIncrement*/ 0.10,
+        /*permanenceDecrement*/ 0.10,
+        /*predictedSegmentDecrement*/ 0.02,
+        /*seed*/ seed
+        );
 
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    synapses.push_back(connections.createSynapse(segment, Cell(23), 0.9));
+      // enough for 4 winner cells
+      const UInt previousActiveColumns[4] ={1, 2, 3, 4};
+      const UInt activeColumns[1] = {0};
+      const vector<Cell> previousActiveCells =
+        {{4}, {5}, {6}, {7}}; // (there are more)
+      vector<Cell> nonmatchingCells = {{0}, {3}};
+      vector<CellIdx> activeCells = {0, 1, 2, 3};
 
-    tm.adaptSegment(
-      segment, synapses, connections, tm.getPermanenceIncrement(), tm.getPermanenceDecrement());
+      Segment segment1 = tm.connections.createSegment(nonmatchingCells[0]);
+      tm.connections.createSynapse(segment1, previousActiveCells[0], 0.5);
+      Segment segment2 = tm.connections.createSegment(nonmatchingCells[1]);
+      tm.connections.createSynapse(segment2, previousActiveCells[1], 0.5);
 
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment)).permanence, Permanence(1.0));
-    EXPECT_TRUE(eq);
+      tm.compute(4, previousActiveColumns, true);
+      tm.compute(1, activeColumns, true);
 
-    // Now permanence should be at min
-    tm.adaptSegment(
-      segment, synapses, connections, tm.getPermanenceIncrement(), tm.getPermanenceDecrement());
+      ASSERT_EQ(activeCells, tm.getActiveCells());
 
-    eq = nupic::nearlyEqual(connections.dataForSynapse(Synapse(0, segment)).permanence, Permanence(1.0));
-    EXPECT_TRUE(eq);
-  }
+      EXPECT_EQ(3, tm.connections.numSegments());
+      EXPECT_EQ(1, tm.connections.segmentsForCell({0}).size());
+      EXPECT_EQ(1, tm.connections.segmentsForCell({3}).size());
+      EXPECT_EQ(1, tm.connections.numSynapses(segment1));
+      EXPECT_EQ(1, tm.connections.numSynapses(segment2));
 
-  TEST(TemporalMemoryTest, testAdaptSegmentToMin)
-  {
-    vector<Synapse> synapses;
+      Segment grownSegment;
+      vector<Segment> segments = tm.connections.segmentsForCell({1});
+      if (segments.empty())
+      {
+        vector<Segment> segments2 = tm.connections.segmentsForCell({2});
+        EXPECT_FALSE(segments2.empty());
+        grewOnCell2 = true;
+        segments.insert(segments.end(), segments2.begin(), segments2.end());
+      }
+      else
+      {
+        grewOnCell1 = true;
+      }
 
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, Cell(23), 0.1);
+      ASSERT_EQ(1, segments.size());
+      vector<Synapse> synapses = tm.connections.synapsesForSegment(segments[0]);
+      EXPECT_EQ(4, synapses.size());
 
-    tm.adaptSegment(
-      segment, synapses, connections, tm.getPermanenceIncrement(), tm.getPermanenceDecrement());
+      set<Cell> columnChecklist(previousActiveColumns, previousActiveColumns+4);
 
-    synapses = connections.synapsesForSegment(segment);
-    ASSERT_EQ(synapses.size(), 0);
-  }
+      for (Synapse synapse : synapses)
+      {
+        SynapseData synapseData = tm.connections.dataForSynapse(synapse);
+        EXPECT_NEAR(0.2, synapseData.permanence, EPSILON);
 
-  TEST(TemporalMemoryTest, testPickCellsToLearnOn)
-  {
-    TemporalMemory tm;
-    setup(tm, 2048);
-    tm.seed_(42);
+        UInt32 column = (UInt)tm.columnForCell(synapseData.presynapticCell);
+        auto position = columnChecklist.find(column);
+        EXPECT_NE(columnChecklist.end(), position);
+        columnChecklist.erase(position);
+      }
+      EXPECT_TRUE(columnChecklist.empty());
+    }
 
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-
-    set<Cell> winnerCells = { Cell(4), Cell(47), Cell(58), Cell(93) };
-    set<Cell> learningCells, expectedCells;
-
-    expectedCells = set<Cell>{ Cell(4), Cell(93) }; // Randomly picked
-    learningCells = tm.pickCellsToLearnOn(2, segment, winnerCells, connections);
-    ASSERT_TRUE(check_set_eq(learningCells, expectedCells));
-
-    expectedCells = set<Cell>{ Cell(4), Cell(47), Cell(58), Cell(93) };
-    learningCells = tm.pickCellsToLearnOn(100, segment, winnerCells, connections);
-    ASSERT_TRUE(check_set_eq(learningCells, expectedCells));
-
-    expectedCells = set<Cell>{};
-    learningCells = tm.pickCellsToLearnOn(0, segment, winnerCells, connections);
-    ASSERT_TRUE(check_set_eq(learningCells, expectedCells));
-  }
-
-  TEST(TemporalMemoryTest, testPickCellsToLearnOnAvoidDuplicates)
-  {
-    TemporalMemory tm;
-    setup(tm, 2048);
-
-    Connections connections = tm.connections;
-    Segment segment = connections.createSegment(Cell(0));
-    connections.createSynapse(segment, 23, 0.6);
-
-    set<Cell> winnerCells = { Cell(23) };
-
-    // Ensure that no additional(duplicate) cells were picked
-    set<Cell> expectedCells;
-    set<Cell> learningCells = tm.pickCellsToLearnOn(2, segment, winnerCells, connections);
-    ASSERT_TRUE(check_set_eq(learningCells, expectedCells));
+    EXPECT_TRUE(grewOnCell1);
+    EXPECT_TRUE(grewOnCell2);
   }
 
   TEST(TemporalMemoryTest, testColumnForCell1D)
@@ -708,28 +579,17 @@ namespace {
     tm.initialize(vector<UInt>{2048}, 5);
 
     vector<Cell> expectedCells = { Cell(5), Cell(6), Cell(7), Cell(8), Cell(9) };
-    vector<Cell> cellsForColumn = tm.cellsForColumnCell(1);
-    ASSERT_TRUE(check_vector_eq(cellsForColumn, expectedCells));
+    vector<Cell> cellsForColumn = cellsForColumnCell(tm, 1);
+    ASSERT_EQ(expectedCells, cellsForColumn);
   }
 
   TEST(TemporalMemoryTest, testCellsForColumn2D)
   {
     TemporalMemory tm;
     tm.initialize(vector<UInt>{64, 64}, 4);
-
     vector<Cell> expectedCells = { Cell(256), Cell(257), Cell(258), Cell(259) };
-    vector<Cell> cellsForColumn = tm.cellsForColumnCell(64);
-    ASSERT_TRUE(check_vector_eq(cellsForColumn, expectedCells));
-  }
-
-  TEST(TemporalMemoryTest, testCellsForColumnInvalidColumn)
-  {
-    TemporalMemory tm;
-    tm.initialize(vector<UInt>{64, 64}, 4);
-
-    EXPECT_NO_THROW(tm.cellsForColumnCell(4095));
-    EXPECT_THROW(tm.cellsForColumnCell(4096), std::exception);
-    EXPECT_THROW(tm.cellsForColumnCell(-1), std::exception);
+    vector<Cell> cellsForColumn = cellsForColumnCell(tm, 64);
+    ASSERT_EQ(expectedCells, cellsForColumn);
   }
 
   TEST(TemporalMemoryTest, testNumberOfColumns)
@@ -748,22 +608,6 @@ namespace {
 
     Int numberOfCells = tm.numberOfCells();
     ASSERT_EQ(numberOfCells, 64 * 64 * 32);
-  }
-
-  TEST(TemporalMemoryTest, testMapCellsToColumns)
-  {
-    TemporalMemory tm;
-    tm.initialize(vector<UInt>{100}, 4);
-
-    set<Cell> cells = { Cell(0), Cell(1), Cell(2), Cell(5), Cell(399) };
-    map<Int, set<Cell>> columnsForCells = tm.mapCellsToColumns(cells);
-
-    set<Cell> expectedCells = { Cell(0), Cell(1), Cell(2) };
-    ASSERT_TRUE(check_set_eq(columnsForCells[0], expectedCells));
-    expectedCells = { Cell(5) };
-    ASSERT_TRUE(check_set_eq(columnsForCells[1], expectedCells));
-    expectedCells = { Cell(399) };
-    ASSERT_TRUE(check_set_eq(columnsForCells[99], expectedCells));
   }
 
   TEST(TemporalMemoryTest, testSaveLoad)
@@ -785,7 +629,7 @@ namespace {
     tm2.load(infile);
     infile.close();
 
-    check_spatial_eq(tm1, tm2);
+    check_tm_eq(tm1, tm2);
 
     int ret = ::remove(filename);
     ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
@@ -799,17 +643,17 @@ namespace {
 
     // Run some data through before serializing
     /*
-    PatternMachine patternMachine = PatternMachine(100, 4);
-    SequenceMachine sequenceMachine = SequenceMachine(self.patternMachine);
-    Sequence sequence = self.sequenceMachine.generateFromNumbers(range(5));
+      PatternMachine patternMachine = PatternMachine(100, 4);
+      SequenceMachine sequenceMachine = SequenceMachine(self.patternMachine);
+      Sequence sequence = self.sequenceMachine.generateFromNumbers(range(5));
     */
     vector<vector<UInt>> sequence = 
-    { 
-      { 83, 53, 70, 45 },
-      { 8, 65, 67, 59 },
-      { 25, 98, 99, 39 },
-      { 66, 11, 78, 14 },
-      { 96, 87, 69, 95 } };
+      { 
+        { 83, 53, 70, 45 },
+        { 8, 65, 67, 59 },
+        { 25, 98, 99, 39 },
+        { 66, 11, 78, 14 },
+        { 96, 87, 69, 95 } };
 
     for (UInt i = 0; i < 3; i++)
     {
@@ -823,72 +667,35 @@ namespace {
     tm2.read(ss);
 
     // Check that the two temporal memory objects have the same attributes
-    check_spatial_eq(tm1, tm2);
+    check_tm_eq(tm1, tm2);
 
     tm1.compute(sequence[0].size(), sequence[0].data());
     tm2.compute(sequence[0].size(), sequence[0].data());
     ASSERT_EQ(tm1.activeCells, tm2.activeCells);
-    ASSERT_EQ(tm1.predictiveCells, tm2.predictiveCells);
     ASSERT_EQ(tm1.winnerCells, tm2.winnerCells);
     ASSERT_EQ(tm1.connections, tm2.connections);
 
     tm1.compute(sequence[3].size(), sequence[3].data());
     tm2.compute(sequence[3].size(), sequence[3].data());
     ASSERT_EQ(tm1.activeCells, tm2.activeCells);
-    ASSERT_EQ(tm1.predictiveCells, tm2.predictiveCells);
+
+    ASSERT_EQ(tm1.activeSegments.size(), tm2.activeSegments.size());
+    for (size_t i = 0; i < tm1.activeSegments.size(); i++)
+    {
+      ASSERT_EQ(tm1.activeSegments[i].segment, tm2.activeSegments[i].segment);
+      ASSERT_EQ(tm1.activeSegments[i].overlap, tm2.activeSegments[i].overlap);
+    }
+
+    ASSERT_EQ(tm1.matchingSegments.size(), tm2.matchingSegments.size());
+    for (size_t i = 0; i < tm1.matchingSegments.size(); i++)
+    {
+      ASSERT_EQ(tm1.matchingSegments[i].segment, tm2.matchingSegments[i].segment);
+      ASSERT_EQ(tm1.matchingSegments[i].overlap, tm2.matchingSegments[i].overlap);
+    }
+
     ASSERT_EQ(tm1.winnerCells, tm2.winnerCells);
     ASSERT_EQ(tm1.connections, tm2.connections);
-  }
 
-  bool check_set_eq(set<UInt>& vec1, set<UInt>& vec2)
-  {
-    if (vec1.size() != vec2.size()) {
-      return false;
-    }
-    for (UInt i : vec2) {
-      if (vec1.find(i) == vec1.end()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool check_set_eq(set<Cell>& vec1, set<Cell>& vec2)
-  {
-    if (vec1.size() != vec2.size()) {
-      return false;
-    }
-    for (Cell cell : vec2) {
-      if (vec1.find(cell) == vec1.end()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool check_vector_eq(vector<Cell>& vec1, vector<Cell>& vec2)
-  {
-    if (vec1.size() != vec2.size()) {
-      return false;
-    }
-    for (UInt i = 0; i < vec1.size(); i++) {
-      if (vec1[i].idx != vec2[i].idx) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool check_vector_eq(vector<Segment>& vec1, vector<Segment>& vec2)
-  {
-    if (vec1.size() != vec2.size()) {
-      return false;
-    }
-    for (UInt i = 0; i < vec1.size(); i++) {
-      if (vec1[i].idx != vec2[i].idx || vec1[i].cell.idx != vec2[i].cell.idx) {
-        return false;
-      }
-    }
-    return true;
+    check_tm_eq(tm1, tm2);
   }
 } // end namespace nupic

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -258,7 +258,7 @@ namespace {
     tm.compute(1, activeColumns, false);
 
     vector<CellIdx> winnerCells = tm.getWinnerCells();
-    EXPECT_EQ(1, winnerCells.size());
+    ASSERT_EQ(1, winnerCells.size());
     EXPECT_TRUE(burstingCells.find(winnerCells[0]) != burstingCells.end());
   }
 


### PR DESCRIPTION
To describe this change, I'll start by describing the current code.

Currently the TemporalMemory algorithm is implemented as a series of phases:

- Activate the correctly predictive cells.
- Burst unpredicted columns.
- Perform learning by adapting segments.
- Compute predictive cells due to lateral input on distal dendrites

Through all of this, it's maintaining a central set of data: activeColumns, activeCells, winnerCells, predictedActiveColumns, predictedInactiveCells, predictiveCells, matchingCells, learningSegments, activeSegments, matchingSegments.

Phases 1 and 2 each append to the data. Phases 1, 2, and 3 do lookups in the data.

Phase 1 walks the predicted cells, checking which are active, doing one set lookup per predicted cell. Similarly, it walks the matching cells, doing one set lookup per matching cell. For each predicted/matching cell, it does a set insertion.

Phase 2 does a set difference to figure out the unpredicted active columns. For each, it does a set insertion. It scans all segments in the column, looks at all their synapses, figures out the best, and it saves a learning segment.

Phase 3 combines all of the active and learning segments. For each segment, it does two set lookups to figure out whether the segment is from a correctly predicted cell or learning bursting cell. Then, for each matching segment it does a set lookup to see if it's in an inactive column.

Phase 4 uses the active cells and connections to figure out the new cell excitations.


You could optimize this, kinda. Some of those set lookups aren't necessary. You could use the matchingSegments during Phase 3 to avoid repeating work from Phase 4 of the previous step. But this "phases" approach will always do two bad things:

- It throws away context, then has to infer it again later. (e.g. set lookups).  When Phase 1 finds a segment, the code has a lot of context, e.g. the fact that the segment correctly predicted a column. Later when Phase 3 finds this segment, it has to reinfer the same context.
- It builds central collections of transient data. That's a lot of memory allocations to do per timestep. It's accessing memory all over the place. There will be cache misses.

This change merges phases 1 - 3 , eliminates every set lookup/insert/difference that I mentioned above, and abolishes the central bundle of transient data. With a single O(n) pass, it finds every bursting column, non-bursting column, and predicted inactive column. To accomplish this, once per timestep it does a O(n log n) sort of the active columns, the active segments, and the matching segments.

The segment learning all happens during the O(n) pass. Now the learning segments are selected in O(nMatchingSegments). For each learning segment, learning is still O(nSynapsesOnSegment log nActiveCells). So, selection is much faster, but the actual learning is the same.

The only data that's maintained during TemporalMemory::compute is the non-transient data, i.e. the data that we serialize. The CPU spends its time accessing the stack and sequentially accessing memory on the heap (a few vectors). We do all needed processing for a column, then we move on, so there's no need to preserve information for future phases. This is all designed around abolishing cache misses.


I call this O(n) pass the `columnSegmentWalk`. By organizing it this way, TemporalMemory::compute is very readable. You can basically read the entire TemporalMemory algorithm by reading `TemporalMemory::compute`. The code is less complicated because it no longer has to infer the same context multiple times.


The existing TemporalMemory unit tests don't call `TemporalMemory::compute`, they instead call phase methods. So I had to create a fresh set of unit tests. They call `compute`, so they'll survive future changes.

Fixes #916

Here's the output for:

~~~
python $NUPIC/scripts/temporal_memory_performance_benchmark.py
~~~

Reference:
TP10X2: 1.684118s

Before:
TM (C++): 1.555487s

After:
TM (C++): 0.269989s