### PR TITLE
Build debug and release mode in Bamboo

### DIFF
--- a/ci/bamboo/build-linux-debug.sh
+++ b/ci/bamboo/build-linux-debug.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+set -o xtrace
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Run the common setup
+${DIR}/setup-dependencies.sh
+
+# Install nupic.core dependencies
+pip install \
+    --cache-dir /usr/local/src/nupic.core/pip-cache \
+    --build /usr/local/src/nupic.core/pip-build \
+    --no-clean \
+    pycapnp==0.5.5 \
+    -r bindings/py/requirements.txt
+
+# Build and install nupic.core
+mkdir -p build/scripts
+cmake -DCMAKE_BUILD_TYPE=Debug -DNTA_COV_ENABLED=ON -DCMAKE_INSTALL_PREFIX=`pwd`/build/release -DPY_EXTENSIONS_DIR=`pwd`/bindings/py/nupic/bindings .
+make install
+./build/release/bin/cpp_region_test
+./build/release/bin/unit_tests
+
+# Build installable python packages
+python setup.py install
+py.test bindings/py/tests

--- a/ci/bamboo/build-linux-release.sh
+++ b/ci/bamboo/build-linux-release.sh
@@ -17,7 +17,7 @@ pip install \
 
 # Build and install nupic.core
 mkdir -p build/scripts
-cmake . -DNTA_COV_ENABLED=ON -DCMAKE_INSTALL_PREFIX=`pwd`/build/release -DPY_EXTENSIONS_DIR=`pwd`/bindings/py/nupic/bindings
+cmake -DCMAKE_INSTALL_PREFIX=`pwd`/build/release -DPY_EXTENSIONS_DIR=`pwd`/bindings/py/nupic/bindings .
 make install
 ./build/release/bin/cpp_region_test
 ./build/release/bin/unit_tests

--- a/ci/bamboo/build-linux.sh
+++ b/ci/bamboo/build-linux.sh
@@ -2,45 +2,10 @@
 set -o errexit
 set -o xtrace
 
-# Environment defaults
-if [ -z "${USER}" ]; then
-    USER="docker"
-fi
-export USER
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Setup compiler
-if [ -z "${CC}" ]; then
-    CC="gcc"
-fi
-export CC
-
-if [ "${CC}" = "clang" ]; then
-    if [ -z "${CXX}" ]; then
-        CXX="clang++"
-    fi
-    COMPILER_PACKAGES="clang-3.4" # Ubuntu-specific apt package name
-else
-    if [ -z "${CXX}" ]; then
-        CXX="g++"
-    fi
-    COMPILER_PACKAGES="${CC} ${CXX}" # Ubuntu-specific apt package names
-fi
-export CXX
-
-# Install OS dependencies, assuming stock ubuntu:latest
-apt-get update
-apt-get install -y \
-    curl \
-    wget \
-    git-core \
-    ${COMPILER_PACKAGES} \
-    cmake \
-    python \
-    python2.7 \
-    python2.7-dev
-wget https://bootstrap.pypa.io/get-pip.py -O - | python
-pip install --upgrade --ignore-installed setuptools
-pip install wheel
+# Run the common setup
+${DIR}/setup-dependencies.sh
 
 # Install nupic.core dependencies
 pip install \

--- a/ci/bamboo/setup-dependencies.sh
+++ b/ci/bamboo/setup-dependencies.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Environment defaults
+if [ -z "${USER}" ]; then
+    USER="docker"
+fi
+export USER
+
+# Setup compiler
+if [ -z "${CC}" ]; then
+    CC="gcc"
+fi
+export CC
+
+if [ "${CC}" = "clang" ]; then
+    if [ -z "${CXX}" ]; then
+        CXX="clang++"
+    fi
+    COMPILER_PACKAGES="clang-3.4" # Ubuntu-specific apt package name
+else
+    if [ -z "${CXX}" ]; then
+        CXX="g++"
+    fi
+    COMPILER_PACKAGES="${CC} ${CXX}" # Ubuntu-specific apt package names
+fi
+export CXX
+
+# Install OS dependencies, assuming stock ubuntu:latest
+apt-get update
+apt-get install -y \
+    curl \
+    wget \
+    git-core \
+    ${COMPILER_PACKAGES} \
+    cmake \
+    python \
+    python2.7 \
+    python2.7-dev
+wget https://bootstrap.pypa.io/get-pip.py -O - | python
+pip install --upgrade --ignore-installed setuptools
+pip install wheel


### PR DESCRIPTION
@oxtopus please review
@mrcslws fyi

fixes #941

This splits the Bamboo build script for linux into two:

- One builds in debug mode with coverage enabled and does not produce eggs or wheels. The coverage info will be extracted from this job.
- One builds in release mode with coverage disabled and produces binary and source distributions. The release artifacts will be extracted from this job.