### PR TITLE
Disable asserts in release builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,11 +71,15 @@ set(src_compiler_definitions
     -DNTA_INTERNAL
     -DBOOST_NO_WREGEX
     -DNUPIC2
-    -DNTA_ASSERTIONS_ON
     -DNTA_ASM
     -DAPR_DECLARE_STATIC
     -DAPU_DECLARE_STATIC)
 
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+  set(src_compiler_definitions
+      ${src_compiler_definitions}
+      -DNTA_ASSERTIONS_ON)
+endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(src_compiler_definitions

--- a/src/nupic/engine/RegionImpl.cpp
+++ b/src/nupic/engine/RegionImpl.cpp
@@ -230,7 +230,11 @@ void RegionImpl::setParameterArray(const std::string& name, Int64 index,const Ar
       break;
     }
 
-    NTA_ASSERT(rc == 0) << "getParameterArray - failure to get parameter '" << name << "' on node of type " << getType();
+    if (rc != 0)
+    {
+      NTA_THROW << "setParameterArray - failure to set parameter '" << name <<
+        "' on node of type " << getType();
+    }
   }
 
   ReadBuffer rb(wb.getData(), wb.getSize(), false);


### PR DESCRIPTION
Fixes #928

I verified that the expression inside NTA_ASSERT is no longer evaluated on release builds.