### PR TITLE
deprecate-spec-vars set defaults for deprecated variables

### DIFF
--- a/src/nupic/engine/Spec.cpp
+++ b/src/nupic/engine/Spec.cpp
@@ -89,7 +89,6 @@ std::string Spec::getDefaultOutputName() const
   return name;
 }
 
-
 InputSpec::InputSpec(std::string description, 
                      NTA_BasicType  dataType, 
                      UInt32 count,

--- a/src/nupic/engine/Spec.hpp
+++ b/src/nupic/engine/Spec.hpp
@@ -33,7 +33,7 @@ Definition of Spec data structures
 #include <map>
 
 namespace nupic
-{ 
+{
   class InputSpec
   {
   public:  

--- a/src/nupic/engine/Spec.hpp
+++ b/src/nupic/engine/Spec.hpp
@@ -33,7 +33,7 @@ Definition of Spec data structures
 #include <map>
 
 namespace nupic
-{
+{ 
   class InputSpec
   {
   public:  
@@ -54,15 +54,16 @@ namespace nupic
     UInt32 count; 
     // TBD. Omit? what is "required"? Is it ok to be zero length?
     bool required;
-    bool regionLevel;
+    bool regionLevel; // As of 6/20/16, optional and default value is true
     bool isDefaultInput;
-    bool requireSplitterMap; // 
+    bool requireSplitterMap; // As of 6/20/16, optional and default value is false
   };
 
   class OutputSpec
   {
   public:
     OutputSpec() {}
+    // 6/20/16 regionLevel is optional and has a default value of true.
     OutputSpec(std::string description, const 
                NTA_BasicType dataType, size_t count, bool regionLevel, bool isDefaultOutput);
 

--- a/src/nupic/engine/Spec.hpp
+++ b/src/nupic/engine/Spec.hpp
@@ -54,16 +54,15 @@ namespace nupic
     UInt32 count; 
     // TBD. Omit? what is "required"? Is it ok to be zero length?
     bool required;
-    bool regionLevel; // As of 6/20/16, optional and default value is true
+    bool regionLevel;
     bool isDefaultInput;
-    bool requireSplitterMap; // As of 6/20/16, optional and default value is false
+    bool requireSplitterMap;
   };
 
   class OutputSpec
   {
   public:
     OutputSpec() {}
-    // 6/20/16 regionLevel is optional and has a default value of true.
     OutputSpec(std::string description, const 
                NTA_BasicType dataType, size_t count, bool regionLevel, bool isDefaultOutput);
 

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -1075,7 +1075,9 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
     {
       requireSplitterMap =  py::Int(input.getItem("requireSplitterMap")) != 0;
     }
-
+    
+    // As of 6/20/16 regionLevel and require SplitterMap are optional parameters
+    // and have default values of true and false respectively.
     ns.inputs.add(
       name,
       InputSpec(
@@ -1129,7 +1131,8 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
     NTA_ASSERT(output.getItem("isDefaultOutput") != nullptr)
         << outputMessagePrefix.str() << "isDefaultOutput";
     bool isDefaultOutput = py::Int(output.getItem("isDefaultOutput")) != 0;
-
+    
+    // As of 6/20/16 regionLevel is optional and defaults to true.
     ns.outputs.add(
       name,
       OutputSpec(

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -1057,18 +1057,25 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
     NTA_ASSERT(input.getItem("required") != nullptr)
         << inputMessagePrefix.str() << "required";
     bool required = py::Int(input.getItem("required")) != 0;
-
-    NTA_ASSERT(input.getItem("regionLevel") != nullptr)
-        << inputMessagePrefix.str() << "regionLevel";
-    bool regionLevel = py::Int(input.getItem("regionLevel")) != 0;
+    
+    // make regionLevel optional and default to true.
+    bool regionLevel = true;
+    if (input.getItem("regionLevel") != nullptr)
+    {
+       regionLevel = py::Int(input.getItem("regionLevel")) != 0;
+    }
 
     NTA_ASSERT(input.getItem("isDefaultInput") != nullptr)
         << inputMessagePrefix.str() << "isDefaultInput";
     bool isDefaultInput = py::Int(input.getItem("isDefaultInput")) != 0;
+    
+    // make requireSplitterMap optional and default to false.
+    bool requireSplitterMap = false;
+    if (input.getItem("requireSplitterMap") != nullptr)
+    {
+      requireSplitterMap =  py::Int(input.getItem("requireSplitterMap")) != 0;
+    }
 
-    NTA_ASSERT(input.getItem("requireSplitterMap") != nullptr)
-        << inputMessagePrefix.str() << "requireSplitterMap";
-    bool requireSplitterMap = py::Int(input.getItem("requireSplitterMap")) != 0;
     ns.inputs.add(
       name,
       InputSpec(
@@ -1112,9 +1119,12 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
         << outputMessagePrefix.str() << "count";
     UInt32 count = py::Int(output.getItem("count"));
 
-    NTA_ASSERT(output.getItem("regionLevel") != nullptr)
-        << outputMessagePrefix.str() << "regionLevel";
-    bool regionLevel = py::Int(output.getItem("regionLevel")) != 0;
+    // make regionLevel optional and default to true.
+    bool regionLevel = true;
+    if (output.getItem("regionLevel") != nullptr)
+    {
+       regionLevel = py::Int(output.getItem("regionLevel")) != 0;
+    }
 
     NTA_ASSERT(output.getItem("isDefaultOutput") != nullptr)
         << outputMessagePrefix.str() << "isDefaultOutput";

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -1076,8 +1076,6 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
       requireSplitterMap =  py::Int(input.getItem("requireSplitterMap")) != 0;
     }
     
-    // As of 6/20/16 regionLevel and require SplitterMap are optional parameters
-    // and have default values of true and false respectively.
     ns.inputs.add(
       name,
       InputSpec(
@@ -1132,7 +1130,6 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
         << outputMessagePrefix.str() << "isDefaultOutput";
     bool isDefaultOutput = py::Int(output.getItem("isDefaultOutput")) != 0;
     
-    // As of 6/20/16 regionLevel is optional and defaults to true.
     ns.outputs.add(
       name,
       OutputSpec(

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -1129,7 +1129,7 @@ void PyRegion::createSpec(const char * nodeType, Spec & ns, const char* classNam
     NTA_ASSERT(output.getItem("isDefaultOutput") != nullptr)
         << outputMessagePrefix.str() << "isDefaultOutput";
     bool isDefaultOutput = py::Int(output.getItem("isDefaultOutput")) != 0;
-    
+
     ns.outputs.add(
       name,
       OutputSpec(


### PR DESCRIPTION
fixes: #979 
makes regionLevel and requireSplitterMap optional parameters and gives them default values in PyRegion.cpp.

Please review:
@subutai @scottpurdy 