### PR TITLE
Timer: test drift

### DIFF
--- a/src/test/unit/os/TimerTest.cpp
+++ b/src/test/unit/os/TimerTest.cpp
@@ -68,3 +68,16 @@ TEST(TimerTest, Basic)
   t1.stop();
   ASSERT_EQ(t1.getStartCount(), 2);
 }
+
+TEST(TimerTest, Drift)
+{
+// Test start/stop delay accumulation
+  Timer t;
+  const UInt EPOCHS = 1000000; // 1M
+  const UInt EPSILON = 5; // tolerate 5us drift on 1M restarts
+  for(UInt i=0; i<EPOCHS; i++){
+    t.start();
+    t.stop(); //immediately
+  }
+  ASSERT_LT(t.getElapsed(), EPSILON);
+}


### PR DESCRIPTION
I was just curious if the `Timer` does not accumulate any delay drift over many consecutive restarts. 
Seems that it does not :+1: 
A tiny unit-test, I thought I'd share it when I wrote it. 

Fixes #965