### PR TITLE
Makefile modifications required for gcc-4.9 (fixes #981)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 get_filename_component(REPOSITORY_DIR ${PROJECT_SOURCE_DIR} ABSOLUTE)
 
+# gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+# fixes #981
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+    set(CMAKE_AR "/usr/bin/gcc-ar")
+    set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")
+  ENDIF()
+ENDIF()
 
 if( POLICY CMP0046 )
   cmake_policy(VERSION 2.8)

--- a/external/Apr1Lib.cmake
+++ b/external/Apr1Lib.cmake
@@ -88,7 +88,14 @@ else()
             -DCMAKE_C_FLAGS=${aprlib_cflags}
             -DCMAKE_INSTALL_PREFIX=${aprlib_install_prefix}
             -DINSTALL_PDB=OFF
-
+         # gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+	 # fixes #981
+	IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	  ENDIF()
+	ENDIF()
 
         #LOG_INSTALL 1
     )

--- a/external/AprUtil1Lib.cmake
+++ b/external/AprUtil1Lib.cmake
@@ -93,6 +93,14 @@ else()
             -DAPR_INCLUDE_DIR=${LIB_STATIC_APR1_INC_DIR}/apr-1
             -DAPR_LIBRARIES=${LIB_STATIC_APR1_LOC}
             -DINSTALL_PDB=OFF
+	# gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+	# fixes #981
+	IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	  ENDIF()
+	ENDIF()
 
         #LOG_INSTALL 1
     )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -24,6 +24,15 @@ project(nupic_core_main CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+# fixes #981
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+    set(CMAKE_AR "/usr/bin/gcc-ar")
+    set(CMAKE_RANLIB "/usr/bin/gcc-ranlib")
+  ENDIF()
+ENDIF()
+
 set_directory_properties(PROPERTIES EP_BASE "${EP_BASE}")
 
 # Shorter aliases for static library prefix and suffix.

--- a/external/CapnProto.cmake
+++ b/external/CapnProto.cmake
@@ -81,6 +81,14 @@ ExternalProject_Add(CapnProto
       -DCMAKE_CXX_FLAGS=${capnp_cxx_flags}
       -DCMAKE_EXE_LINKER_FLAGS=${capnp_linker_flags}
       -DCMAKE_INSTALL_PREFIX=${EP_BASE}/Install
+      # gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+      # fixes #981
+      IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	ENDIF()
+      ENDIF()
 )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/external/YamlCppLib.cmake
+++ b/external/YamlCppLib.cmake
@@ -52,4 +52,12 @@ ExternalProject_Add(YamlCppStaticLib
         -DCMAKE_C_FLAGS=${c_flags}
         -DCMAKE_CXX_FLAGS=${cxx_flags}
         -DCMAKE_INSTALL_PREFIX=${yamlcpplib_install_prefix}
+        # gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+	# fixes #981
+	IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	  ENDIF()
+	ENDIF()
 )

--- a/external/YamlLib.cmake
+++ b/external/YamlLib.cmake
@@ -49,4 +49,12 @@ ExternalProject_Add(YamlStaticLib
         -DBUILD_SHARED_LIBS=OFF
         -DCMAKE_C_FLAGS=${c_flags}
         -DCMAKE_INSTALL_PREFIX=${yamllib_build_dir}
+        # gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+	# fixes #981
+	IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	  ENDIF()
+	ENDIF()
 )

--- a/external/Zlib.cmake
+++ b/external/Zlib.cmake
@@ -62,4 +62,12 @@ ExternalProject_Add(ZStaticLib
         -DINSTALL_LIB_DIR=${zlib_install_lib_dir}
         -DINSTALL_MAN_DIR=${zlib_install_prefix}/man
         -DINSTALL_PKGCONFIG_DIR=${zlib_install_prefix}/pkgconfig
+        # gcc v4.9 requires its own binutils-wrappers for LTO (flag -flto)
+	# fixes #981
+	IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  	  IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
+            CMAKE_ARGS ${CMAKE_ARGS} -DCMAKE_AR=/usr/bin/gcc-ar
+             -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
+	  ENDIF()
+	ENDIF()
 )


### PR DESCRIPTION
Fixes #981

This fix adds conditional cmake parameters that are required to build nupic.core with gcc version 4.9 (and higher) in combination with LTO (-flto). gcc >= 4.9 requires to use its own wrappers for ar, nm and ranlib instead of the regular binutils versions.

Configuration/generation works as usual:

`cmake $NUPIC_CORE -DCMAKE_INSTALL_PREFIX=../release -DPY_EXTENSIONS_DIR=$NUPIC_CORE/bindings/py/nupic/bindings` 

*** Note ****
There's currently a bug in CMAKE that prevents CMAKE from using these variables also for subsequent makefile generations (https://cmake.org/Bug/view.php?id=15547), so CMAKE will pick the wrong (non-gcc) versions of ar and ranlib. To prevent this, make must be executed with some additional environment variables set:

`AR=gcc-ar NM=gcc-nm RANLIB=gcc-ranlib make`

Works fine on Ubuntu 15.10 with gcc-4.9.3, should also work on later versions.