### PR TITLE
C++ ExtendedTemporalMemory: Part 1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -691,6 +691,23 @@ list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
 swig_link_libraries(${src_swig_engine}
                     ${src_swig_link_libraries})
 
+# Experimental
+set(src_swig_experimental_files nupic/bindings/experimental.i)
+set_source_files_properties(${src_swig_experimental_files} PROPERTIES
+                            CPLUSPLUS ON
+                            SWIG_MODULE_NAME experimental
+                            SWIG_FLAGS "${src_swig_flags}")
+set(src_swig_experimental experimental)
+# Make sure we don't attempt to execute the swig executable until it is built.
+set(SWIG_MODULE_${src_swig_experimental}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
+# Create custom command for generating files from SWIG.
+swig_add_module(${src_swig_experimental} python
+                ${src_swig_support_files}
+                ${src_swig_experimental_files})
+list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
+swig_link_libraries(${src_swig_experimental}
+                    ${src_swig_link_libraries})
+
 # Math
 set(src_swig_math_files nupic/bindings/math.i)
 set_source_files_properties(${src_swig_math_files} PROPERTIES
@@ -725,11 +742,13 @@ if (PY_EXTENSIONS_DIR)
   install(TARGETS
           ${SWIG_MODULE_${src_swig_algorithms}_REAL_NAME}
           ${SWIG_MODULE_${src_swig_engine}_REAL_NAME}
+          ${SWIG_MODULE_${src_swig_experimental}_REAL_NAME}
           ${SWIG_MODULE_${src_swig_math}_REAL_NAME}
           LIBRARY DESTINATION ${PY_EXTENSIONS_DIR})
   install(FILES
           ${PROJECT_BINARY_DIR}/algorithms.py
           ${PROJECT_BINARY_DIR}/engine_internal.py
+          ${PROJECT_BINARY_DIR}/experimental.py
           ${PROJECT_BINARY_DIR}/math.py
           DESTINATION ${PY_EXTENSIONS_DIR})
 endif(PY_EXTENSIONS_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,7 @@ set(src_capnp_specs_rel
   nupic/proto/BitHistory.capnp
   nupic/proto/ClaClassifier.capnp
   nupic/proto/ConnectionsProto.capnp
+  nupic/proto/ExtendedTemporalMemoryProto.capnp
   nupic/proto/LinkProto.capnp
   nupic/proto/Map.capnp
   nupic/proto/NetworkProto.capnp
@@ -309,6 +310,7 @@ set(src_nupiccore_srcs
     nupic/engine/TestNode.cpp
     nupic/engine/UniformLinkPolicy.cpp
     nupic/engine/YAMLUtils.cpp
+    nupic/experimental/ExtendedTemporalMemory.cpp
     nupic/math/SparseMatrixAlgorithms.cpp
     nupic/math/StlIo.cpp
     nupic/ntypes/ArrayBase.cpp

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -627,6 +627,11 @@ void Connections::read(ConnectionsProto::Reader& proto)
   iteration_ = proto.getIteration();
 }
 
+CellIdx Connections::numCells() const
+{
+  return cells_.size();
+}
+
 UInt Connections::numSegments() const
 {
   return numSegments_;

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -457,6 +457,13 @@ namespace nupic
         // Debugging
 
         /**
+         * Gets the number of cells.
+         *
+         * @retval Number of cells.
+         */
+        CellIdx numCells() const;
+
+        /**
          * Gets the number of segments.
          *
          * @retval Number of segments.

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -50,10 +50,6 @@ namespace nupic
       typedef Real32 Permanence;
       typedef UInt64 Iteration;
 
-      // Defaults
-      static const UInt16 MAX_SEGMENTS_PER_CELL = 255;
-      static const UInt16 MAX_SYNAPSES_PER_SEGMENT = 255;
-
       /**
        * Segment class used in Connections.
        *
@@ -256,8 +252,8 @@ namespace nupic
          * @param maxSynapsesPerSegment Maximum number of synapses per segment.
          */
         Connections(CellIdx numCells,
-                    SegmentIdx maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-                    SynapseIdx maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+                    SegmentIdx maxSegmentsPerCell=255,
+                    SynapseIdx maxSynapsesPerSegment=255);
 
         virtual ~Connections() {}
 

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -55,30 +55,6 @@ namespace nupic
       static const UInt16 MAX_SYNAPSES_PER_SEGMENT = 255;
 
       /**
-       * Cell class used in Connections.
-       *
-       * @b Description
-       * The Cell class is a data structure that points to a particular cell.
-       *
-       * @param idx Index of cell.
-       *
-       */
-      struct Cell
-      {
-        CellIdx idx;
-
-        Cell(CellIdx idx) : idx(idx) {}
-        Cell() {}
-
-        bool operator==(const Cell &other) const;
-        bool operator!=(const Cell &other) const;
-        bool operator<=(const Cell &other) const;
-        bool operator<(const Cell &other) const;
-        bool operator>=(const Cell &other) const;
-        bool operator>(const Cell &other) const;
-      };
-
-      /**
        * Segment class used in Connections.
        *
        * @b Description
@@ -92,9 +68,9 @@ namespace nupic
       struct Segment
       {
         SegmentIdx idx;
-        Cell cell;
+        CellIdx cell;
 
-        Segment(SegmentIdx idx, Cell cell) : idx(idx), cell(std::move(cell)) {}
+        Segment(SegmentIdx idx, CellIdx cell) : idx(idx), cell(cell) {}
         Segment() {}
 
         bool operator==(const Segment &other) const;
@@ -121,7 +97,7 @@ namespace nupic
         SynapseIdx idx;
         Segment segment;
 
-        Synapse(SynapseIdx idx, Segment segment) : idx(idx), segment(std::move(segment)) {}
+        Synapse(SynapseIdx idx, Segment segment) : idx(idx), segment(segment) {}
         Synapse() {}
 
         bool operator==(const Synapse &other) const;
@@ -141,7 +117,7 @@ namespace nupic
        */
       struct SynapseData
       {
-        Cell presynapticCell;
+        CellIdx presynapticCell;
         Permanence permanence;
         bool destroyed;
       };
@@ -301,7 +277,7 @@ namespace nupic
          *
          * @retval Created segment.
          */
-        Segment createSegment(const Cell& cell);
+        Segment createSegment(CellIdx cell);
 
         /**
          * Creates a synapse on the specified segment.
@@ -313,7 +289,7 @@ namespace nupic
          * @reval Created synapse.
          */
         Synapse createSynapse(const Segment& segment,
-                              const Cell& presynapticCell,
+                              CellIdx presynapticCell,
                               Permanence permanence);
 
         /**
@@ -346,7 +322,7 @@ namespace nupic
          *
          * @retval Segments on cell.
          */
-        std::vector<Segment> segmentsForCell(const Cell& cell) const;
+        std::vector<Segment> segmentsForCell(CellIdx cell) const;
 
         /**
          * Gets the synapses for a segment.
@@ -391,23 +367,8 @@ namespace nupic
          *
          * @return (set)Synapse indices
          */
-        std::vector<Synapse> synapsesForPresynapticCell(const Cell& presynapticCell) const;
-
-        /**
-         * Gets the segment with the most active synapses due to given input,
-         * from among all the segments on all the given cells.
-         *
-         * @param cells            Cells to look among.
-         * @param input            Active cells in the input.
-         * @param synapseThreshold Only consider segments with number of active synapses greater than this threshold.
-         * @param retSegment       Segment to return.
-         *
-         * @retval Segment found?
-         */
-        bool mostActiveSegmentForCells(const std::vector<Cell>& cells,
-                                       std::vector<Cell> input,
-                                       SynapseIdx synapseThreshold,
-                                       Segment& retSegment) const;
+        std::vector<Synapse> synapsesForPresynapticCell(CellIdx presynapticCell)
+          const;
 
         /**
          * Forward-propagates input to synapses, dendrites, and cells, to
@@ -436,7 +397,7 @@ namespace nupic
          * An output vector.
          * On return, filled with matching segments and overlaps.
          */
-        void computeActivity(const std::vector<Cell>& input,
+        void computeActivity(const std::vector<CellIdx>& input,
                              Permanence activePermanenceThreshold,
                              SynapseIdx activeSynapseThreshold,
                              Permanence matchingPermanenceThreshold,
@@ -491,7 +452,7 @@ namespace nupic
          *
          * @retval Number of segments.
          */
-        UInt numSegments(const Cell& cell) const;
+        UInt numSegments(CellIdx cell) const;
 
         /**
          * Gets the number of synapses.
@@ -546,7 +507,7 @@ namespace nupic
          *
          * @retval The least recently used segment.
          */
-        Segment leastRecentlyUsedSegment_(const Cell& cell) const;
+        Segment leastRecentlyUsedSegment_(CellIdx cell) const;
 
          /**
           * Gets the synapse with the lowest permanence on the segment.
@@ -578,7 +539,7 @@ namespace nupic
       private:
         std::vector<CellData> cells_;
         // Mapping (presynaptic cell => synapses) used in forward propagation
-        std::map< Cell, std::vector<Synapse> > synapsesForPresynapticCell_;
+        std::map<CellIdx, std::vector<Synapse> > synapsesForPresynapticCell_;
         UInt numSegments_;
         UInt numSynapses_;
         std::vector<Segment> segmentForFlatIdx_;

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -630,8 +630,17 @@ void TemporalMemory::compute(
   connections.computeActivity(activeCells_,
                               connectedPermanence_, activationThreshold_,
                               0.0, minThreshold_,
-                              activeSegments_, matchingSegments_,
-                              learn);
+                              activeSegments_, matchingSegments_);
+
+  if (learn)
+  {
+    for (const SegmentOverlap& segmentOverlap : activeSegments_)
+    {
+      connections.recordSegmentActivity(segmentOverlap.segment);
+    }
+
+    connections.startNewIteration();
+  }
 }
 
 void TemporalMemory::reset(void)

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -580,15 +580,12 @@ void TemporalMemory::compute(
   const UInt activeColumnsUnsorted[],
   bool learn)
 {
-  const vector<CellIdx> prevActiveCells = activeCells_;
-  const vector<CellIdx> prevWinnerCells = winnerCells_;
+  const vector<CellIdx> prevActiveCells = std::move(activeCells_);
+  const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
 
   vector<UInt> activeColumns(activeColumnsUnsorted,
                              activeColumnsUnsorted + activeColumnsSize);
   std::sort(activeColumns.begin(), activeColumns.end());
-
-  activeCells_.clear();
-  winnerCells_.clear();
 
   for (const ExcitedColumnData& excitedColumn : ExcitedColumns(activeColumns,
                                                                activeSegments_,

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -44,10 +44,10 @@ using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 
 #define EPSILON 0.000001
+#define TM_VERSION 2
 
 TemporalMemory::TemporalMemory()
 {
-  version_ = 2;
 }
 
 TemporalMemory::TemporalMemory(
@@ -103,10 +103,14 @@ void TemporalMemory::initialize(
   // Validate all input parameters
 
   if (columnDimensions.size() <= 0)
+  {
     NTA_THROW << "Number of column dimensions must be greater than 0";
+  }
 
   if (cellsPerColumn <= 0)
+  {
     NTA_THROW << "Number of cells per column must be greater than 0";
+  }
 
   NTA_CHECK(initialPermanence >= 0.0 && initialPermanence <= 1.0);
   NTA_CHECK(connectedPermanence >= 0.0 && connectedPermanence <= 1.0);
@@ -850,6 +854,11 @@ void TemporalMemory::setPredictedSegmentDecrement(Permanence predictedSegmentDec
   predictedSegmentDecrement_ = predictedSegmentDecrement;
 }
 
+UInt TemporalMemory::version() const
+{
+  return TM_VERSION;
+}
+
 /**
 * Create a RNG with given seed
 */
@@ -872,7 +881,7 @@ void TemporalMemory::save(ostream& outStream) const
 {
   // Write a starting marker and version.
   outStream << "TemporalMemory" << endl;
-  outStream << version_ << endl;
+  outStream << TM_VERSION << endl;
 
   outStream << numColumns_ << " "
     << cellsPerColumn_ << " "
@@ -1067,7 +1076,7 @@ void TemporalMemory::load(istream& inStream)
   // Check the saved version.
   UInt version;
   inStream >> version;
-  NTA_CHECK(version <= version_);
+  NTA_CHECK(version <= TM_VERSION);
 
   // Retrieve simple variables
   inStream >> numColumns_
@@ -1197,7 +1206,7 @@ void TemporalMemory::printParameters()
 {
   std::cout << "------------CPP TemporalMemory Parameters ------------------\n";
   std::cout
-    << "version                   = " << version_ << std::endl
+    << "version                   = " << TM_VERSION << std::endl
     << "numColumns                = " << numberOfColumns() << std::endl
     << "cellsPerColumn            = " << getCellsPerColumn() << std::endl
     << "activationThreshold       = " << getActivationThreshold() << std::endl

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -43,8 +43,8 @@ using namespace nupic;
 using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 
-#define EPSILON 0.000001
-#define TM_VERSION 2
+static const Permanence EPSILON = 0.000001;
+static const UInt TM_VERSION = 2;
 
 TemporalMemory::TemporalMemory()
 {

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -336,23 +336,12 @@ namespace nupic {
         Permanence getPredictedSegmentDecrement() const;
         void setPredictedSegmentDecrement(Permanence);
 
-       /**
-        * Extracts a vector<CellIdx> from a Iterable of Cells.
-        *
-        * @param Iterable<Cell> Iterable of Cells
-        *                       (.e.g. set<Cell>, vector<Cell>).
-        *
-        * @returns vector<CellIdx> The indices of the Cells in the Iterable.
-        */
-        template <typename Iterable>
-        vector<CellIdx> _cellsToIndices(const Iterable &cellSet) const;
-
         /**
          * Raises an error if cell index is invalid.
          *
          * @param cell Cell index
          */
-        bool _validateCell(Cell& cell);
+        bool _validateCell(CellIdx cell);
 
         /**
          * Save (serialize) the current state of the spatial pooler to the
@@ -401,7 +390,7 @@ namespace nupic {
          *
          * @return (int) Column index
          */
-        Int columnForCell(Cell& cell);
+        Int columnForCell(CellIdx cell);
 
         /**
          * Print the given UInt array in a nice format
@@ -426,8 +415,8 @@ namespace nupic {
         Permanence permanenceDecrement_;
         Permanence predictedSegmentDecrement_;
 
-        vector<Cell> activeCells_;
-        vector<Cell> winnerCells_;
+        vector<CellIdx> activeCells_;
+        vector<CellIdx> winnerCells_;
         vector<SegmentOverlap> activeSegments_;
         vector<SegmentOverlap> matchingSegments_;
 

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -166,9 +166,7 @@ namespace nupic {
          *
          * @returns Integer version number.
          */
-        virtual UInt version() const {
-          return version_;
-        };
+        virtual UInt version() const;
 
         /**
          * This *only* updates _rng to a new Random using seed.
@@ -420,7 +418,6 @@ namespace nupic {
         vector<SegmentOverlap> activeSegments_;
         vector<SegmentOverlap> matchingSegments_;
 
-        UInt version_;
         Random rng_;
 
       public:

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -137,8 +137,8 @@ namespace nupic {
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
           Int seed = 42,
-          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+          UInt maxSegmentsPerCell=255,
+          UInt maxSynapsesPerSegment=255);
 
         virtual void initialize(
           vector<UInt> columnDimensions = { 2048 },
@@ -152,8 +152,8 @@ namespace nupic {
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
           Int seed = 42,
-          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+          UInt maxSegmentsPerCell=255,
+          UInt maxSynapsesPerSegment=255);
 
         virtual ~TemporalMemory();
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1644,8 +1644,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
                  permanenceIncrement=0.10,
                  permanenceDecrement=0.10,
                  predictedSegmentDecrement=0.00,
-                 maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-                 maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT,
+                 maxSegmentsPerCell=255,
+                 maxSynapsesPerSegment=255,
                  seed=42):
       self.this = _ALGORITHMS.new_TemporalMemory()
       _ALGORITHMS.TemporalMemory_initialize(

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1511,10 +1511,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // Data structures (Connections)
 %rename(ConnectionsSynapse) nupic::algorithms::connections::Synapse;
 %rename(ConnectionsSegment) nupic::algorithms::connections::Segment;
-%rename(ConnectionsCell) nupic::algorithms::connections::Cell;
 %template(ConnectionsSynapseVector) vector<nupic::algorithms::connections::Synapse>;
 %template(ConnectionsSegmentVector) vector<nupic::algorithms::connections::Segment>;
-%template(ConnectionsCellVector) vector<nupic::algorithms::connections::Cell>;
 %feature("director") nupic::algorithms::connections::ConnectionsEventHandler;
 %include <nupic/algorithms/Connections.hpp>
 
@@ -1531,12 +1529,6 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
       self.this = _ALGORITHMS.new_Connections(numCells,
                                               maxSegmentsPerCell,
                                               maxSynapsesPerSegment)
-
-    def mostActiveSegmentForCells(self, cells, input, synapseThreshold):
-      segment = ConnectionsSegment()
-      result = _ALGORITHMS.Connections_mostActiveSegmentForCells(
-        self, cells, input, synapseThreshold, segment)
-      return segment if result else None
 
     def cellForSegment(self, segment):
       """Used by TemporalMemory.learnOnSegments"""
@@ -1574,28 +1566,6 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
   %#endif
   }
 
-}
-
-%extend nupic::algorithms::connections::Cell
-{
-  %pythoncode %{
-
-    def __key(self):
-      return (self.idx,)
-
-    def __eq__(x, y):
-      return x.__key() == y.__key()
-
-    def __hash__(self):
-      return hash(self.__key())
-
-    def __str__(self):
-      return str(self.idx)
-
-    def __repr__(self):
-      return str(self)
-
-  %}
 }
 
 %extend nupic::algorithms::connections::Segment
@@ -1744,12 +1714,6 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
   {
     const vector<CellIdx> cellIdxs = self->cellsForColumn(columnIdx);
     return vectorToList(cellIdxs);
-  }
-
-  UInt columnForCell(UInt cellIdx)
-  {
-    nupic::algorithms::connections::Cell cell(cellIdx);
-    return self->columnForCell(cell);
   }
 
   inline void convertedCompute(PyObject *py_x, bool learn)

--- a/src/nupic/bindings/experimental.i
+++ b/src/nupic/bindings/experimental.i
@@ -146,6 +146,7 @@ using namespace nupic;
                  permanenceIncrement=0.10,
                  permanenceDecrement=0.10,
                  predictedSegmentDecrement=0.00,
+                 formInternalConnections=True,
                  maxSegmentsPerCell=255,
                  maxSynapsesPerSegment=255,
                  seed=42):
@@ -154,8 +155,8 @@ using namespace nupic;
         self, columnDimensions, cellsPerColumn, activationThreshold,
         initialPermanence, connectedPermanence,
         minThreshold, maxNewSynapseCount, permanenceIncrement,
-        permanenceDecrement, predictedSegmentDecrement, seed,
-        maxSegmentsPerCell, maxSynapsesPerSegment)
+        permanenceDecrement, predictedSegmentDecrement, formInternalConnections,
+        seed, maxSegmentsPerCell, maxSynapsesPerSegment)
 
     def __getstate__(self):
       # Save the local attributes but override the C++ temporal memory with the

--- a/src/nupic/bindings/experimental.i
+++ b/src/nupic/bindings/experimental.i
@@ -1,0 +1,266 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+%module(package="bindings") experimental
+%import <nupic/bindings/algorithms.i>
+
+%pythoncode %{
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import os
+
+_EXPERIMENTAL = _experimental
+
+%}
+
+%{
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+#include <Python.h>
+
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+#include <nupic/experimental/ExtendedTemporalMemory.hpp>
+
+#include <nupic/proto/ExtendedTemporalMemoryProto.capnp.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <nupic/py_support/NumpyVector.hpp>
+#if !CAPNP_LITE
+#include <nupic/py_support/PyCapnp.hpp>
+#endif
+#include <nupic/py_support/PythonStream.hpp>
+#include <nupic/py_support/PyHelpers.hpp>
+
+// Hack to fix SWIGPY_SLICE_ARG not found bug
+#if PY_VERSION_HEX >= 0x03020000
+# define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
+#else
+# define SWIGPY_SLICE_ARG(obj) ((PySliceObject*) (obj))
+#endif
+
+using namespace nupic::experimental::extended_temporal_memory;
+using namespace nupic;
+
+#define CHECKSIZE(var) \
+  NTA_ASSERT(PyArray_DESCR(var)->elsize == 4) << " elsize:" << PyArray_DESCR(var)->elsize
+
+%}
+
+%pythoncode %{
+  uintDType = "uint32"
+%}
+
+%naturalvar;
+
+//--------------------------------------------------------------------------------
+// Extended Temporal Memory
+//--------------------------------------------------------------------------------
+%inline %{
+  template <typename IntType>
+  inline PyObject* vectorToList(const vector<IntType> &cellIdxs)
+  {
+    PyObject *list = PyList_New(cellIdxs.size());
+    for (size_t i = 0; i < cellIdxs.size(); i++)
+    {
+      PyObject *pyIdx = PyInt_FromLong(cellIdxs[i]);
+      PyList_SET_ITEM(list, i, pyIdx);
+    }
+    return list;
+  }
+%}
+
+%extend nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory
+{
+  %pythoncode %{
+    def __init__(self,
+                 columnDimensions=(2048,),
+                 cellsPerColumn=32,
+                 activationThreshold=13,
+                 initialPermanence=0.21,
+                 connectedPermanence=0.50,
+                 minThreshold=10,
+                 maxNewSynapseCount=20,
+                 permanenceIncrement=0.10,
+                 permanenceDecrement=0.10,
+                 predictedSegmentDecrement=0.00,
+                 maxSegmentsPerCell=255,
+                 maxSynapsesPerSegment=255,
+                 seed=42):
+      self.this = _EXPERIMENTAL.new_ExtendedTemporalMemory()
+      _EXPERIMENTAL.ExtendedTemporalMemory_initialize(
+        self, columnDimensions, cellsPerColumn, activationThreshold,
+        initialPermanence, connectedPermanence,
+        minThreshold, maxNewSynapseCount, permanenceIncrement,
+        permanenceDecrement, predictedSegmentDecrement, seed,
+        maxSegmentsPerCell, maxSynapsesPerSegment)
+
+    def __getstate__(self):
+      # Save the local attributes but override the C++ temporal memory with the
+      # string representation.
+      d = dict(self.__dict__)
+      d["this"] = self.getCState()
+      return d
+
+    def __setstate__(self, state):
+      # Create an empty C++ temporal memory and populate it from the serialized
+      # string.
+      self.this = _EXPERIMENTAL.new_ExtendedTemporalMemory()
+      if isinstance(state, str):
+        self.loadFromString(state)
+        self.valueToCategory = {}
+      else:
+        self.loadFromString(state["this"])
+        # Use the rest of the state to set local Python attributes.
+        del state["this"]
+        self.__dict__.update(state)
+
+    @classmethod
+    def read(cls, proto):
+      instance = cls()
+      instance.convertedRead(proto)
+      return instance
+  %}
+
+  inline PyObject* getActiveCells()
+  {
+    const vector<CellIdx> cellIdxs = self->getActiveCells();
+    return vectorToList(cellIdxs);
+  }
+
+  inline PyObject* getPredictiveCells()
+  {
+    const vector<CellIdx> cellIdxs = self->getPredictiveCells();
+    return vectorToList(cellIdxs);
+  }
+
+  inline PyObject* getWinnerCells()
+  {
+    const vector<CellIdx> cellIdxs = self->getWinnerCells();
+    return vectorToList(cellIdxs);
+  }
+
+  inline PyObject* getMatchingCells()
+  {
+    const vector<CellIdx> cellIdxs = self->getMatchingCells();
+    return vectorToList(cellIdxs);
+  }
+
+  inline PyObject* cellsForColumn(UInt columnIdx)
+  {
+    const vector<CellIdx> cellIdxs = self->cellsForColumn(columnIdx);
+    return vectorToList(cellIdxs);
+  }
+
+  inline void write(PyObject* pyBuilder) const
+  {
+%#if !CAPNP_LITE
+    ExtendedTemporalMemoryProto::Builder proto =
+        getBuilder<ExtendedTemporalMemoryProto>(pyBuilder);
+    self->write(proto);
+  %#else
+    throw std::logic_error(
+        "ExtendedTemporalMemory.write is not implemented when compiled with CAPNP_LITE=1.");
+  %#endif
+  }
+
+  inline void convertedRead(PyObject* pyReader)
+  {
+%#if !CAPNP_LITE
+    ExtendedTemporalMemoryProto::Reader proto =
+        getReader<ExtendedTemporalMemoryProto>(pyReader);
+    self->read(proto);
+  %#else
+    throw std::logic_error(
+        "ExtendedTemporalMemory.read is not implemented when compiled with CAPNP_LITE=1.");
+  %#endif
+  }
+
+  void loadFromString(const std::string& inString)
+  {
+    std::istringstream inStream(inString);
+    self->load(inStream);
+  }
+
+  PyObject* getCState()
+  {
+    SharedPythonOStream py_s(self->persistentSize());
+    std::ostream& s = py_s.getStream();
+    // TODO: Consider writing floats as binary instead.
+    s.flags(ios::scientific);
+    s.precision(numeric_limits<double>::digits10 + 1);
+    self->save(s);
+    return py_s.close();
+  }
+}
+
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getActiveCells;
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getPredictiveCells;
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getWinnerCells;
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getMatchingCells;
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::cellsForColumn;
+%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::columnForCell;
+
+%include <nupic/experimental/ExtendedTemporalMemory.hpp>

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -632,8 +632,17 @@ void ExtendedTemporalMemory::compute(
   connections.computeActivity(activeCells_,
                               connectedPermanence_, activationThreshold_,
                               0.0, minThreshold_,
-                              activeSegments_, matchingSegments_,
-                              learn);
+                              activeSegments_, matchingSegments_);
+
+  if (learn)
+  {
+    for (const SegmentOverlap& segmentOverlap : activeSegments_)
+    {
+      connections.recordSegmentActivity(segmentOverlap.segment);
+    }
+
+    connections.startNewIteration();
+  }
 }
 
 void ExtendedTemporalMemory::reset(void)

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -41,7 +41,7 @@
 using namespace std;
 using namespace nupic;
 using namespace nupic::algorithms::connections;
-using namespace nupic::algorithms::extended_temporal_memory;
+using namespace nupic::experimental::extended_temporal_memory;
 
 #define EPSILON 0.000001
 

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -1,0 +1,1249 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Implementation of ExtendedTemporalMemory
+ */
+
+#include <cstring>
+#include <climits>
+#include <iostream>
+#include <string>
+#include <iterator>
+#include <vector>
+
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+#include <kj/std/iostream.h>
+
+#include <nupic/algorithms/Connections.hpp>
+#include <nupic/experimental/ExtendedTemporalMemory.hpp>
+
+using namespace std;
+using namespace nupic;
+using namespace nupic::algorithms::connections;
+using namespace nupic::algorithms::extended_temporal_memory;
+
+#define EPSILON 0.000001
+
+ExtendedTemporalMemory::ExtendedTemporalMemory()
+{
+  version_ = 2;
+}
+
+ExtendedTemporalMemory::ExtendedTemporalMemory(
+  vector<UInt> columnDimensions,
+  UInt cellsPerColumn,
+  UInt activationThreshold,
+  Permanence initialPermanence,
+  Permanence connectedPermanence,
+  UInt minThreshold,
+  UInt maxNewSynapseCount,
+  Permanence permanenceIncrement,
+  Permanence permanenceDecrement,
+  Permanence predictedSegmentDecrement,
+  Int seed,
+  UInt maxSegmentsPerCell,
+  UInt maxSynapsesPerSegment)
+{
+  initialize(
+    columnDimensions,
+    cellsPerColumn,
+    activationThreshold,
+    initialPermanence,
+    connectedPermanence,
+    minThreshold,
+    maxNewSynapseCount,
+    permanenceIncrement,
+    permanenceDecrement,
+    predictedSegmentDecrement,
+    seed,
+    maxSegmentsPerCell,
+    maxSynapsesPerSegment);
+}
+
+ExtendedTemporalMemory::~ExtendedTemporalMemory()
+{
+}
+
+void ExtendedTemporalMemory::initialize(
+  vector<UInt> columnDimensions,
+  UInt cellsPerColumn,
+  UInt activationThreshold,
+  Permanence initialPermanence,
+  Permanence connectedPermanence,
+  UInt minThreshold,
+  UInt maxNewSynapseCount,
+  Permanence permanenceIncrement,
+  Permanence permanenceDecrement,
+  Permanence predictedSegmentDecrement,
+  Int seed,
+  UInt maxSegmentsPerCell,
+  UInt maxSynapsesPerSegment)
+{
+  // Validate all input parameters
+
+  if (columnDimensions.size() <= 0)
+    NTA_THROW << "Number of column dimensions must be greater than 0";
+
+  if (cellsPerColumn <= 0)
+    NTA_THROW << "Number of cells per column must be greater than 0";
+
+  NTA_CHECK(initialPermanence >= 0.0 && initialPermanence <= 1.0);
+  NTA_CHECK(connectedPermanence >= 0.0 && connectedPermanence <= 1.0);
+  NTA_CHECK(permanenceIncrement >= 0.0 && permanenceIncrement <= 1.0);
+  NTA_CHECK(permanenceDecrement >= 0.0 && permanenceDecrement <= 1.0);
+
+  // Save member variables
+
+  numColumns_ = 1;
+  columnDimensions_.clear();
+  for (auto & columnDimension : columnDimensions)
+  {
+    numColumns_ *= columnDimension;
+    columnDimensions_.push_back(columnDimension);
+  }
+
+  cellsPerColumn_ = cellsPerColumn;
+  activationThreshold_ = activationThreshold;
+  initialPermanence_ = initialPermanence;
+  connectedPermanence_ = connectedPermanence;
+  minThreshold_ = minThreshold;
+  maxNewSynapseCount_ = maxNewSynapseCount;
+  permanenceIncrement_ = permanenceIncrement;
+  permanenceDecrement_ = permanenceDecrement;
+  predictedSegmentDecrement_ = predictedSegmentDecrement;
+
+  // Initialize member variables
+  connections = Connections(
+    numberOfCells(),
+    maxSegmentsPerCell,
+    maxSynapsesPerSegment);
+  seed_((UInt64)(seed < 0 ? rand() : seed));
+
+  activeCells_.clear();
+  activeSegments_.clear();
+  winnerCells_.clear();
+  matchingSegments_.clear();
+}
+
+struct ExcitedColumnData
+{
+  UInt column;
+  bool isActiveColumn;
+  vector<SegmentOverlap>::const_iterator activeSegmentsBegin;
+  vector<SegmentOverlap>::const_iterator activeSegmentsEnd;
+  vector<SegmentOverlap>::const_iterator matchingSegmentsBegin;
+  vector<SegmentOverlap>::const_iterator matchingSegmentsEnd;
+};
+
+/**
+ * Walk the sorted lists of active columns, active segments, and matching
+ * segments, grouping them by column. Each list is traversed exactly once.
+ *
+ * Perform the walk by using iterators.
+ */
+class ExcitedColumns
+{
+public:
+
+  ExcitedColumns(const vector<UInt>& activeColumns,
+                 const vector<SegmentOverlap>& activeSegments,
+                 const vector<SegmentOverlap>& matchingSegments,
+                 UInt cellsPerColumn)
+    :activeColumns_(activeColumns),
+     cellsPerColumn_(cellsPerColumn),
+     activeSegments_(activeSegments),
+     matchingSegments_(matchingSegments)
+  {
+    NTA_ASSERT(std::is_sorted(activeColumns.begin(), activeColumns.end()));
+    NTA_ASSERT(std::is_sorted(activeSegments.begin(), activeSegments.end(),
+                              [](const SegmentOverlap& a,
+                                 const SegmentOverlap& b)
+                              {
+                                return a.segment < b.segment;
+                              }));
+    NTA_ASSERT(std::is_sorted(matchingSegments.begin(), matchingSegments.end(),
+                              [](const SegmentOverlap& a,
+                                 const SegmentOverlap& b)
+                              {
+                                return a.segment < b.segment;
+                              }));
+  }
+
+  class Iterator
+  {
+  public:
+    Iterator(vector<UInt>::const_iterator activeColumn,
+             vector<UInt>::const_iterator activeColumnsEnd,
+             vector<SegmentOverlap>::const_iterator activeSegment,
+             vector<SegmentOverlap>::const_iterator activeSegmentsEnd,
+             vector<SegmentOverlap>::const_iterator matchingSegment,
+             vector<SegmentOverlap>::const_iterator matchingSegmentsEnd,
+             UInt cellsPerColumn)
+      :activeColumn_(activeColumn),
+       activeColumnsEnd_(activeColumnsEnd),
+       activeSegment_(activeSegment),
+       activeSegmentsEnd_(activeSegmentsEnd),
+       matchingSegment_(matchingSegment),
+       matchingSegmentsEnd_(matchingSegmentsEnd),
+       cellsPerColumn_(cellsPerColumn),
+       finished_(false)
+    {
+      calculateNext_();
+    }
+
+    bool operator !=(const Iterator& other)
+    {
+      return finished_ != other.finished_ ||
+        activeColumn_ != other.activeColumn_ ||
+        activeSegment_ != other.activeSegment_ ||
+        matchingSegment_ != other.matchingSegment_;
+    }
+
+    const ExcitedColumnData& operator*() const
+    {
+      NTA_ASSERT(!finished_);
+      return current_;
+    }
+
+    const Iterator& operator++()
+    {
+      NTA_ASSERT(!finished_);
+      calculateNext_();
+      return *this;
+    }
+
+  private:
+
+    UInt columnOf_(const SegmentOverlap& segmentOverlap) const
+    {
+      return segmentOverlap.segment.cell.idx / cellsPerColumn_;
+    }
+
+    void calculateNext_()
+    {
+      if (activeColumn_ != activeColumnsEnd_ ||
+          activeSegment_ != activeSegmentsEnd_ ||
+          matchingSegment_ != matchingSegmentsEnd_)
+      {
+        current_.column = UINT_MAX;
+
+        if (activeSegment_ != activeSegmentsEnd_)
+        {
+          current_.column = std::min(current_.column,
+                                     columnOf_(*activeSegment_));
+        }
+
+        if (matchingSegment_ != matchingSegmentsEnd_)
+        {
+          current_.column = std::min(current_.column,
+                                     columnOf_(*matchingSegment_));
+        }
+
+        if (activeColumn_ != activeColumnsEnd_ &&
+            *activeColumn_ <= current_.column)
+        {
+          current_.column = *activeColumn_;
+          current_.isActiveColumn = true;
+          activeColumn_++;
+        }
+        else
+        {
+          current_.isActiveColumn = false;
+        }
+
+        current_.activeSegmentsBegin = activeSegment_;
+        while (activeSegment_ != activeSegmentsEnd_ &&
+               columnOf_(*activeSegment_) == current_.column)
+        {
+          activeSegment_++;
+        }
+        current_.activeSegmentsEnd = activeSegment_;
+
+        current_.matchingSegmentsBegin = matchingSegment_;
+        while (matchingSegment_ != matchingSegmentsEnd_ &&
+               columnOf_(*matchingSegment_) == current_.column)
+        {
+          matchingSegment_++;
+        }
+        current_.matchingSegmentsEnd = matchingSegment_;
+      }
+      else
+      {
+        finished_ = true;
+      }
+    }
+
+    vector<UInt>::const_iterator activeColumn_;
+    vector<UInt>::const_iterator activeColumnsEnd_;
+    vector<SegmentOverlap>::const_iterator activeSegment_;
+    vector<SegmentOverlap>::const_iterator activeSegmentsEnd_;
+    vector<SegmentOverlap>::const_iterator matchingSegment_;
+    vector<SegmentOverlap>::const_iterator matchingSegmentsEnd_;
+    const UInt cellsPerColumn_;
+
+    bool finished_;
+    ExcitedColumnData current_;
+  };
+
+  Iterator begin()
+  {
+    return Iterator(activeColumns_.begin(),
+                    activeColumns_.end(),
+                    activeSegments_.begin(),
+                    activeSegments_.end(),
+                    matchingSegments_.begin(),
+                    matchingSegments_.end(),
+                    cellsPerColumn_);
+  }
+
+  Iterator end()
+  {
+    return Iterator(activeColumns_.end(),
+                    activeColumns_.end(),
+                    activeSegments_.end(),
+                    activeSegments_.end(),
+                    matchingSegments_.end(),
+                    matchingSegments_.end(),
+                    cellsPerColumn_);
+  }
+
+private:
+  const vector<UInt>& activeColumns_;
+  const UInt cellsPerColumn_;
+  const vector<SegmentOverlap>& activeSegments_;
+  const vector<SegmentOverlap>& matchingSegments_;
+};
+
+static Cell getLeastUsedCell(
+  Connections& connections,
+  Random& rng,
+  UInt column,
+  UInt cellsPerColumn)
+{
+  vector<Cell> leastUsedCells;
+  UInt32 minNumSegments = UINT_MAX;
+  const CellIdx start = column * cellsPerColumn;
+  const CellIdx end = start + cellsPerColumn;
+  for (CellIdx i = start; i < end; i++)
+  {
+    Cell cell(i);
+    UInt32 numSegments = connections.segmentsForCell(cell).size();
+
+    if (numSegments < minNumSegments)
+    {
+      minNumSegments = numSegments;
+      leastUsedCells.clear();
+    }
+
+    if (numSegments == minNumSegments)
+    {
+      leastUsedCells.push_back(cell);
+    }
+  }
+
+  return leastUsedCells[rng.getUInt32(leastUsedCells.size())];
+}
+
+static void adaptSegment(
+  Connections& connections,
+  Segment segment,
+  const vector<Cell>& prevActiveCells,
+  Permanence permanenceIncrement,
+  Permanence permanenceDecrement)
+{
+  vector<Synapse> synapses = connections.synapsesForSegment(segment);
+
+  for (Synapse synapse : synapses)
+  {
+    const SynapseData synapseData = connections.dataForSynapse(synapse);
+    const bool isActive =
+      std::binary_search(prevActiveCells.begin(), prevActiveCells.end(),
+                         synapseData.presynapticCell);
+    Permanence permanence = synapseData.permanence;
+
+    if (isActive)
+    {
+      permanence += permanenceIncrement;
+    }
+    else
+    {
+      permanence -= permanenceDecrement;
+    }
+
+    permanence = min(permanence, (Permanence)1.0);
+    permanence = max(permanence, (Permanence)0.0);
+
+    if (permanence < EPSILON)
+    {
+      connections.destroySynapse(synapse);
+    }
+    else
+    {
+      connections.updateSynapsePermanence(synapse, permanence);
+    }
+  }
+
+  if (connections.numSynapses(segment) == 0)
+  {
+    connections.destroySegment(segment);
+  }
+}
+
+static void growSynapses(
+  Connections& connections,
+  Random& rng,
+  Segment segment,
+  UInt32 nDesiredNewSynapses,
+  const vector<Cell>& prevWinnerCells,
+  Permanence initialPermanence)
+{
+  vector<Cell> candidates(prevWinnerCells.begin(), prevWinnerCells.end());
+
+  // Instead of erasing candidates, swap them to the end, and remember where the
+  // "eligible" candidates end.
+  auto eligibleEnd = candidates.end();
+
+  // Remove cells that are already synapsed on by this segment
+  for (Synapse synapse : connections.synapsesForSegment(segment))
+  {
+    Cell presynapticCell = connections.dataForSynapse(synapse).presynapticCell;
+    auto ineligible = find(candidates.begin(), eligibleEnd, presynapticCell);
+    if (ineligible != eligibleEnd)
+    {
+      eligibleEnd--;
+      std::iter_swap(ineligible, eligibleEnd);
+    }
+  }
+
+  const UInt32 nActual =
+    std::min(nDesiredNewSynapses,
+             (UInt32)std::distance(candidates.begin(), eligibleEnd));
+
+  // Pick nActual cells randomly.
+  for (UInt32 c = 0; c < nActual; c++)
+  {
+    size_t i = rng.getUInt32(std::distance(candidates.begin(), eligibleEnd));;
+    connections.createSynapse(segment, candidates[i], initialPermanence);
+    eligibleEnd--;
+    std::swap(candidates[i], *eligibleEnd);
+  }
+}
+
+static void activatePredictedColumn(
+  vector<Cell>& activeCells,
+  vector<Cell>& winnerCells,
+  Connections& connections,
+  const ExcitedColumnData& excitedColumn,
+  bool learn,
+  const vector<Cell>& prevActiveCells,
+  Permanence permanenceIncrement,
+  Permanence permanenceDecrement)
+{
+  auto active = excitedColumn.activeSegmentsBegin;
+  do
+  {
+    Cell cell(active->segment.cell);
+    activeCells.push_back(cell);
+    winnerCells.push_back(cell);
+
+    // This cell might have multiple active segments.
+    do
+    {
+      if (learn)
+      {
+        adaptSegment(connections,
+                     active->segment,
+                     prevActiveCells,
+                     permanenceIncrement, permanenceDecrement);
+      }
+      active++;
+    } while (active != excitedColumn.activeSegmentsEnd &&
+             active->segment.cell == cell);
+  } while (active != excitedColumn.activeSegmentsEnd);
+}
+
+static void burstColumn(
+  vector<Cell>& activeCells,
+  vector<Cell>& winnerCells,
+  Connections& connections,
+  Random& rng,
+  const ExcitedColumnData& excitedColumn,
+  bool learn,
+  const vector<Cell>& prevActiveCells,
+  const vector<Cell>& prevWinnerCells,
+  UInt cellsPerColumn,
+  Permanence initialPermanence,
+  UInt maxNewSynapseCount,
+  Permanence permanenceIncrement,
+  Permanence permanenceDecrement)
+{
+  const CellIdx start = excitedColumn.column * cellsPerColumn;
+  const CellIdx end = start + cellsPerColumn;
+  for (CellIdx i = start; i < end; i++)
+  {
+    activeCells.push_back(Cell(i));
+  }
+
+  if (excitedColumn.matchingSegmentsBegin != excitedColumn.matchingSegmentsEnd)
+  {
+    auto bestMatch = std::max_element(
+      excitedColumn.matchingSegmentsBegin,
+      excitedColumn.matchingSegmentsEnd,
+      [](const SegmentOverlap& a, const SegmentOverlap& b)
+      {
+        return a.overlap < b.overlap;
+      });
+
+    winnerCells.push_back(bestMatch->segment.cell);
+
+    if (learn)
+    {
+      adaptSegment(connections,
+                   bestMatch->segment,
+                   prevActiveCells,
+                   permanenceIncrement, permanenceDecrement);
+
+      const UInt32 nGrowDesired = maxNewSynapseCount - bestMatch->overlap;
+      if (nGrowDesired > 0)
+      {
+        growSynapses(connections, rng,
+                     bestMatch->segment, nGrowDesired,
+                     prevWinnerCells,
+                     initialPermanence);
+      }
+    }
+  }
+  else
+  {
+    const Cell winnerCell = getLeastUsedCell(connections, rng,
+                                             excitedColumn.column,
+                                             cellsPerColumn);
+    winnerCells.push_back(winnerCell);
+
+    if (learn)
+    {
+      // Don't grow a segment that will never match.
+      const UInt32 nGrowExact = std::min(maxNewSynapseCount,
+                                         (UInt32)prevWinnerCells.size());
+      if (nGrowExact > 0)
+      {
+        const Segment segment = connections.createSegment(winnerCell);
+        growSynapses(connections, rng,
+                     segment, nGrowExact,
+                     prevWinnerCells,
+                     initialPermanence);
+        NTA_ASSERT(connections.numSynapses(segment) == nGrowExact);
+      }
+    }
+  }
+}
+
+static void punishPredictedColumn(
+  Connections& connections,
+  const ExcitedColumnData& excitedColumn,
+  const vector<Cell>& prevActiveCells,
+  Permanence predictedSegmentDecrement)
+{
+  if (predictedSegmentDecrement > 0.0)
+  {
+    for (auto matching = excitedColumn.matchingSegmentsBegin;
+         matching != excitedColumn.matchingSegmentsEnd;
+         matching++)
+    {
+      adaptSegment(connections, matching->segment, prevActiveCells,
+                   -predictedSegmentDecrement, 0.0);
+    }
+  }
+}
+
+void ExtendedTemporalMemory::compute(
+  UInt activeColumnsSize,
+  const UInt activeColumnsUnsorted[],
+  bool learn)
+{
+  const vector<Cell> prevActiveCells = activeCells_;
+  const vector<Cell> prevWinnerCells = winnerCells_;
+
+  vector<UInt> activeColumns(activeColumnsUnsorted,
+                             activeColumnsUnsorted + activeColumnsSize);
+  std::sort(activeColumns.begin(), activeColumns.end());
+
+  activeCells_.clear();
+  winnerCells_.clear();
+
+  for (const ExcitedColumnData& excitedColumn : ExcitedColumns(activeColumns,
+                                                               activeSegments_,
+                                                               matchingSegments_,
+                                                               cellsPerColumn_))
+  {
+    if (excitedColumn.isActiveColumn)
+    {
+      if (excitedColumn.activeSegmentsBegin != excitedColumn.activeSegmentsEnd)
+      {
+        activatePredictedColumn(activeCells_, winnerCells_, connections,
+                                excitedColumn, learn,
+                                prevActiveCells,
+                                permanenceIncrement_, permanenceDecrement_);
+      }
+      else
+      {
+        burstColumn(activeCells_, winnerCells_, connections, rng_,
+                    excitedColumn, learn,
+                    prevActiveCells, prevWinnerCells,
+                    cellsPerColumn_, initialPermanence_, maxNewSynapseCount_,
+                    permanenceIncrement_, permanenceDecrement_);
+      }
+    }
+    else
+    {
+      if (learn)
+      {
+        punishPredictedColumn(connections,
+                              excitedColumn,
+                              prevActiveCells,
+                              predictedSegmentDecrement_);
+      }
+    }
+  }
+
+  activeSegments_.clear();
+  matchingSegments_.clear();
+  connections.computeActivity(activeCells_,
+                              connectedPermanence_, activationThreshold_,
+                              0.0, minThreshold_,
+                              activeSegments_, matchingSegments_,
+                              learn);
+}
+
+void ExtendedTemporalMemory::reset(void)
+{
+  activeCells_.clear();
+  activeSegments_.clear();
+  matchingSegments_.clear();
+  winnerCells_.clear();
+}
+
+// ==============================
+//  Helper functions
+// ==============================
+
+Int ExtendedTemporalMemory::columnForCell(Cell& cell)
+{
+  _validateCell(cell);
+
+  return cell.idx / cellsPerColumn_;
+}
+
+vector<CellIdx> ExtendedTemporalMemory::cellsForColumn(Int column)
+{
+  const CellIdx start = cellsPerColumn_ * column;
+  const CellIdx end = start + cellsPerColumn_;
+
+  vector<CellIdx> cellsInColumn;
+  for (CellIdx i = start; i < end; i++)
+  {
+    cellsInColumn.push_back(i);
+  }
+
+  return cellsInColumn;
+}
+
+UInt ExtendedTemporalMemory::numberOfCells(void)
+{
+  return numberOfColumns() * cellsPerColumn_;
+}
+
+vector<CellIdx> ExtendedTemporalMemory::getActiveCells() const
+{
+  return _cellsToIndices(activeCells_);
+}
+
+vector<CellIdx> ExtendedTemporalMemory::getPredictiveCells() const
+{
+  vector<CellIdx> predictiveCells;
+
+  for (auto segOverlap = activeSegments_.begin();
+       segOverlap != activeSegments_.end();
+       segOverlap++)
+  {
+    if (segOverlap == activeSegments_.begin() ||
+        segOverlap->segment.cell.idx != predictiveCells.back())
+    {
+      predictiveCells.push_back(segOverlap->segment.cell.idx);
+    }
+  }
+
+  return predictiveCells;
+}
+
+vector<CellIdx> ExtendedTemporalMemory::getWinnerCells() const
+{
+  return _cellsToIndices(winnerCells_);
+}
+
+vector<CellIdx> ExtendedTemporalMemory::getMatchingCells() const
+{
+  vector<CellIdx> matchingCells;
+
+  for (auto segOverlap = matchingSegments_.begin();
+       segOverlap != matchingSegments_.end();
+       segOverlap++)
+  {
+    if (segOverlap == matchingSegments_.begin() ||
+        segOverlap->segment.cell.idx != matchingCells.back())
+    {
+      matchingCells.push_back(segOverlap->segment.cell.idx);
+    }
+  }
+
+  return matchingCells;
+}
+
+vector<Segment> ExtendedTemporalMemory::getActiveSegments() const
+{
+  vector<Segment> ret;
+  ret.reserve(activeSegments_.size());
+  for (const SegmentOverlap& segmentOverlap : activeSegments_)
+  {
+    ret.push_back(segmentOverlap.segment);
+  }
+  return ret;
+}
+
+vector<Segment> ExtendedTemporalMemory::getMatchingSegments() const
+{
+  vector<Segment> ret;
+  ret.reserve(matchingSegments_.size());
+  for (const SegmentOverlap& segmentOverlap : matchingSegments_)
+  {
+    ret.push_back(segmentOverlap.segment);
+  }
+  return ret;
+}
+
+UInt ExtendedTemporalMemory::numberOfColumns() const
+{
+  return numColumns_;
+}
+
+template <typename Iterable>
+vector<CellIdx> ExtendedTemporalMemory::_cellsToIndices(
+  const Iterable& cellSet) const
+{
+  vector<CellIdx> idxVector;
+  idxVector.reserve(cellSet.size());
+  for (Cell cell : cellSet)
+  {
+    idxVector.push_back(cell.idx);
+  }
+  return idxVector;
+}
+
+bool ExtendedTemporalMemory::_validateCell(Cell& cell)
+{
+  if (cell.idx < numberOfCells())
+    return true;
+
+  NTA_THROW << "Invalid cell " << cell.idx;
+  return false;
+}
+
+vector<UInt> ExtendedTemporalMemory::getColumnDimensions() const
+{
+  return columnDimensions_;
+}
+
+UInt ExtendedTemporalMemory::getCellsPerColumn() const
+{
+  return cellsPerColumn_;
+}
+
+UInt ExtendedTemporalMemory::getActivationThreshold() const
+{
+  return activationThreshold_;
+}
+
+void ExtendedTemporalMemory::setActivationThreshold(UInt activationThreshold)
+{
+  activationThreshold_ = activationThreshold;
+}
+
+Permanence ExtendedTemporalMemory::getInitialPermanence() const
+{
+  return initialPermanence_;
+}
+
+void ExtendedTemporalMemory::setInitialPermanence(Permanence initialPermanence)
+{
+  initialPermanence_ = initialPermanence;
+}
+
+Permanence ExtendedTemporalMemory::getConnectedPermanence() const
+{
+  return connectedPermanence_;
+}
+
+void ExtendedTemporalMemory::setConnectedPermanence(
+  Permanence connectedPermanence)
+{
+  connectedPermanence_ = connectedPermanence;
+}
+
+UInt ExtendedTemporalMemory::getMinThreshold() const
+{
+  return minThreshold_;
+}
+
+void ExtendedTemporalMemory::setMinThreshold(UInt minThreshold)
+{
+  minThreshold_ = minThreshold;
+}
+
+UInt ExtendedTemporalMemory::getMaxNewSynapseCount() const
+{
+  return maxNewSynapseCount_;
+}
+
+void ExtendedTemporalMemory::setMaxNewSynapseCount(UInt maxNewSynapseCount)
+{
+  maxNewSynapseCount_ = maxNewSynapseCount;
+}
+
+Permanence ExtendedTemporalMemory::getPermanenceIncrement() const
+{
+  return permanenceIncrement_;
+}
+
+void ExtendedTemporalMemory::setPermanenceIncrement(
+  Permanence permanenceIncrement)
+{
+  permanenceIncrement_ = permanenceIncrement;
+}
+
+Permanence ExtendedTemporalMemory::getPermanenceDecrement() const
+{
+  return permanenceDecrement_;
+}
+
+void ExtendedTemporalMemory::setPermanenceDecrement(
+  Permanence permanenceDecrement)
+{
+  permanenceDecrement_ = permanenceDecrement;
+}
+
+Permanence ExtendedTemporalMemory::getPredictedSegmentDecrement() const
+{
+  return predictedSegmentDecrement_;
+}
+
+void ExtendedTemporalMemory::setPredictedSegmentDecrement(
+  Permanence predictedSegmentDecrement)
+{
+  predictedSegmentDecrement_ = predictedSegmentDecrement;
+}
+
+/**
+* Create a RNG with given seed
+*/
+void ExtendedTemporalMemory::seed_(UInt64 seed)
+{
+  rng_ = Random(seed);
+}
+
+UInt ExtendedTemporalMemory::persistentSize() const
+{
+  // TODO: this won't scale!
+  stringstream s;
+  s.flags(ios::scientific);
+  s.precision(numeric_limits<double>::digits10 + 1);
+  this->save(s);
+  return s.str().size();
+}
+
+void ExtendedTemporalMemory::save(ostream& outStream) const
+{
+  // Write a starting marker and version.
+  outStream << "ExtendedTemporalMemory" << endl;
+  outStream << version_ << endl;
+
+  outStream << numColumns_ << " "
+    << cellsPerColumn_ << " "
+    << activationThreshold_ << " "
+    << initialPermanence_ << " "
+    << connectedPermanence_ << " "
+    << minThreshold_ << " "
+    << maxNewSynapseCount_ << " "
+    << permanenceIncrement_ << " "
+    << permanenceDecrement_ << " "
+    << predictedSegmentDecrement_ << " "
+    << endl;
+
+  connections.save(outStream);
+  outStream << endl;
+
+  outStream << rng_ << endl;
+
+  outStream << columnDimensions_.size() << " ";
+  for (auto & elem : columnDimensions_) {
+    outStream << elem << " ";
+  }
+  outStream << endl;
+
+  outStream << activeCells_.size() << " ";
+  for (Cell elem : activeCells_) {
+    outStream << elem.idx << " ";
+  }
+  outStream << endl;
+
+  outStream << winnerCells_.size() << " ";
+  for (Cell elem : winnerCells_) {
+    outStream << elem.idx << " ";
+  }
+  outStream << endl;
+
+  outStream << activeSegments_.size() << " ";
+  for (SegmentOverlap elem : activeSegments_) {
+    outStream << elem.segment.idx << " ";
+    outStream << elem.segment.cell.idx << " ";
+    outStream << elem.overlap << " ";
+  }
+  outStream << endl;
+
+  outStream << matchingSegments_.size() << " ";
+  for (SegmentOverlap elem : matchingSegments_) {
+    outStream << elem.segment.idx << " ";
+    outStream << elem.segment.cell.idx << " ";
+    outStream << elem.overlap << " ";
+  }
+  outStream << endl;
+
+  outStream << "~ExtendedTemporalMemory" << endl;
+}
+
+void ExtendedTemporalMemory::write(
+  ExtendedTemporalMemoryProto::Builder& proto) const
+{
+  auto columnDims = proto.initColumnDimensions(columnDimensions_.size());
+  for (UInt i = 0; i < columnDimensions_.size(); i++)
+  {
+    columnDims.set(i, columnDimensions_[i]);
+  }
+
+  proto.setCellsPerColumn(cellsPerColumn_);
+  proto.setActivationThreshold(activationThreshold_);
+  proto.setInitialPermanence(initialPermanence_);
+  proto.setConnectedPermanence(connectedPermanence_);
+  proto.setMinThreshold(minThreshold_);
+  proto.setMaxNewSynapseCount(maxNewSynapseCount_);
+  proto.setPermanenceIncrement(permanenceIncrement_);
+  proto.setPermanenceDecrement(permanenceDecrement_);
+  proto.setPredictedSegmentDecrement(predictedSegmentDecrement_);
+
+  auto _connections = proto.initConnections();
+  connections.write(_connections);
+
+  auto random = proto.initRandom();
+  rng_.write(random);
+
+  auto activeCells = proto.initActiveCells(activeCells_.size());
+  UInt i = 0;
+  for (Cell c : activeCells_)
+  {
+    activeCells.set(i++, c.idx);
+  }
+
+  auto activeSegmentOverlaps =
+    proto.initActiveSegmentOverlaps(activeSegments_.size());
+  for (UInt i = 0; i < activeSegments_.size(); ++i)
+  {
+    Segment segment = activeSegments_[i].segment;
+    activeSegmentOverlaps[i].setCell(segment.cell.idx);
+    activeSegmentOverlaps[i].setSegment(segment.idx);
+    activeSegmentOverlaps[i].setOverlap(activeSegments_[i].overlap);
+  }
+
+  auto winnerCells = proto.initWinnerCells(winnerCells_.size());
+  i = 0;
+  for (Cell c : winnerCells_)
+  {
+    winnerCells.set(i++, c.idx);
+  }
+
+  auto matchingSegmentOverlaps =
+    proto.initMatchingSegmentOverlaps(matchingSegments_.size());
+  for (UInt i = 0; i < matchingSegments_.size(); ++i)
+  {
+    Segment segment = matchingSegments_[i].segment;
+    matchingSegmentOverlaps[i].setCell(segment.cell.idx);
+    matchingSegmentOverlaps[i].setSegment(segment.idx);
+    matchingSegmentOverlaps[i].setOverlap(matchingSegments_[i].overlap);
+  }
+}
+
+// Implementation note: this method sets up the instance using data from
+// proto. This method does not call initialize. As such we have to be careful
+// that everything in initialize is handled properly here.
+void ExtendedTemporalMemory::read(ExtendedTemporalMemoryProto::Reader& proto)
+{
+  numColumns_ = 1;
+  columnDimensions_.clear();
+  for (UInt dimension : proto.getColumnDimensions())
+  {
+    numColumns_ *= dimension;
+    columnDimensions_.push_back(dimension);
+  }
+
+  cellsPerColumn_ = proto.getCellsPerColumn();
+  activationThreshold_ = proto.getActivationThreshold();
+  initialPermanence_ = proto.getInitialPermanence();
+  connectedPermanence_ = proto.getConnectedPermanence();
+  minThreshold_ = proto.getMinThreshold();
+  maxNewSynapseCount_ = proto.getMaxNewSynapseCount();
+  permanenceIncrement_ = proto.getPermanenceIncrement();
+  permanenceDecrement_ = proto.getPermanenceDecrement();
+  predictedSegmentDecrement_ = proto.getPredictedSegmentDecrement();
+
+  auto _connections = proto.getConnections();
+  connections.read(_connections);
+
+  auto random = proto.getRandom();
+  rng_.read(random);
+
+  activeCells_.clear();
+  for (auto value : proto.getActiveCells())
+  {
+    activeCells_.push_back(Cell(value));
+  }
+
+  if (proto.getActiveSegments().size())
+  {
+    // There's no way to convert a UInt32 to a segment. It never worked.
+    NTA_WARN << "ExtendedTemporalMemory::read :: Obsolete field 'activeSegments' isn't usable. "
+             << "ExtendedTemporalMemory results will be goofy for one timestep.";
+  }
+
+  activeSegments_.clear();
+  for (auto value : proto.getActiveSegmentOverlaps())
+  {
+    Segment segment = {(SegmentIdx)value.getSegment(),
+                       {(CellIdx)value.getCell()}};
+    activeSegments_.push_back({segment, value.getOverlap()});
+  }
+
+  winnerCells_.clear();
+  for (auto value : proto.getWinnerCells())
+  {
+    winnerCells_.push_back(Cell(value));
+  }
+
+  if (proto.getMatchingSegments().size())
+  {
+    // There's no way to convert a UInt32 to a segment. It never worked.
+    NTA_WARN << "ExtendedTemporalMemory::read :: Obsolete field 'matchingSegments' isn't usable. "
+             << "ExtendedTemporalMemory results will be goofy for one timestep.";
+  }
+
+  matchingSegments_.clear();
+  for (auto value : proto.getMatchingSegmentOverlaps())
+  {
+    Segment segment = {(SegmentIdx)value.getSegment(),
+                       {(CellIdx)value.getCell()}};
+    matchingSegments_.push_back({segment, value.getOverlap()});
+  }
+}
+
+void ExtendedTemporalMemory::load(istream& inStream)
+{
+  // Check the marker
+  string marker;
+  inStream >> marker;
+  NTA_CHECK(marker == "ExtendedTemporalMemory");
+
+  // Check the saved version.
+  UInt version;
+  inStream >> version;
+  NTA_CHECK(version <= version_);
+
+  // Retrieve simple variables
+  inStream >> numColumns_
+    >> cellsPerColumn_
+    >> activationThreshold_
+    >> initialPermanence_
+    >> connectedPermanence_
+    >> minThreshold_
+    >> maxNewSynapseCount_
+    >> permanenceIncrement_
+    >> permanenceDecrement_
+    >> predictedSegmentDecrement_;
+
+  connections.load(inStream);
+
+  inStream >> rng_;
+
+  // Retrieve vectors.
+  UInt numColumnDimensions;
+  inStream >> numColumnDimensions;
+  columnDimensions_.resize(numColumnDimensions);
+  for (UInt i = 0; i < numColumnDimensions; i++)
+  {
+    inStream >> columnDimensions_[i];
+  }
+
+  CellIdx cellIndex;
+
+  UInt numActiveCells;
+  inStream >> numActiveCells;
+  for (UInt i = 0; i < numActiveCells; i++)
+  {
+    inStream >> cellIndex;
+    activeCells_.push_back(Cell(cellIndex));
+  }
+
+  if (version < 2)
+  {
+    UInt numPredictiveCells;
+    inStream >> numPredictiveCells;
+    for (UInt i = 0; i < numPredictiveCells; i++)
+    {
+      inStream >> cellIndex; // Ignore
+    }
+  }
+
+  if (version < 2)
+  {
+    UInt numActiveSegments;
+    inStream >> numActiveSegments;
+    activeSegments_.resize(numActiveSegments);
+    for (UInt i = 0; i < numActiveSegments; i++)
+    {
+      inStream >> activeSegments_[i].segment.idx;
+      inStream >> activeSegments_[i].segment.cell.idx;
+      activeSegments_[i].overlap = 0; // Unknown
+    }
+  }
+  else
+  {
+    UInt numActiveSegments;
+    inStream >> numActiveSegments;
+    activeSegments_.resize(numActiveSegments);
+    for (UInt i = 0; i < numActiveSegments; i++)
+    {
+      inStream >> activeSegments_[i].segment.idx;
+      inStream >> activeSegments_[i].segment.cell.idx;
+      inStream >> activeSegments_[i].overlap;
+    }
+  }
+
+  UInt numWinnerCells;
+  inStream >> numWinnerCells;
+  for (UInt i = 0; i < numWinnerCells; i++)
+  {
+    inStream >> cellIndex;
+    winnerCells_.push_back(Cell(cellIndex));
+  }
+
+  if (version < 2)
+  {
+    UInt numMatchingSegments;
+    inStream >> numMatchingSegments;
+    matchingSegments_.resize(numMatchingSegments);
+    for (UInt i = 0; i < numMatchingSegments; i++)
+    {
+      inStream >> matchingSegments_[i].segment.idx;
+      inStream >> matchingSegments_[i].segment.cell.idx;
+      matchingSegments_[i].overlap = 0; // Unknown
+    }
+  }
+  else
+  {
+    UInt numMatchingSegments;
+    inStream >> numMatchingSegments;
+    matchingSegments_.resize(numMatchingSegments);
+    for (UInt i = 0; i < numMatchingSegments; i++)
+    {
+      inStream >> matchingSegments_[i].segment.idx;
+      inStream >> matchingSegments_[i].segment.cell.idx;
+      inStream >> matchingSegments_[i].overlap;
+    }
+  }
+
+  if (version < 2)
+  {
+    UInt numMatchingCells;
+    inStream >> numMatchingCells;
+    for (UInt i = 0; i < numMatchingCells; i++) {
+      inStream >> cellIndex; // Ignore
+    }
+  }
+
+  inStream >> marker;
+  NTA_CHECK(marker == "~ExtendedTemporalMemory");
+
+}
+
+//----------------------------------------------------------------------
+// Debugging helpers
+//----------------------------------------------------------------------
+
+// Print the main TM creation parameters
+void ExtendedTemporalMemory::printParameters()
+{
+  std::cout << "------------CPP ExtendedTemporalMemory Parameters ------------------\n";
+  std::cout
+    << "version                   = " << version_ << std::endl
+    << "numColumns                = " << numberOfColumns() << std::endl
+    << "cellsPerColumn            = " << getCellsPerColumn() << std::endl
+    << "activationThreshold       = " << getActivationThreshold() << std::endl
+    << "initialPermanence         = " << getInitialPermanence() << std::endl
+    << "connectedPermanence       = " << getConnectedPermanence() << std::endl
+    << "minThreshold              = " << getMinThreshold() << std::endl
+    << "maxNewSynapseCount        = " << getMaxNewSynapseCount() << std::endl
+    << "permanenceIncrement       = " << getPermanenceIncrement() << std::endl
+    << "permanenceDecrement       = " << getPermanenceDecrement() << std::endl
+    << "predictedSegmentDecrement = " << getPredictedSegmentDecrement() << std::endl;
+}
+
+void ExtendedTemporalMemory::printState(vector<UInt> &state)
+{
+  std::cout << "[  ";
+  for (UInt i = 0; i != state.size(); ++i) {
+    if (i > 0 && i % 10 == 0) {
+      std::cout << "\n   ";
+    }
+    std::cout << state[i] << " ";
+  }
+  std::cout << "]\n";
+}
+
+void ExtendedTemporalMemory::printState(vector<Real> &state)
+{
+  std::cout << "[  ";
+  for (UInt i = 0; i != state.size(); ++i) {
+    if (i > 0 && i % 10 == 0) {
+      std::cout << "\n   ";
+    }
+    std::printf("%6.3f ", state[i]);
+  }
+  std::cout << "]\n";
+}

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -582,15 +582,12 @@ void ExtendedTemporalMemory::compute(
   const UInt activeColumnsUnsorted[],
   bool learn)
 {
-  const vector<CellIdx> prevActiveCells = activeCells_;
-  const vector<CellIdx> prevWinnerCells = winnerCells_;
+  const vector<CellIdx> prevActiveCells = std::move(activeCells_);
+  const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
 
   vector<UInt> activeColumns(activeColumnsUnsorted,
                              activeColumnsUnsorted + activeColumnsSize);
   std::sort(activeColumns.begin(), activeColumns.end());
-
-  activeCells_.clear();
-  winnerCells_.clear();
 
   for (const ExcitedColumnData& excitedColumn : ExcitedColumns(activeColumns,
                                                                activeSegments_,

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -43,8 +43,8 @@ using namespace nupic;
 using namespace nupic::algorithms::connections;
 using namespace nupic::experimental::extended_temporal_memory;
 
-#define EPSILON 0.000001
-#define EXTENDED_TM_VERSION 1
+static const Permanence EPSILON = 0.000001;
+static const UInt EXTENDED_TM_VERSION = 1;
 
 ExtendedTemporalMemory::ExtendedTemporalMemory()
 {

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -120,8 +120,8 @@ namespace nupic {
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
           Int seed = 42,
-          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+          UInt maxSegmentsPerCell=255,
+          UInt maxSynapsesPerSegment=255);
 
         virtual void initialize(
           vector<UInt> columnDimensions = { 2048 },
@@ -135,8 +135,8 @@ namespace nupic {
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
           Int seed = 42,
-          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
-          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+          UInt maxSegmentsPerCell=255,
+          UInt maxSynapsesPerSegment=255);
 
         virtual ~ExtendedTemporalMemory();
 

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -119,6 +119,7 @@ namespace nupic {
           Permanence permanenceIncrement = 0.10,
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
+          bool formInternalConnections = true,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
           UInt maxSynapsesPerSegment=255);
@@ -134,6 +135,7 @@ namespace nupic {
           Permanence permanenceIncrement = 0.10,
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
+          bool formInternalConnections = true,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
           UInt maxSynapsesPerSegment=255);
@@ -341,6 +343,14 @@ namespace nupic {
         void setMaxNewSynapseCount(UInt);
 
         /**
+         * Returns whether to form internal connections between cells.
+         *
+         * @returns the formInternalConnections parameter
+         */
+        bool getFormInternalConnections() const;
+        void setFormInternalConnections(bool formInternalConnections);
+
+        /**
          * Returns the permanence increment.
          *
          * @returns Returns the Permanence increment
@@ -438,6 +448,7 @@ namespace nupic {
         UInt activationThreshold_;
         UInt minThreshold_;
         UInt maxNewSynapseCount_;
+        bool formInternalConnections_;
         Permanence initialPermanence_;
         Permanence connectedPermanence_;
         Permanence permanenceIncrement_;

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -337,23 +337,12 @@ namespace nupic {
         Permanence getPredictedSegmentDecrement() const;
         void setPredictedSegmentDecrement(Permanence);
 
-       /**
-        * Extracts a vector<CellIdx> from a Iterable of Cells.
-        *
-        * @param Iterable<Cell> Iterable of Cells
-        *                       (.e.g. set<Cell>, vector<Cell>).
-        *
-        * @returns vector<CellIdx> The indices of the Cells in the Iterable.
-        */
-        template <typename Iterable>
-        vector<CellIdx> _cellsToIndices(const Iterable &cellSet) const;
-
         /**
          * Raises an error if cell index is invalid.
          *
          * @param cell Cell index
          */
-        bool _validateCell(Cell& cell);
+        bool _validateCell(CellIdx cell);
 
         /**
          * Save (serialize) the current state of the spatial pooler to the
@@ -403,7 +392,7 @@ namespace nupic {
          *
          * @return (int) Column index
          */
-        Int columnForCell(Cell& cell);
+        Int columnForCell(CellIdx cell);
 
         /**
          * Print the given UInt array in a nice format
@@ -428,8 +417,8 @@ namespace nupic {
         Permanence permanenceDecrement_;
         Permanence predictedSegmentDecrement_;
 
-        vector<Cell> activeCells_;
-        vector<Cell> winnerCells_;
+        vector<CellIdx> activeCells_;
+        vector<CellIdx> winnerCells_;
         vector<SegmentOverlap> activeSegments_;
         vector<SegmentOverlap> matchingSegments_;
 

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -40,7 +40,7 @@ using namespace nupic::algorithms::connections;
 #include <nupic/proto/ExtendedTemporalMemoryProto.capnp.h>
 
 namespace nupic {
-  namespace algorithms {
+  namespace experimental {
     namespace extended_temporal_memory {
 
       /**

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -151,9 +151,7 @@ namespace nupic {
          *
          * @returns Integer version number.
          */
-        virtual UInt version() const {
-          return version_;
-        };
+        virtual UInt version() const;
 
         /**
          * This *only* updates _rng to a new Random using seed.
@@ -460,7 +458,6 @@ namespace nupic {
         vector<SegmentOverlap> activeSegments_;
         vector<SegmentOverlap> matchingSegments_;
 
-        UInt version_;
         Random rng_;
 
       public:

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -44,25 +44,7 @@ namespace nupic {
     namespace extended_temporal_memory {
 
       /**
-       * CLA temporal memory implementation in C++.
-       *
-       * The primary public interfaces to this function are the "initialize"
-       * and "compute" methods.
-       *
-       * Example usage:
-       *
-       *     SpatialPooler sp;
-       *     sp.initialize(inputDimensions, columnDimensions, <parameters>);
-       *
-       *     ExtendedTemporalMemory tm;
-       *     tm.initialize(columnDimensions, <parameters>);
-       *
-       *     while (true) {
-       *        <get input vector, streaming spatiotemporal information>
-       *        sp.compute(inputVector, learn, activeColumns)
-       *        tm.compute(number of activeColumns, activeColumns, learn)
-       *        <do something with output, e.g. classify it>
-       *     }
+       * Extended Temporal Memory implementation in C++.
        *
        */
       class ExtendedTemporalMemory :
@@ -185,20 +167,65 @@ namespace nupic {
         virtual void reset();
 
         /**
+         * Calculate the active cells, using the current active columns and
+         * dendrite segments. Grow and reinforce synapses.
+         *
+         * @param activeColumns
+         * A sorted list of active column indices.
+         *
+         * @param prevActiveExternalCells
+         * The external cells that were used to calculate the current segment
+         * excitation. This class doesn't save a copy of these cells because the
+         * caller is more flexible to find ways of keeping this list available
+         * without extra copying.
+         *
+         * @param learn
+         * If true, reinforce / punish / grow synapses.
+         */
+        void activateCells(
+          const vector<UInt>& activeColumns,
+          const vector<CellIdx>& prevActiveExternalCells,
+          bool learn = true);
+
+        /**
+         * Calculate dendrite segment activity, using the current active cells.
+         *
+         * @param activeExternalCells
+         * Active external cells that should be used for activating dendrites in
+         * this timestep.
+         *
+         * @param learn
+         * If true, segment activations will be recorded. This information is
+         * used during segment cleanup.
+         */
+        void activateDendrites(
+          const vector<CellIdx>& activeExternalCells,
+          bool learn = true);
+
+        /**
          * Feeds input record through TM, performing inference and learning.
          *
-         * @param activeColumnsSize Number of active columns
-         * @param activeColumns     Indices of active columns
-         * @param learn             Whether or not learning is enabled
+         * @param activeColumnsUnsorted
+         * A list of active column indices.
          *
-         * Updates member variables:
-         * - `activeCells`
-         * - `winnerCells`
-         * - `activeSegments`
-         * - `matchingSegments`
+         * @param prevActiveExternalCells
+         * The external cells that were used to calculate the current segment
+         * excitation. This class doesn't save a copy of these cells because the
+         * caller is more flexible to find ways of keeping this list available
+         * without extra copying.
+         *
+         * @param activeExternalCells
+         * Active external cells that should be used for activating dendrites in
+         * this timestep.
+         *
+         * @param learn
+         * Whether or not learning is enabled
          */
         virtual void compute(
-          UInt activeColumnsSize, const UInt activeColumns[], bool learn = true);
+          const vector<UInt>& activeColumnsUnsorted,
+          const vector<CellIdx>& prevActiveExternalCells,
+          const vector<CellIdx>& activeExternalCells,
+          bool learn = true);
 
 
         // ==============================

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -1,0 +1,447 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013-2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Definitions for the Extended Temporal Memory in C++
+ */
+
+#ifndef NTA_EXTENDED_TEMPORAL_MEMORY_HPP
+#define NTA_EXTENDED_TEMPORAL_MEMORY_HPP
+
+#include <vector>
+#include <nupic/types/Serializable.hpp>
+#include <nupic/types/Types.hpp>
+#include <nupic/utils/Random.hpp>
+#include <nupic/algorithms/Connections.hpp>
+
+using namespace std;
+using namespace nupic;
+using namespace nupic::algorithms::connections;
+
+#include <nupic/proto/ExtendedTemporalMemoryProto.capnp.h>
+
+namespace nupic {
+  namespace algorithms {
+    namespace extended_temporal_memory {
+
+      /**
+       * CLA temporal memory implementation in C++.
+       *
+       * The primary public interfaces to this function are the "initialize"
+       * and "compute" methods.
+       *
+       * Example usage:
+       *
+       *     SpatialPooler sp;
+       *     sp.initialize(inputDimensions, columnDimensions, <parameters>);
+       *
+       *     ExtendedTemporalMemory tm;
+       *     tm.initialize(columnDimensions, <parameters>);
+       *
+       *     while (true) {
+       *        <get input vector, streaming spatiotemporal information>
+       *        sp.compute(inputVector, learn, activeColumns)
+       *        tm.compute(number of activeColumns, activeColumns, learn)
+       *        <do something with output, e.g. classify it>
+       *     }
+       *
+       */
+      class ExtendedTemporalMemory :
+        public Serializable<ExtendedTemporalMemoryProto> {
+      public:
+        ExtendedTemporalMemory();
+
+        /**
+         * Initialize the temporal memory (TM) using the given parameters.
+         *
+         * @param columnDimensions
+         * Dimensions of the column space
+         *
+         * @param cellsPerColumn
+         * Number of cells per column
+         *
+         * @param activationThreshold
+         * If the number of active connected synapses on a segment is at least
+         * this threshold, the segment is said to be active.
+         *
+         * @param initialPermanence
+         * Initial permanence of a new synapse.
+         *
+         * @param connectedPermanence
+         * If the permanence value for a synapse is greater than this value, it
+         * is said to be connected.
+         *
+         * @param minThreshold
+         * If the number of synapses active on a segment is at least this
+         * threshold, it is selected as the best matching cell in a bursting
+         * column.
+         *
+         * @param maxNewSynapseCount
+         * The maximum number of synapses added to a segment during learning.
+         *
+         * @param permanenceIncrement
+         * Amount by which permanences of synapses are incremented during
+         * learning.
+         *
+         * @param permanenceDecrement
+         * Amount by which permanences of synapses are decremented during
+         * learning.
+         *
+         * @param predictedSegmentDecrement
+         * Amount by which active permanences of synapses of previously
+         * predicted but inactive segments are decremented.
+         *
+         * @param seed
+         * Seed for the random number generator.
+         *
+         * @param maxSegmentsPerCell
+         * The maximum number of segments per cell.
+         *
+         * @param maxSynapsesPerSegment
+         * The maximum number of synapses per segment.
+         *
+         * Notes:
+         *
+         * predictedSegmentDecrement: A good value is just a bit larger than
+         * (the column-level sparsity * permanenceIncrement). So, if column-level
+         * sparsity is 2% and permanenceIncrement is 0.01, this parameter should be
+         * something like 4% * 0.01 = 0.0004).
+         */
+        ExtendedTemporalMemory(
+          vector<UInt> columnDimensions,
+          UInt cellsPerColumn = 32,
+          UInt activationThreshold = 13,
+          Permanence initialPermanence = 0.21,
+          Permanence connectedPermanence = 0.50,
+          UInt minThreshold = 10,
+          UInt maxNewSynapseCount = 20,
+          Permanence permanenceIncrement = 0.10,
+          Permanence permanenceDecrement = 0.10,
+          Permanence predictedSegmentDecrement = 0.0,
+          Int seed = 42,
+          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
+          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+
+        virtual void initialize(
+          vector<UInt> columnDimensions = { 2048 },
+          UInt cellsPerColumn = 32,
+          UInt activationThreshold = 13,
+          Permanence initialPermanence = 0.21,
+          Permanence connectedPermanence = 0.50,
+          UInt minThreshold = 10,
+          UInt maxNewSynapseCount = 20,
+          Permanence permanenceIncrement = 0.10,
+          Permanence permanenceDecrement = 0.10,
+          Permanence predictedSegmentDecrement = 0.0,
+          Int seed = 42,
+          UInt maxSegmentsPerCell=MAX_SEGMENTS_PER_CELL,
+          UInt maxSynapsesPerSegment=MAX_SYNAPSES_PER_SEGMENT);
+
+        virtual ~ExtendedTemporalMemory();
+
+        //----------------------------------------------------------------------
+        //  Main functions
+        //----------------------------------------------------------------------
+
+        /**
+         * Get the version number of for the TM implementation.
+         *
+         * @returns Integer version number.
+         */
+        virtual UInt version() const {
+          return version_;
+        };
+
+        /**
+         * This *only* updates _rng to a new Random using seed.
+         *
+         * @returns Integer version number.
+         */
+        void seed_(UInt64 seed);
+
+        /**
+         * Indicates the start of a new sequence.
+         * Resets sequence state of the TM.
+         */
+        virtual void reset();
+
+        /**
+         * Feeds input record through TM, performing inference and learning.
+         *
+         * @param activeColumnsSize Number of active columns
+         * @param activeColumns     Indices of active columns
+         * @param learn             Whether or not learning is enabled
+         *
+         * Updates member variables:
+         * - `activeCells`
+         * - `winnerCells`
+         * - `activeSegments`
+         * - `matchingSegments`
+         */
+        virtual void compute(
+          UInt activeColumnsSize, const UInt activeColumns[], bool learn = true);
+
+
+        // ==============================
+        //  Helper functions
+        // ==============================
+
+        /**
+         * Returns the indices of cells that belong to a column.
+         *
+         * @param column Column index
+         *
+         * @return (vector<CellIdx>) Cell indices
+         */
+        vector<CellIdx> cellsForColumn(Int column);
+
+        /**
+         * Returns the number of cells in this layer.
+         *
+         * @return (int) Number of cells
+         */
+        UInt numberOfCells(void);
+
+        /**
+        * Returns the indices of the active cells.
+        *
+        * @returns (std::vector<CellIdx>) Vector of indices of active cells.
+        */
+        vector<CellIdx> getActiveCells() const;
+
+        /**
+        * Returns the indices of the predictive cells.
+        *
+        * @returns (std::vector<CellIdx>) Vector of indices of predictive cells.
+        */
+        vector<CellIdx> getPredictiveCells() const;
+
+        /**
+        * Returns the indices of the winner cells.
+        *
+        * @returns (std::vector<CellIdx>) Vector of indices of winner cells.
+        */
+        vector<CellIdx> getWinnerCells() const;
+
+        /**
+        * Returns the indices of the matching cells.
+        *
+        * @returns (std::vector<CellIdx>) Vector of indices of matching cells.
+        */
+        vector<CellIdx> getMatchingCells() const;
+
+        vector<Segment> getActiveSegments() const;
+        vector<Segment> getMatchingSegments() const;
+
+        /**
+         * Returns the dimensions of the columns in the region.
+         *
+         * @returns Integer number of column dimension
+         */
+        vector<UInt> getColumnDimensions() const;
+
+        /**
+         * Returns the total number of columns.
+         *
+         * @returns Integer number of column numbers
+         */
+        UInt numberOfColumns() const;
+
+        /**
+         * Returns the number of cells per column.
+         *
+         * @returns Integer number of cells per column
+         */
+        UInt getCellsPerColumn() const;
+
+        /**
+         * Returns the activation threshold.
+         *
+         * @returns Integer number of the activation threshold
+         */
+        UInt getActivationThreshold() const;
+        void setActivationThreshold(UInt);
+
+        /**
+         * Returns the initial permanence.
+         *
+         * @returns Initial permanence
+         */
+        Permanence getInitialPermanence() const;
+        void setInitialPermanence(Permanence);
+
+        /**
+         * Returns the connected permanance.
+         *
+         * @returns Returns the connected permanance
+         */
+        Permanence getConnectedPermanence() const;
+        void setConnectedPermanence(Permanence);
+
+        /**
+         * Returns the minimum threshold.
+         *
+         * @returns Integer number of minimum threshold
+         */
+        UInt getMinThreshold() const;
+        void setMinThreshold(UInt);
+
+        /**
+         * Returns the maximum new synapse count.
+         *
+         * @returns Integer number of maximum new synapse count
+         */
+        UInt getMaxNewSynapseCount() const;
+        void setMaxNewSynapseCount(UInt);
+
+        /**
+         * Returns the permanence increment.
+         *
+         * @returns Returns the Permanence increment
+         */
+        Permanence getPermanenceIncrement() const;
+        void setPermanenceIncrement(Permanence);
+
+        /**
+         * Returns the permanence decrement.
+         *
+         * @returns Returns the Permanence decrement
+         */
+        Permanence getPermanenceDecrement() const;
+        void setPermanenceDecrement(Permanence);
+
+        /**
+         * Returns the predicted Segment decrement.
+         *
+         * @returns Returns the segment decrement
+         */
+        Permanence getPredictedSegmentDecrement() const;
+        void setPredictedSegmentDecrement(Permanence);
+
+       /**
+        * Extracts a vector<CellIdx> from a Iterable of Cells.
+        *
+        * @param Iterable<Cell> Iterable of Cells
+        *                       (.e.g. set<Cell>, vector<Cell>).
+        *
+        * @returns vector<CellIdx> The indices of the Cells in the Iterable.
+        */
+        template <typename Iterable>
+        vector<CellIdx> _cellsToIndices(const Iterable &cellSet) const;
+
+        /**
+         * Raises an error if cell index is invalid.
+         *
+         * @param cell Cell index
+         */
+        bool _validateCell(Cell& cell);
+
+        /**
+         * Save (serialize) the current state of the spatial pooler to the
+         * specified file.
+         *
+         * @param fd A valid file descriptor.
+         */
+        virtual void save(ostream& outStream) const;
+
+        using Serializable::write;
+        virtual void write(
+          ExtendedTemporalMemoryProto::Builder& proto) const override;
+
+        /**
+         * Load (deserialize) and initialize the spatial pooler from the
+         * specified input stream.
+         *
+         * @param inStream A valid istream.
+         */
+        virtual void load(istream& inStream);
+
+        using Serializable::read;
+        virtual void read(ExtendedTemporalMemoryProto::Reader& proto) override;
+
+        /**
+         * Returns the number of bytes that a save operation would result in.
+         * Note: this method is currently somewhat inefficient as it just does
+         * a full save into an ostream and counts the resulting size.
+         *
+         * @returns Integer number of bytes
+         */
+        virtual UInt persistentSize() const;
+
+        //----------------------------------------------------------------------
+        // Debugging helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * Print the main TM creation parameters
+         */
+        void printParameters();
+
+        /**
+         * Returns the index of the column that a cell belongs to.
+         *
+         * @param cell Cell index
+         *
+         * @return (int) Column index
+         */
+        Int columnForCell(Cell& cell);
+
+        /**
+         * Print the given UInt array in a nice format
+         */
+        void printState(vector<UInt> &state);
+
+        /**
+         * Print the given Real array in a nice format
+         */
+        void printState(vector<Real> &state);
+
+      protected:
+        UInt numColumns_;
+        vector<UInt> columnDimensions_;
+        UInt cellsPerColumn_;
+        UInt activationThreshold_;
+        UInt minThreshold_;
+        UInt maxNewSynapseCount_;
+        Permanence initialPermanence_;
+        Permanence connectedPermanence_;
+        Permanence permanenceIncrement_;
+        Permanence permanenceDecrement_;
+        Permanence predictedSegmentDecrement_;
+
+        vector<Cell> activeCells_;
+        vector<Cell> winnerCells_;
+        vector<SegmentOverlap> activeSegments_;
+        vector<SegmentOverlap> matchingSegments_;
+
+        UInt version_;
+        Random rng_;
+
+      public:
+        Connections connections;
+      };
+
+    } // end namespace extended_temporal_memory
+  } // end namespace algorithms
+} // end namespace nta
+
+#endif // NTA_EXTENDED_TEMPORAL_MEMORY_HPP

--- a/src/nupic/proto/ExtendedTemporalMemoryProto.capnp
+++ b/src/nupic/proto/ExtendedTemporalMemoryProto.capnp
@@ -1,0 +1,45 @@
+@0xe6601be8ebc25c9b;
+
+# TODO: Use absolute path
+using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto;
+using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto.SegmentOverlapProto;
+using import "/nupic/proto/RandomProto.capnp".RandomProto;
+
+# Next ID: 21
+struct ExtendedTemporalMemoryProto {
+
+  columnDimensions @0 :List(UInt32);
+  cellsPerColumn @1 :UInt32;
+  activationThreshold @2 :UInt32;
+  learningRadius @3 :UInt32;
+  initialPermanence @4 :Float32;
+  connectedPermanence @5 :Float32;
+  minThreshold @6 :UInt32;
+  maxNewSynapseCount @7 :UInt32;
+  permanenceIncrement @8 :Float32;
+  permanenceDecrement @9 :Float32;
+
+  connections @10 :ConnectionsProto;
+  random @11 :RandomProto;
+
+  # Lists of indices
+  activeCells @12 :List(UInt32);
+
+  # Obsolete, information contained in activeSegmentOverlaps
+  predictiveCells @13 :List(UInt32);
+
+  # Obsolete, replaced by activeSegmentOverlaps
+  activeSegments @14 :List(UInt32);
+
+  winnerCells @15 :List(UInt32);
+
+  # Obsolete, replaced by matchingSegmentOverlaps
+  matchingSegments @16 :List(UInt32);
+
+  # Obsolete, information contained in matchingSegmentOverlaps
+  matchingCells @17 :List(UInt32);
+
+  predictedSegmentDecrement @18 :Float32;
+  activeSegmentOverlaps @19 :List(SegmentOverlapProto);
+  matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
+}

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -105,9 +105,9 @@ namespace nupic
 
     // Learn
 
-    vector< vector< vector<Cell> > >sequences;
-    vector< vector<Cell> >sequence;
-    vector<Cell> sdr;
+    vector< vector< vector<CellIdx> > >sequences;
+    vector< vector<CellIdx> >sequence;
+    vector<CellIdx> sdr;
 
     for (int i = 0; i < numSequences; i++)
     {
@@ -157,15 +157,13 @@ namespace nupic
     clock_t timer = clock();
 
     Connections connections(numCells, 1, numInputs);
-    Cell cell;
     Segment segment;
-    vector<Cell> sdr;
+    vector<CellIdx> sdr;
 
     // Initialize
 
     for (UInt c = 0; c < numCells; c++)
     {
-      cell = Cell(c);
       segment = connections.createSegment(c);
 
       for (UInt i = 0; i < numInputs; i++)
@@ -180,7 +178,7 @@ namespace nupic
 
     // Learn
 
-    vector<Cell> winnerCells;
+    vector<CellIdx> winnerCells;
     SynapseData synapseData;
     Permanence permanence;
 
@@ -193,7 +191,7 @@ namespace nupic
                                   activeSegments, matchingSegments);
       winnerCells = computeSPWinnerCells(connections, numWinners, activeSegments);
 
-      for (Cell winnerCell : winnerCells)
+      for (CellIdx winnerCell : winnerCells)
       {
         segment = Segment(0, winnerCell);
 
@@ -250,10 +248,10 @@ namespace nupic
     cout << duration << " in " << text << endl;
   }
 
-  vector<Cell> ConnectionsPerformanceTest::randomSDR(UInt n, UInt w)
+  vector<CellIdx> ConnectionsPerformanceTest::randomSDR(UInt n, UInt w)
   {
     set<UInt> sdrSet = set<UInt>();
-    vector<Cell> sdr = vector<Cell>();
+    vector<CellIdx> sdr;
 
     for (UInt i = 0; i < w; i++)
     {
@@ -262,31 +260,31 @@ namespace nupic
 
     for (UInt c : sdrSet)
     {
-      sdr.push_back(Cell(c));
+      sdr.push_back(c);
     }
 
     return sdr;
   }
 
   void ConnectionsPerformanceTest::feedTM(TemporalMemory &tm,
-                                          vector<Cell> sdr,
+                                          vector<CellIdx> sdr,
                                           bool learn)
   {
     vector<UInt> activeColumns;
 
     for (auto c : sdr)
     {
-      activeColumns.push_back(c.idx);
+      activeColumns.push_back(c);
     }
 
     tm.compute(activeColumns.size(), activeColumns.data(), learn);
   }
 
-  vector<Cell> ConnectionsPerformanceTest::computeSPWinnerCells(
+  vector<CellIdx> ConnectionsPerformanceTest::computeSPWinnerCells(
     Connections& connections, UInt numCells,
     vector<SegmentOverlap> activeSegments)
   {
-    set<Cell> winnerCells;
+    set<CellIdx> winnerCells;
 
     std::sort(activeSegments.begin(), activeSegments.end(),
               [](const SegmentOverlap& a, const SegmentOverlap&b)
@@ -303,7 +301,7 @@ namespace nupic
       }
     }
 
-    return vector<Cell>(winnerCells.begin(), winnerCells.end());
+    return vector<CellIdx>(winnerCells.begin(), winnerCells.end());
   }
 
 } // end namespace nupic

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -46,7 +46,6 @@ namespace nupic
     namespace connections
     {
       struct SegmentOverlap;
-      struct Cell;
     }
   }
 
@@ -77,11 +76,11 @@ namespace nupic
                               std::string label);
 
     void checkpoint(clock_t timer, std::string text);
-    std::vector<algorithms::connections::Cell> randomSDR(UInt n, UInt w);
+    std::vector<UInt32> randomSDR(UInt n, UInt w);
     void feedTM(algorithms::temporal_memory::TemporalMemory &tm,
-                std::vector<algorithms::connections::Cell> sdr,
+                std::vector<CellIdx> sdr,
                 bool learn = true);
-    std::vector<algorithms::connections::Cell> computeSPWinnerCells(
+    std::vector<CellIdx> computeSPWinnerCells(
       Connections& connections,
       UInt numCells,
       vector<algorithms::connections::SegmentOverlap> activeSegments);

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -43,42 +43,42 @@ namespace {
     // Segment with:
     // - 1 connected synapse: active
     // - 2 matching synapses
-    const Segment segment1_1 = connections.createSegment(Cell(10));
-    connections.createSynapse(segment1_1, Cell(150), 0.85);
-    connections.createSynapse(segment1_1, Cell(151), 0.15);
+    const Segment segment1_1 = connections.createSegment(10);
+    connections.createSynapse(segment1_1, 150, 0.85);
+    connections.createSynapse(segment1_1, 151, 0.15);
 
     // Cell with 2 segments.
     // Segment with:
     // - 2 connected synapses: 2 active
     // - 3 matching synapses: 3 active
-    const Segment segment2_1 = connections.createSegment(Cell(20));
-    connections.createSynapse(segment2_1, Cell(80), 0.85);
-    connections.createSynapse(segment2_1, Cell(81), 0.85);
-    Synapse synapse = connections.createSynapse(segment2_1, Cell(82), 0.85);
+    const Segment segment2_1 = connections.createSegment(20);
+    connections.createSynapse(segment2_1, 80, 0.85);
+    connections.createSynapse(segment2_1, 81, 0.85);
+    Synapse synapse = connections.createSynapse(segment2_1, 82, 0.85);
     connections.updateSynapsePermanence(synapse, 0.15);
 
     // Segment with:
     // - 2 connected synapses: 1 active, 1 inactive
     // - 3 matching synapses: 2 active, 1 inactive
     // - 1 non-matching synapse: 1 active
-    const Segment segment2_2 = connections.createSegment(Cell(20));
-    connections.createSynapse(segment2_2, Cell(50), 0.85);
-    connections.createSynapse(segment2_2, Cell(51), 0.85);
-    connections.createSynapse(segment2_2, Cell(52), 0.15);
-    connections.createSynapse(segment2_2, Cell(53), 0.05);
+    const Segment segment2_2 = connections.createSegment(20);
+    connections.createSynapse(segment2_2, 50, 0.85);
+    connections.createSynapse(segment2_2, 51, 0.85);
+    connections.createSynapse(segment2_2, 52, 0.15);
+    connections.createSynapse(segment2_2, 53, 0.05);
 
     // Cell with one segment.
     // Segment with:
     // - 1 non-matching synapse: 1 active
-    const Segment segment3_1 = connections.createSegment(Cell(30));
-    connections.createSynapse(segment3_1, Cell(53), 0.05);
+    const Segment segment3_1 = connections.createSegment(30);
+    connections.createSynapse(segment3_1, 53, 0.05);
   }
 
   void computeSampleActivity(Connections &connections)
   {
-    vector<Cell> input = {{50}, {52}, {53},
-                          {80}, {81}, {82},
-                          {150}, {151}};
+    vector<UInt32> input = {50, 52, 53,
+                            80, 81, 82,
+                            150, 151};
 
     vector<SegmentOverlap> activeSegments;
     vector<SegmentOverlap> matchingSegments;
@@ -94,22 +94,22 @@ namespace {
   {
     Connections connections(1024);
     Segment segment;
-    Cell cell(10);
+    UInt32 cell = 10;
 
     segment = connections.createSegment(cell);
     ASSERT_EQ(segment.idx, 0);
-    ASSERT_EQ(segment.cell.idx, cell.idx);
+    ASSERT_EQ(segment.cell, cell);
 
     segment = connections.createSegment(cell);
     ASSERT_EQ(segment.idx, 1);
-    ASSERT_EQ(segment.cell.idx, cell.idx);
+    ASSERT_EQ(segment.cell, cell);
 
     vector<Segment> segments = connections.segmentsForCell(cell);
     ASSERT_EQ(segments.size(), 2);
 
     for (SegmentIdx i = 0; i < (SegmentIdx)segments.size(); i++) {
       ASSERT_EQ(segments[i].idx, i);
-      ASSERT_EQ(segments[i].cell.idx, cell.idx);
+      ASSERT_EQ(segments[i].cell, cell);
     }
   }
 
@@ -122,9 +122,9 @@ namespace {
   {
     Connections connections(1024, 2);
 
-    Segment segment1 = connections.createSegment(Cell(42));
-    connections.createSynapse(segment1, Cell(1), 0.5);
-    connections.createSynapse(segment1, Cell(2), 0.5);
+    Segment segment1 = connections.createSegment(42);
+    connections.createSynapse(segment1, 1, 0.5);
+    connections.createSynapse(segment1, 2, 0.5);
 
     // Let some time pass.
     vector<SegmentOverlap> activeSegments;
@@ -139,16 +139,16 @@ namespace {
                                 0.5, 2, 0.10, 1,
                                 activeSegments, matchingSegments);
 
-    Segment segment2 = connections.createSegment(Cell(42));
+    Segment segment2 = connections.createSegment(42);
 
     // Give the first segment some activity.
-    connections.computeActivity({Cell(1), Cell(2)},
+    connections.computeActivity({1, 2},
                                 0.5, 2, 0.10, 1,
                                 activeSegments, matchingSegments);
     ASSERT_EQ(1, activeSegments.size());
     ASSERT_EQ(segment1, activeSegments[0].segment);
 
-    Segment segment3 = connections.createSegment(Cell(42));
+    Segment segment3 = connections.createSegment(42);
 
     EXPECT_EQ(segment2.idx, segment3.idx);
   }
@@ -160,17 +160,15 @@ namespace {
   TEST(ConnectionsTest, testCreateSynapse)
   {
     Connections connections(1024);
-    Cell cell(10), presynapticCell;
+    UInt32 cell = 10;
     Segment segment = connections.createSegment(cell);
     Synapse synapse;
 
-    presynapticCell.idx = 50;
-    synapse = connections.createSynapse(segment, presynapticCell, 0.34);
+    synapse = connections.createSynapse(segment, 50, 0.34);
     ASSERT_EQ(synapse.idx, 0);
     ASSERT_EQ(synapse.segment.idx, segment.idx);
 
-    presynapticCell.idx = 150;
-    synapse = connections.createSynapse(segment, presynapticCell, 0.48);
+    synapse = connections.createSynapse(segment, 150, 0.48);
     ASSERT_EQ(synapse.idx, 1);
     ASSERT_EQ(synapse.segment.idx, segment.idx);
 
@@ -180,17 +178,17 @@ namespace {
     for (SynapseIdx i = 0; i < synapses.size(); i++) {
       ASSERT_EQ(synapses[i].idx, i);
       ASSERT_EQ(synapses[i].segment.idx, segment.idx);
-      ASSERT_EQ(synapses[i].segment.cell.idx, cell.idx);
+      ASSERT_EQ(synapses[i].segment.cell, cell);
     }
 
     SynapseData synapseData;
 
     synapseData = connections.dataForSynapse(synapses[0]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 50);
+    ASSERT_EQ(synapseData.presynapticCell, 50);
     ASSERT_NEAR(synapseData.permanence, (Permanence)0.34, EPSILON);
 
     synapseData = connections.dataForSynapse(synapses[1]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 150);
+    ASSERT_EQ(synapseData.presynapticCell, 150);
     ASSERT_NEAR(synapseData.permanence, (Permanence)0.48, EPSILON);
   }
 
@@ -203,40 +201,37 @@ namespace {
   {
     // Limit to only two synapses per segment
     Connections connections(1024, 1024, 2);
-    Cell cell(10), presynapticCell;
+    UInt32 cell = 10;
     Segment segment = connections.createSegment(cell);
     Synapse synapse;
     vector<Synapse> synapses;
     SynapseData synapseData;
 
-    presynapticCell.idx = 50;
-    synapse = connections.createSynapse(segment, presynapticCell, 0.34);
-    presynapticCell.idx = 51;
-    synapse = connections.createSynapse(segment, presynapticCell, 0.48);
+    synapse = connections.createSynapse(segment, 50, 0.34);
+    synapse = connections.createSynapse(segment, 51, 0.48);
 
     // Verify that the synapses we added are there
     synapses = connections.synapsesForSegment(segment);
     ASSERT_EQ(synapses.size(), 2);
     synapseData = connections.dataForSynapse(synapses[0]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 50);
+    ASSERT_EQ(synapseData.presynapticCell, 50);
     ASSERT_NEAR(synapseData.permanence, (Permanence)0.34, EPSILON);
     synapseData = connections.dataForSynapse(synapses[1]);
-    ASSERT_EQ(synapseData.presynapticCell.idx, 51);
+    ASSERT_EQ(synapseData.presynapticCell, 51);
     ASSERT_NEAR(synapseData.permanence, (Permanence)0.48, EPSILON);
 
     // Add an additional synapse over the limit
-    presynapticCell.idx = 52;
-    synapse = connections.createSynapse(segment, presynapticCell, 0.52);
+    synapse = connections.createSynapse(segment, 52, 0.52);
     EXPECT_EQ(0, synapse.idx);
 
     // Verify that the lowest permanence synapse was removed
     synapses = connections.synapsesForSegment(segment);
     ASSERT_EQ(synapses.size(), 2);
     synapseData = connections.dataForSynapse(synapses[0]);
-    ASSERT_EQ(52, synapseData.presynapticCell.idx);
+    ASSERT_EQ(52, synapseData.presynapticCell);
     ASSERT_NEAR((Permanence)0.52, synapseData.permanence, EPSILON);
     synapseData = connections.dataForSynapse(synapses[1]);
-    ASSERT_EQ(51, synapseData.presynapticCell.idx);
+    ASSERT_EQ(51, synapseData.presynapticCell);
     ASSERT_NEAR((Permanence)0.48, synapseData.permanence, EPSILON);
   }
 
@@ -248,14 +243,14 @@ namespace {
   {
     Connections connections(1024);
 
-    /*      segment1*/ connections.createSegment(Cell(10));
-    Segment segment2 = connections.createSegment(Cell(20));
-    /*      segment3*/ connections.createSegment(Cell(20));
-    /*      segment4*/ connections.createSegment(Cell(30));
+    /*      segment1*/ connections.createSegment(10);
+    Segment segment2 = connections.createSegment(20);
+    /*      segment3*/ connections.createSegment(20);
+    /*      segment4*/ connections.createSegment(30);
 
-    connections.createSynapse(segment2, Cell(80), 0.85);
-    connections.createSynapse(segment2, Cell(81), 0.85);
-    connections.createSynapse(segment2, Cell(82), 0.15);
+    connections.createSynapse(segment2, 80, 0.85);
+    connections.createSynapse(segment2, 81, 0.85);
+    connections.createSynapse(segment2, 82, 0.15);
 
     ASSERT_EQ(4, connections.numSegments());
     ASSERT_EQ(3, connections.numSynapses());
@@ -268,7 +263,7 @@ namespace {
 
     vector<SegmentOverlap> activeSegments;
     vector<SegmentOverlap> matchingSegments;
-    connections.computeActivity({{80}, {81}, {82}},
+    connections.computeActivity({80, 81, 82},
                                 0.5, 2, 0.0, 1,
                                 activeSegments, matchingSegments);
 
@@ -284,10 +279,10 @@ namespace {
   {
     Connections connections(1024);
 
-    Segment segment = connections.createSegment(Cell(20));
-    /*      synapse1*/ connections.createSynapse(segment, Cell(80), 0.85);
-    Synapse synapse2 = connections.createSynapse(segment, Cell(81), 0.85);
-    /*      synapse3*/ connections.createSynapse(segment, Cell(82), 0.15);
+    Segment segment = connections.createSegment(20);
+    /*      synapse1*/ connections.createSynapse(segment, 80, 0.85);
+    Synapse synapse2 = connections.createSynapse(segment, 81, 0.85);
+    /*      synapse3*/ connections.createSynapse(segment, 82, 0.15);
 
     ASSERT_EQ(3, connections.numSynapses());
 
@@ -298,7 +293,7 @@ namespace {
 
     vector<SegmentOverlap> activeSegments;
     vector<SegmentOverlap> matchingSegments;
-    connections.computeActivity({{80}, {81}, {82}},
+    connections.computeActivity({80, 81, 82},
                                 0.5, 2, 0.0, 1,
                                 activeSegments, matchingSegments);
 
@@ -316,30 +311,30 @@ namespace {
   {
     Connections connections(1024);
 
-    Segment segment1 = connections.createSegment(Cell(11));
-    /*      segment2*/ connections.createSegment(Cell(12));
+    Segment segment1 = connections.createSegment(11);
+    /*      segment2*/ connections.createSegment(12);
 
-    Segment segment3 = connections.createSegment(Cell(13));
-    Synapse synapse1 = connections.createSynapse(segment3, Cell(201), 0.85);
-    /*      synapse2*/ connections.createSynapse(segment3, Cell(202), 0.85);
-    Synapse synapse3 = connections.createSynapse(segment3, Cell(203), 0.85);
-    /*      synapse4*/ connections.createSynapse(segment3, Cell(204), 0.85);
-    Synapse synapse5 = connections.createSynapse(segment3, Cell(205), 0.85);
+    Segment segment3 = connections.createSegment(13);
+    Synapse synapse1 = connections.createSynapse(segment3, 201, 0.85);
+    /*      synapse2*/ connections.createSynapse(segment3, 202, 0.85);
+    Synapse synapse3 = connections.createSynapse(segment3, 203, 0.85);
+    /*      synapse4*/ connections.createSynapse(segment3, 204, 0.85);
+    Synapse synapse5 = connections.createSynapse(segment3, 205, 0.85);
 
-    /*      segment4*/ connections.createSegment(Cell(14));
-    Segment segment5 = connections.createSegment(Cell(15));
+    /*      segment4*/ connections.createSegment(14);
+    Segment segment5 = connections.createSegment(15);
 
-    ASSERT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    ASSERT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell);
     connections.destroySynapse(synapse1);
-    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell);
     connections.destroySynapse(synapse5);
-    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell);
 
     connections.destroySegment(segment1);
     EXPECT_EQ(3, connections.synapsesForSegment(segment3).size());
     connections.destroySegment(segment5);
     EXPECT_EQ(3, connections.synapsesForSegment(segment3).size());
-    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell.idx);
+    EXPECT_EQ(203, connections.dataForSynapse(synapse3).presynapticCell);
   }
 
   /**
@@ -350,12 +345,12 @@ namespace {
   {
     Connections connections(1024);
 
-    Segment segment1 = connections.createSegment(Cell(11));
-    Segment segment2 = connections.createSegment(Cell(12));
+    Segment segment1 = connections.createSegment(11);
+    Segment segment2 = connections.createSegment(12);
 
-    /*      synapse1_1*/ connections.createSynapse(segment1, Cell(101), 0.85);
-    Synapse synapse2_1 = connections.createSynapse(segment2, Cell(201), 0.85);
-    /*      synapse2_2*/ connections.createSynapse(segment2, Cell(202), 0.85);
+    /*      synapse1_1*/ connections.createSynapse(segment1, 101, 0.85);
+    Synapse synapse2_1 = connections.createSynapse(segment2, 201, 0.85);
+    /*      synapse2_2*/ connections.createSynapse(segment2, 202, 0.85);
 
     ASSERT_EQ(3, connections.numSynapses());
 
@@ -379,17 +374,17 @@ namespace {
   {
     Connections connections(1024);
 
-    Segment segment = connections.createSegment(Cell(11));
+    Segment segment = connections.createSegment(11);
 
-    Synapse synapse1 = connections.createSynapse(segment, Cell(201), 0.85);
-    /*      synapse2*/ connections.createSynapse(segment, Cell(202), 0.85);
+    Synapse synapse1 = connections.createSynapse(segment, 201, 0.85);
+    /*      synapse2*/ connections.createSynapse(segment, 202, 0.85);
 
     connections.destroySynapse(synapse1);
 
     ASSERT_EQ(1, connections.numSynapses(segment));
 
     connections.destroySegment(segment);
-    Segment reincarnated = connections.createSegment(Cell(11));
+    Segment reincarnated = connections.createSegment(11);
 
     EXPECT_EQ(0, connections.numSynapses(reincarnated));
     EXPECT_EQ(0, connections.synapsesForSegment(reincarnated).size());
@@ -404,8 +399,8 @@ namespace {
     Connections connections(1024, 2, 2);
 
     {
-      Segment segment1 = connections.createSegment(Cell(11));
-      Segment segment2 = connections.createSegment(Cell(11));
+      Segment segment1 = connections.createSegment(11);
+      Segment segment2 = connections.createSegment(11);
       ASSERT_EQ(2, connections.numSegments());
       connections.destroySegment(segment1);
       connections.destroySegment(segment2);
@@ -413,11 +408,11 @@ namespace {
     }
 
     {
-      connections.createSegment(Cell(11));
+      connections.createSegment(11);
       EXPECT_EQ(1, connections.numSegments());
-      connections.createSegment(Cell(11));
+      connections.createSegment(11);
       EXPECT_EQ(2, connections.numSegments());
-      Segment segment = connections.createSegment(Cell(11));
+      Segment segment = connections.createSegment(11);
       EXPECT_LT(segment.idx, 2);
       EXPECT_EQ(2, connections.numSegments());
     }
@@ -431,11 +426,11 @@ namespace {
   {
     Connections connections(1024, 2, 2);
 
-    Segment segment = connections.createSegment(Cell(10));
+    Segment segment = connections.createSegment(10);
 
     {
-      Synapse synapse1 = connections.createSynapse(segment, Cell(201), 0.85);
-      Synapse synapse2 = connections.createSynapse(segment, Cell(202), 0.85);
+      Synapse synapse1 = connections.createSynapse(segment, 201, 0.85);
+      Synapse synapse2 = connections.createSynapse(segment, 202, 0.85);
       ASSERT_EQ(2, connections.numSynapses());
       connections.destroySynapse(synapse1);
       connections.destroySynapse(synapse2);
@@ -443,11 +438,11 @@ namespace {
     }
 
     {
-      connections.createSynapse(segment, Cell(201), 0.85);
+      connections.createSynapse(segment, 201, 0.85);
       EXPECT_EQ(1, connections.numSynapses());
-      connections.createSynapse(segment, Cell(202), 0.90);
+      connections.createSynapse(segment, 202, 0.90);
       EXPECT_EQ(2, connections.numSynapses());
-      Synapse synapse = connections.createSynapse(segment, Cell(203), 0.80);
+      Synapse synapse = connections.createSynapse(segment, 203, 0.80);
       EXPECT_LT(synapse.idx, 2);
       EXPECT_EQ(2, connections.numSynapses());
     }
@@ -461,13 +456,13 @@ namespace {
   {
     Connections connections(1024, 2, 2);
 
-    connections.createSegment(Cell(10));
+    connections.createSegment(10);
     ASSERT_EQ(1, connections.numSegments());
-    connections.createSegment(Cell(10));
+    connections.createSegment(10);
     ASSERT_EQ(2, connections.numSegments());
-    connections.createSegment(Cell(10));
+    connections.createSegment(10);
     ASSERT_EQ(2, connections.numSegments());
-    connections.createSegment(Cell(10));
+    connections.createSegment(10);
     EXPECT_EQ(2, connections.numSegments());
   }
 
@@ -479,14 +474,14 @@ namespace {
   {
     Connections connections(1024, 2, 2);
 
-    Segment segment = connections.createSegment(Cell(10));
-    connections.createSynapse(segment, Cell(201), 0.85);
+    Segment segment = connections.createSegment(10);
+    connections.createSynapse(segment, 201, 0.85);
     ASSERT_EQ(1, connections.numSynapses());
-    connections.createSynapse(segment, Cell(202), 0.90);
+    connections.createSynapse(segment, 202, 0.90);
     ASSERT_EQ(2, connections.numSynapses());
-    connections.createSynapse(segment, Cell(203), 0.80);
+    connections.createSynapse(segment, 203, 0.80);
     ASSERT_EQ(2, connections.numSynapses());
-    Synapse synapse = connections.createSynapse(segment, Cell(204), 0.80);
+    Synapse synapse = connections.createSynapse(segment, 204, 0.80);
     EXPECT_LT(synapse.idx, 2);
     EXPECT_EQ(2, connections.numSynapses());
   }
@@ -498,86 +493,13 @@ namespace {
   TEST(ConnectionsTest, testUpdateSynapsePermanence)
   {
     Connections connections(1024);
-    Cell cell(10), presynapticCell(50);
-    Segment segment = connections.createSegment(cell);
-    Synapse synapse = connections.createSynapse(segment, presynapticCell, 0.34);
+    Segment segment = connections.createSegment(10);
+    Synapse synapse = connections.createSynapse(segment, 50, 0.34);
 
     connections.updateSynapsePermanence(synapse, 0.21);
 
     SynapseData synapseData = connections.dataForSynapse(synapse);
     ASSERT_NEAR(synapseData.permanence, (Real)0.21, EPSILON);
-  }
-
-  /**
-   * Creates a sample set of connections, and makes sure that getting the most
-   * active segment for a collection of cells returns the right segment.
-   */
-  TEST(ConnectionsTest, testMostActiveSegmentForCells)
-  {
-    Connections connections(1024);
-    Segment segment;
-    Synapse synapse;
-    Cell cell, presynapticCell;
-    vector<Cell> cells;
-    vector<Cell> input;
-
-    cell.idx = 10; presynapticCell.idx = 150;
-    segment = connections.createSegment(cell);
-    synapse = connections.createSynapse(segment, presynapticCell, 0.34);
-
-    cell.idx = 20; presynapticCell.idx = 50;
-    segment = connections.createSegment(cell);
-    synapse = connections.createSynapse(segment, presynapticCell, 0.85);
-
-    Cell cell1(10), cell2(20);
-    cells.push_back(cell1);
-    cells.push_back(cell2);
-
-    Cell input1(50);
-    input.push_back(input1);
-
-    bool result = connections.mostActiveSegmentForCells(
-      cells, input, 0, segment);
-
-    ASSERT_EQ(result, true);
-
-    ASSERT_EQ(segment.cell.idx, 20);
-    ASSERT_EQ(segment.idx, 0);
-  }
-
-  /**
-   * Creates a sample set of connections, and makes sure that getting the most
-   * active segment for a collection of cells with no activity returns
-   * no segment.
-   */
-  TEST(ConnectionsTest, testMostActiveSegmentForCellsNone)
-  {
-    Connections connections(1024);
-    Segment segment;
-    Synapse synapse;
-    Cell cell, presynapticCell;
-    vector<Cell> cells;
-    vector<Cell> input;
-
-    cell.idx = 10; presynapticCell.idx = 150;
-    segment = connections.createSegment(cell);
-    synapse = connections.createSynapse(segment, presynapticCell, 0.34);
-
-    cell.idx = 20; presynapticCell.idx = 50;
-    segment = connections.createSegment(cell);
-    synapse = connections.createSynapse(segment, presynapticCell, 0.85);
-
-    Cell cell1(10), cell2(20);
-    cells.push_back(cell1);
-    cells.push_back(cell2);
-
-    Cell input1(150);
-    input.push_back(input1);
-
-    bool result = connections.mostActiveSegmentForCells(
-      cells, input, 2, segment);
-
-    ASSERT_EQ(result, false);
   }
 
   /**
@@ -593,39 +515,39 @@ namespace {
     // Segment with:
     // - 1 connected synapse: active
     // - 2 matching synapses
-    const Segment segment1_1 = connections.createSegment(Cell(10));
-    connections.createSynapse(segment1_1, Cell(150), 0.85);
-    connections.createSynapse(segment1_1, Cell(151), 0.15);
+    const Segment segment1_1 = connections.createSegment(10);
+    connections.createSynapse(segment1_1, 150, 0.85);
+    connections.createSynapse(segment1_1, 151, 0.15);
 
     // Cell with 2 segments.
     // Segment with:
     // - 2 connected synapses: 2 active
     // - 3 matching synapses: 3 active
-    const Segment segment2_1 = connections.createSegment(Cell(20));
-    connections.createSynapse(segment2_1, Cell(80), 0.85);
-    connections.createSynapse(segment2_1, Cell(81), 0.85);
-    Synapse synapse = connections.createSynapse(segment2_1, Cell(82), 0.85);
+    const Segment segment2_1 = connections.createSegment(20);
+    connections.createSynapse(segment2_1, 80, 0.85);
+    connections.createSynapse(segment2_1, 81, 0.85);
+    Synapse synapse = connections.createSynapse(segment2_1, 82, 0.85);
     connections.updateSynapsePermanence(synapse, 0.15);
 
     // Segment with:
     // - 2 connected synapses: 1 active, 1 inactive
     // - 3 matching synapses: 2 active, 1 inactive
     // - 1 non-matching synapse: 1 active
-    const Segment segment2_2 = connections.createSegment(Cell(20));
-    connections.createSynapse(segment2_2, Cell(50), 0.85);
-    connections.createSynapse(segment2_2, Cell(51), 0.85);
-    connections.createSynapse(segment2_2, Cell(52), 0.15);
-    connections.createSynapse(segment2_2, Cell(53), 0.05);
+    const Segment segment2_2 = connections.createSegment(20);
+    connections.createSynapse(segment2_2, 50, 0.85);
+    connections.createSynapse(segment2_2, 51, 0.85);
+    connections.createSynapse(segment2_2, 52, 0.15);
+    connections.createSynapse(segment2_2, 53, 0.05);
 
     // Cell with one segment.
     // Segment with:
     // - 1 non-matching synapse: 1 active
-    const Segment segment3_1 = connections.createSegment(Cell(30));
-    connections.createSynapse(segment3_1, Cell(53), 0.05);
+    const Segment segment3_1 = connections.createSegment(30);
+    connections.createSynapse(segment3_1, 53, 0.05);
 
-    vector<Cell> input = {{50}, {52}, {53},
-                          {80}, {81}, {82},
-                          {150}, {151}};
+    vector<UInt32> input = {50, 52, 53,
+                            80, 81, 82,
+                            150, 151};
 
     vector<SegmentOverlap> activeSegments;
     vector<SegmentOverlap> matchingSegments;
@@ -711,11 +633,11 @@ namespace {
     auto token = connections.subscribe(handler);
 
     ASSERT_FALSE(handler->didCreateSegment);
-    Segment segment = connections.createSegment(Cell(42));
+    Segment segment = connections.createSegment(42);
     EXPECT_TRUE(handler->didCreateSegment);
 
     ASSERT_FALSE(handler->didCreateSynapse);
-    Synapse synapse = connections.createSynapse(segment, Cell(41), 0.50);
+    Synapse synapse = connections.createSynapse(segment, 41, 0.50);
     EXPECT_TRUE(handler->didCreateSynapse);
 
     ASSERT_FALSE(handler->didUpdateSynapsePermanence);
@@ -782,13 +704,8 @@ namespace {
     Connections c1(1024, 1024, 1024), c2;
     setupSampleConnections(c1);
 
-    Segment segment;
-    Cell cell, presynapticCell;
-
-    cell.idx = 10;
-    presynapticCell.idx = 400;
-    segment = c1.createSegment(cell);
-    c1.createSynapse(segment, presynapticCell, 0.5);
+    Segment segment = c1.createSegment(10);
+    c1.createSynapse(segment, 400, 0.5);
     c1.destroySegment(segment);
 
     computeSampleActivity(c1);
@@ -812,10 +729,9 @@ namespace {
     Connections c1(1024, 1024, 1024), c2;
     setupSampleConnections(c1);
 
-    Cell cell(10), presynapticCell(400);
-    auto segment = c1.createSegment(cell);
+    auto segment = c1.createSegment(10);
 
-    c1.createSynapse(segment, presynapticCell, 0.5);
+    c1.createSynapse(segment, 400, 0.5);
     c1.destroySegment(segment);
 
     computeSampleActivity(c1);

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -127,26 +127,16 @@ namespace {
     connections.createSynapse(segment1, 2, 0.5);
 
     // Let some time pass.
-    vector<SegmentOverlap> activeSegments;
-    vector<SegmentOverlap> matchingSegments;
-    connections.computeActivity({},
-                                0.5, 2, 0.10, 1,
-                                activeSegments, matchingSegments);
-    connections.computeActivity({},
-                                0.5, 2, 0.10, 1,
-                                activeSegments, matchingSegments);
-    connections.computeActivity({},
-                                0.5, 2, 0.10, 1,
-                                activeSegments, matchingSegments);
+    connections.startNewIteration();
+    connections.startNewIteration();
+    connections.startNewIteration();
 
     Segment segment2 = connections.createSegment(42);
 
+    connections.startNewIteration();
+
     // Give the first segment some activity.
-    connections.computeActivity({1, 2},
-                                0.5, 2, 0.10, 1,
-                                activeSegments, matchingSegments);
-    ASSERT_EQ(1, activeSegments.size());
-    ASSERT_EQ(segment1, activeSegments[0].segment);
+    connections.recordSegmentActivity(segment1);
 
     Segment segment3 = connections.createSegment(42);
 

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -92,15 +92,11 @@ namespace {
     const vector<CellIdx> expectedActiveCells = {4};
 
     Segment activeSegment =
-      tm.connections.createSegment(Cell(expectedActiveCells[0]));
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[0]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[1]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[2]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[3]), 0.5);
+      tm.connections.createSegment(expectedActiveCells[0]);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
 
     tm.compute(numActiveColumns, previousActiveColumns, true);
     ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
@@ -163,11 +159,11 @@ namespace {
     const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const vector<CellIdx> expectedActiveCells = {4};
 
-    Segment segment = tm.connections.createSegment(Cell(expectedActiveCells[0]));
-    tm.connections.createSynapse(segment, Cell(previousActiveCells[0]), 0.5);
-    tm.connections.createSynapse(segment, Cell(previousActiveCells[1]), 0.5);
-    tm.connections.createSynapse(segment, Cell(previousActiveCells[2]), 0.5);
-    tm.connections.createSynapse(segment, Cell(previousActiveCells[3]), 0.5);
+    Segment segment = tm.connections.createSegment(expectedActiveCells[0]);
+    tm.connections.createSynapse(segment, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(segment, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(segment, previousActiveCells[2], 0.5);
+    tm.connections.createSynapse(segment, previousActiveCells[3], 0.5);
 
     tm.compute(1, previousActiveColumns, true);
     ASSERT_FALSE(tm.getActiveCells().empty());
@@ -209,22 +205,16 @@ namespace {
     const vector<CellIdx> expectedWinnerCells = {4, 6};
 
     Segment activeSegment1 =
-      tm.connections.createSegment(Cell(expectedWinnerCells[0]));
-    tm.connections.createSynapse(activeSegment1,
-                                 Cell(previousActiveCells[0]), 0.5);
-    tm.connections.createSynapse(activeSegment1,
-                                 Cell(previousActiveCells[1]), 0.5);
-    tm.connections.createSynapse(activeSegment1,
-                                 Cell(previousActiveCells[2]), 0.5);
+      tm.connections.createSegment(expectedWinnerCells[0]);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment1, previousActiveCells[2], 0.5);
 
     Segment activeSegment2 =
-      tm.connections.createSegment(Cell(expectedWinnerCells[1]));
-    tm.connections.createSynapse(activeSegment2,
-                                 Cell(previousActiveCells[0]), 0.5);
-    tm.connections.createSynapse(activeSegment2,
-                                 Cell(previousActiveCells[1]), 0.5);
-    tm.connections.createSynapse(activeSegment2,
-                                 Cell(previousActiveCells[2]), 0.5);
+      tm.connections.createSegment(expectedWinnerCells[1]);
+    tm.connections.createSynapse(activeSegment2, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment2, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment2, previousActiveCells[2], 0.5);
 
     tm.compute(numActiveColumns, previousActiveColumns, false);
     tm.compute(numActiveColumns, activeColumns, false);
@@ -284,10 +274,10 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {1};
     const vector<CellIdx> activeCells = {5};
-    const Cell activeCell = {5};
+    const CellIdx activeCell = 5;
 
     Segment activeSegment = tm.connections.createSegment(activeCell);
     Synapse activeSynapse1 =
@@ -297,7 +287,7 @@ namespace {
     Synapse activeSynapse3 =
       tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
     Synapse inactiveSynapse =
-      tm.connections.createSynapse(activeSegment, Cell(81), 0.5);
+      tm.connections.createSynapse(activeSegment, 81, 0.5);
 
     tm.compute(numActiveColumns, previousActiveColumns, true);
     tm.compute(numActiveColumns, activeColumns, true);
@@ -333,10 +323,10 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {1};
     const vector<CellIdx> activeCells = {5};
-    const Cell activeCell = {5};
+    const CellIdx activeCell = 5;
 
     Segment activeSegment = tm.connections.createSegment(activeCell);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
@@ -376,29 +366,29 @@ namespace {
     const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
     Segment selectedMatchingSegment =
-      tm.connections.createSegment(Cell(burstingCells[0]));
+      tm.connections.createSegment(burstingCells[0]);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(selectedMatchingSegment,
-                                   Cell(previousActiveCells[0]), 0.3);
+                                   previousActiveCells[0], 0.3);
     Synapse activeSynapse2 =
       tm.connections.createSynapse(selectedMatchingSegment,
-                                   Cell(previousActiveCells[1]), 0.3);
+                                   previousActiveCells[1], 0.3);
     Synapse activeSynapse3 =
       tm.connections.createSynapse(selectedMatchingSegment,
-                                   Cell(previousActiveCells[2]), 0.3);
+                                   previousActiveCells[2], 0.3);
     Synapse inactiveSynapse =
       tm.connections.createSynapse(selectedMatchingSegment,
-                                   Cell(81), 0.3);
+                                   81, 0.3);
 
     // Add some competition.
     Segment otherMatchingSegment =
-      tm.connections.createSegment(Cell(burstingCells[1]));
+      tm.connections.createSegment(burstingCells[1]);
     tm.connections.createSynapse(otherMatchingSegment,
-                                 Cell(previousActiveCells[0]), 0.3);
+                                 previousActiveCells[0], 0.3);
     tm.connections.createSynapse(otherMatchingSegment,
-                                 Cell(previousActiveCells[1]), 0.3);
+                                 previousActiveCells[1], 0.3);
     tm.connections.createSynapse(otherMatchingSegment,
-                                 Cell(81), 0.3);
+                                 81, 0.3);
 
     tm.compute(numActiveColumns, previousActiveColumns, true);
     tm.compute(numActiveColumns, activeColumns, true);
@@ -439,27 +429,27 @@ namespace {
     const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
     Segment selectedMatchingSegment =
-      tm.connections.createSegment(Cell(burstingCells[0]));
+      tm.connections.createSegment(burstingCells[0]);
     tm.connections.createSynapse(selectedMatchingSegment,
-                                 Cell(previousActiveCells[0]), 0.3);
+                                 previousActiveCells[0], 0.3);
     tm.connections.createSynapse(selectedMatchingSegment,
-                                 Cell(previousActiveCells[1]), 0.3);
+                                 previousActiveCells[1], 0.3);
     tm.connections.createSynapse(selectedMatchingSegment,
-                                 Cell(previousActiveCells[2]), 0.3);
+                                 previousActiveCells[2], 0.3);
     tm.connections.createSynapse(selectedMatchingSegment,
-                                 Cell(81), 0.3);
+                                 81, 0.3);
 
     Segment otherMatchingSegment =
-      tm.connections.createSegment(Cell(burstingCells[1]));
+      tm.connections.createSegment(burstingCells[1]);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(otherMatchingSegment,
-                                   Cell(previousActiveCells[0]), 0.3);
+                                   previousActiveCells[0], 0.3);
     Synapse activeSynapse2 =
       tm.connections.createSynapse(otherMatchingSegment,
-                                   Cell(previousActiveCells[1]), 0.3);
+                                   previousActiveCells[1], 0.3);
     Synapse inactiveSynapse =
       tm.connections.createSynapse(otherMatchingSegment,
-                                   Cell(81), 0.3);
+                                   81, 0.3);
 
     tm.compute(1, previousActiveColumns, true);
     tm.compute(1, activeColumns, true);
@@ -499,33 +489,29 @@ namespace {
     const vector<CellIdx> otherBurstingCells = {5, 6, 7};
 
     Segment activeSegment =
-      tm.connections.createSegment(Cell(expectedActiveCells[0]));
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[0]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[1]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[2]), 0.5);
-    tm.connections.createSynapse(activeSegment,
-                                 Cell(previousActiveCells[3]), 0.5);
+      tm.connections.createSegment(expectedActiveCells[0]);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    tm.connections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
 
     Segment matchingSegmentOnSameCell =
-      tm.connections.createSegment(Cell(expectedActiveCells[0]));
+      tm.connections.createSegment(expectedActiveCells[0]);
     Synapse synapse1 =
       tm.connections.createSynapse(matchingSegmentOnSameCell,
-                                   Cell(previousActiveCells[0]), 0.3);
+                                   previousActiveCells[0], 0.3);
     Synapse synapse2 =
       tm.connections.createSynapse(matchingSegmentOnSameCell,
-                                   Cell(previousActiveCells[1]), 0.3);
+                                   previousActiveCells[1], 0.3);
 
     Segment matchingSegmentOnOtherCell =
-      tm.connections.createSegment(Cell(otherBurstingCells[0]));
+      tm.connections.createSegment(otherBurstingCells[0]);
     Synapse synapse3 =
       tm.connections.createSynapse(matchingSegmentOnOtherCell,
-                                   Cell(previousActiveCells[0]), 0.3);
+                                   previousActiveCells[0], 0.3);
     Synapse synapse4 =
       tm.connections.createSynapse(matchingSegmentOnOtherCell,
-                                   Cell(previousActiveCells[1]), 0.3);
+                                   previousActiveCells[1], 0.3);
 
     tm.compute(1, previousActiveColumns, true);
     ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
@@ -602,7 +588,7 @@ namespace {
 
     vector<CellIdx> winnerCells = tm.getWinnerCells();
     ASSERT_EQ(1, winnerCells.size());
-    vector<Segment> segments = tm.connections.segmentsForCell(Cell(winnerCells[0]));
+    vector<Segment> segments = tm.connections.segmentsForCell(winnerCells[0]);
     ASSERT_EQ(1, segments.size());
     vector<Synapse> synapses = tm.connections.synapsesForSegment(segments[0]);
     ASSERT_EQ(2, synapses.size());
@@ -610,9 +596,9 @@ namespace {
     {
       SynapseData synapseData = tm.connections.dataForSynapse(synapse);
       EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
-      EXPECT_TRUE(synapseData.presynapticCell == Cell(prevWinnerCells[0]) ||
-                  synapseData.presynapticCell == Cell(prevWinnerCells[1]) ||
-                  synapseData.presynapticCell == Cell(prevWinnerCells[2]));
+      EXPECT_TRUE(synapseData.presynapticCell == prevWinnerCells[0] ||
+                  synapseData.presynapticCell == prevWinnerCells[1] ||
+                  synapseData.presynapticCell == prevWinnerCells[2]);
     }
 
   }
@@ -649,7 +635,7 @@ namespace {
 
     vector<CellIdx> winnerCells = tm.getWinnerCells();
     ASSERT_EQ(1, winnerCells.size());
-    vector<Segment> segments = tm.connections.segmentsForCell(Cell(winnerCells[0]));
+    vector<Segment> segments = tm.connections.segmentsForCell(winnerCells[0]);
     ASSERT_EQ(1, segments.size());
     vector<Synapse> synapses = tm.connections.synapsesForSegment(segments[0]);
     ASSERT_EQ(3, synapses.size());
@@ -659,7 +645,7 @@ namespace {
     {
       SynapseData synapseData = tm.connections.dataForSynapse(synapse);
       EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
-      presynapticCells.push_back(synapseData.presynapticCell.idx);
+      presynapticCells.push_back(synapseData.presynapticCell);
     }
     std::sort(presynapticCells.begin(), presynapticCells.end());
     EXPECT_EQ(prevWinnerCells, presynapticCells);
@@ -691,8 +677,8 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(Cell(4));
-    tm.connections.createSynapse(matchingSegment, Cell(0), 0.5);
+    Segment matchingSegment = tm.connections.createSegment(4);
+    tm.connections.createSynapse(matchingSegment, 0, 0.5);
 
     tm.compute(4, previousActiveColumns);
 
@@ -702,13 +688,13 @@ namespace {
 
     vector<Synapse> synapses = tm.connections.synapsesForSegment(matchingSegment);
     ASSERT_EQ(3, synapses.size());
-    for (UInt32 i = 1; i < synapses.size(); i++)
+    for (SynapseIdx i = 1; i < synapses.size(); i++)
     {
       SynapseData synapseData = tm.connections.dataForSynapse(synapses[i]);
       EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
-      EXPECT_TRUE(synapseData.presynapticCell == Cell(prevWinnerCells[1]) ||
-                  synapseData.presynapticCell == Cell(prevWinnerCells[2]) ||
-                  synapseData.presynapticCell == Cell(prevWinnerCells[3]));
+      EXPECT_TRUE(synapseData.presynapticCell == prevWinnerCells[1] ||
+                  synapseData.presynapticCell == prevWinnerCells[2] ||
+                  synapseData.presynapticCell == prevWinnerCells[3]);
     }
   }
 
@@ -738,8 +724,8 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(Cell(4));
-    tm.connections.createSynapse(matchingSegment, Cell(0), 0.5);
+    Segment matchingSegment = tm.connections.createSegment(4);
+    tm.connections.createSynapse(matchingSegment, 0, 0.5);
 
     tm.compute(2, previousActiveColumns);
 
@@ -752,7 +738,7 @@ namespace {
 
     SynapseData synapseData = tm.connections.dataForSynapse(synapses[1]);
     EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
-    EXPECT_EQ(Cell(prevWinnerCells[1]), synapseData.presynapticCell);
+    EXPECT_EQ(prevWinnerCells[1], synapseData.presynapticCell);
   }
 
   /**
@@ -777,9 +763,9 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {2};
-    const Cell expectedActiveCell = {5};
+    const CellIdx expectedActiveCell = 5;
 
     Segment activeSegment = tm.connections.createSegment(expectedActiveCell);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
@@ -816,16 +802,16 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {1};
-    const Cell activeCell = {5};
+    const CellIdx activeCell = 5;
 
     Segment activeSegment = tm.connections.createSegment(activeCell);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
     Synapse weakInactiveSynapse =
-      tm.connections.createSynapse(activeSegment, Cell(81), 0.09);
+      tm.connections.createSynapse(activeSegment, 81, 0.09);
 
     tm.compute(numActiveColumns, previousActiveColumns, true);
     tm.compute(numActiveColumns, activeColumns, true);
@@ -860,12 +846,12 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1, 2};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(Cell(4));
-    tm.connections.createSynapse(matchingSegment, Cell(81), 0.6);
+    Segment matchingSegment = tm.connections.createSegment(4);
+    tm.connections.createSynapse(matchingSegment, 81, 0.6);
 
     // Still the weakest after adding permanenceIncrement.
     Synapse weakestSynapse =
-      tm.connections.createSynapse(matchingSegment, Cell(0), 0.11);
+      tm.connections.createSynapse(matchingSegment, 0, 0.11);
 
     tm.compute(3, previousActiveColumns);
 
@@ -876,7 +862,7 @@ namespace {
     // Note that it destroys the weak active synapse, not the strong inactive
     // synapse.
     SynapseData synapseData = tm.connections.dataForSynapse(weakestSynapse);
-    EXPECT_NE(Cell(0), synapseData.presynapticCell);
+    EXPECT_NE(0, synapseData.presynapticCell);
     EXPECT_FALSE(synapseData.destroyed);
     EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
   }
@@ -910,31 +896,31 @@ namespace {
     tm.compute(3, previousActiveColumns1);
     tm.compute(1, activeColumns);
 
-    ASSERT_EQ(1, tm.connections.numSegments(Cell(9)));
-    Segment oldestSegment = tm.connections.segmentsForCell(Cell(9))[0];
+    ASSERT_EQ(1, tm.connections.numSegments(9));
+    Segment oldestSegment = tm.connections.segmentsForCell(9)[0];
 
     tm.reset();
     tm.compute(3, previousActiveColumns2);
     tm.compute(1, activeColumns);
 
-    ASSERT_EQ(2, tm.connections.numSegments(Cell(9)));
+    ASSERT_EQ(2, tm.connections.numSegments(9));
 
     tm.reset();
     tm.compute(3, previousActiveColumns3);
     tm.compute(1, activeColumns);
 
-    ASSERT_EQ(2, tm.connections.numSegments(Cell(9)));
+    ASSERT_EQ(2, tm.connections.numSegments(9));
 
     vector<Synapse> synapses = tm.connections.synapsesForSegment(oldestSegment);
     ASSERT_EQ(3, synapses.size());
-    set<Cell> presynapticCells;
+    set<CellIdx> presynapticCells;
     for (Synapse synapse : synapses)
     {
       SynapseData synapseData = tm.connections.dataForSynapse(synapse);
       presynapticCells.insert(synapseData.presynapticCell);
     }
 
-    const set<Cell> expected = {Cell(6), Cell(7), Cell(8)};
+    const set<CellIdx> expected = {6, 7, 8};
     EXPECT_EQ(expected, presynapticCells);
   }
 
@@ -960,9 +946,9 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {2};
-    const Cell expectedActiveCell = {5};
+    const CellIdx expectedActiveCell = 5;
 
     Segment matchingSegment = tm.connections.createSegment(expectedActiveCell);
     tm.connections.createSynapse(matchingSegment, previousActiveCells[0], 0.015);
@@ -1004,11 +990,11 @@ namespace {
 
     const UInt numActiveColumns = 1;
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {1};
-    const Cell previousInactiveCell = {81};
+    const CellIdx previousInactiveCell = 81;
 
-    Segment activeSegment = tm.connections.createSegment(Cell(42));
+    Segment activeSegment = tm.connections.createSegment(42);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     Synapse activeSynapse2 =
@@ -1018,7 +1004,7 @@ namespace {
     Synapse inactiveSynapse1 =
       tm.connections.createSynapse(activeSegment, previousInactiveCell, 0.5);
 
-    Segment matchingSegment = tm.connections.createSegment(Cell(43));
+    Segment matchingSegment = tm.connections.createSegment(43);
     Synapse activeSynapse4 =
       tm.connections.createSynapse(matchingSegment, previousActiveCells[0], 0.5);
     Synapse activeSynapse5 =
@@ -1072,9 +1058,9 @@ namespace {
       // enough for 4 winner cells
       const UInt previousActiveColumns[4] ={1, 2, 3, 4};
       const UInt activeColumns[1] = {0};
-      const vector<Cell> previousActiveCells =
-        {{4}, {5}, {6}, {7}}; // (there are more)
-      vector<Cell> nonmatchingCells = {{0}, {3}};
+      const vector<CellIdx> previousActiveCells =
+        {4, 5, 6, 7}; // (there are more)
+      vector<CellIdx> nonmatchingCells = {0, 3};
       vector<CellIdx> activeCells = {0, 1, 2, 3};
 
       Segment segment1 = tm.connections.createSegment(nonmatchingCells[0]);
@@ -1088,16 +1074,16 @@ namespace {
       ASSERT_EQ(activeCells, tm.getActiveCells());
 
       EXPECT_EQ(3, tm.connections.numSegments());
-      EXPECT_EQ(1, tm.connections.segmentsForCell({0}).size());
-      EXPECT_EQ(1, tm.connections.segmentsForCell({3}).size());
+      EXPECT_EQ(1, tm.connections.segmentsForCell(0).size());
+      EXPECT_EQ(1, tm.connections.segmentsForCell(3).size());
       EXPECT_EQ(1, tm.connections.numSynapses(segment1));
       EXPECT_EQ(1, tm.connections.numSynapses(segment2));
 
       Segment grownSegment;
-      vector<Segment> segments = tm.connections.segmentsForCell({1});
+      vector<Segment> segments = tm.connections.segmentsForCell(1);
       if (segments.empty())
       {
-        vector<Segment> segments2 = tm.connections.segmentsForCell({2});
+        vector<Segment> segments2 = tm.connections.segmentsForCell(2);
         EXPECT_FALSE(segments2.empty());
         grewOnCell2 = true;
         segments.insert(segments.end(), segments2.begin(), segments2.end());
@@ -1111,7 +1097,7 @@ namespace {
       vector<Synapse> synapses = tm.connections.synapsesForSegment(segments[0]);
       EXPECT_EQ(4, synapses.size());
 
-      set<Cell> columnChecklist(previousActiveColumns, previousActiveColumns+4);
+      set<CellIdx> columnChecklist(previousActiveColumns, previousActiveColumns+4);
 
       for (Synapse synapse : synapses)
       {
@@ -1152,24 +1138,24 @@ namespace {
       );
 
     const UInt previousActiveColumns[1] = {0};
-    const vector<Cell> previousActiveCells = {{0}, {1}, {2}, {3}};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const UInt activeColumns[2] = {
       1, // predicted
       2  // bursting
     };
-    const Cell previousInactiveCell = {81};
+    const CellIdx previousInactiveCell = 81;
     const vector<CellIdx> expectedActiveCells = {4};
 
     Segment correctActiveSegment =
-      tm.connections.createSegment(Cell(expectedActiveCells[0]));
+      tm.connections.createSegment(expectedActiveCells[0]);
     tm.connections.createSynapse(correctActiveSegment,
-                                 Cell(previousActiveCells[0]), 0.5);
+                                 previousActiveCells[0], 0.5);
     tm.connections.createSynapse(correctActiveSegment,
-                                 Cell(previousActiveCells[1]), 0.5);
+                                 previousActiveCells[1], 0.5);
     tm.connections.createSynapse(correctActiveSegment,
-                                 Cell(previousActiveCells[2]), 0.5);
+                                 previousActiveCells[2], 0.5);
 
-    Segment wrongMatchingSegment = tm.connections.createSegment(Cell(43));
+    Segment wrongMatchingSegment = tm.connections.createSegment(43);
     tm.connections.createSynapse(wrongMatchingSegment,
                                  previousActiveCells[0], 0.5);
     tm.connections.createSynapse(wrongMatchingSegment,
@@ -1190,16 +1176,10 @@ namespace {
     TemporalMemory tm;
     tm.initialize(vector<UInt>{2048}, 5);
 
-    Cell cell;
-
-    cell.idx = 0;
-    ASSERT_TRUE(tm.columnForCell(cell) == 0);
-    cell.idx = 4;
-    ASSERT_TRUE(tm.columnForCell(cell) == 0);
-    cell.idx = 5;
-    ASSERT_TRUE(tm.columnForCell(cell) == 1);
-    cell.idx = 10239;
-    ASSERT_TRUE(tm.columnForCell(cell) == 2047);
+    ASSERT_EQ(0, tm.columnForCell(0));
+    ASSERT_EQ(0, tm.columnForCell(4));
+    ASSERT_EQ(1, tm.columnForCell(5));
+    ASSERT_EQ(2047, tm.columnForCell(10239));
   }
 
   TEST(TemporalMemoryTest, testColumnForCell2D)
@@ -1207,16 +1187,10 @@ namespace {
     TemporalMemory tm;
     tm.initialize(vector<UInt>{64, 64}, 4);
 
-    Cell cell;
-
-    cell.idx = 0;
-    ASSERT_TRUE(tm.columnForCell(cell) == 0);
-    cell.idx = 3;
-    ASSERT_TRUE(tm.columnForCell(cell) == 0);
-    cell.idx = 4;
-    ASSERT_TRUE(tm.columnForCell(cell) == 1);
-    cell.idx = 16383;
-    ASSERT_TRUE(tm.columnForCell(cell) == 4095);
+    ASSERT_EQ(0, tm.columnForCell(0));
+    ASSERT_EQ(0, tm.columnForCell(3));
+    ASSERT_EQ(1, tm.columnForCell(4));
+    ASSERT_EQ(4095, tm.columnForCell(16383));
   }
 
   TEST(TemporalMemoryTest, testColumnForCellInvalidCell)
@@ -1224,14 +1198,9 @@ namespace {
     TemporalMemory tm;
     tm.initialize(vector<UInt>{64, 64}, 4);
 
-    Cell cell;
-
-    cell.idx = 16383;
-    EXPECT_NO_THROW(tm.columnForCell(cell));
-    cell.idx = 16384;
-    EXPECT_THROW(tm.columnForCell(cell), std::exception);
-    cell.idx = -1;
-    EXPECT_THROW(tm.columnForCell(cell), std::exception);
+    EXPECT_NO_THROW(tm.columnForCell(16383));
+    EXPECT_THROW(tm.columnForCell(16384), std::exception);
+    EXPECT_THROW(tm.columnForCell(-1), std::exception);
   }
 
   TEST(TemporalMemoryTest, testNumberOfColumns)

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -837,7 +837,7 @@ namespace {
       /*permanenceDecrement*/ 0.02,
       /*predictedSegmentDecrement*/ 0.0,
       /*seed*/ 42,
-      /*maxSegmentsPerCell*/ MAX_SEGMENTS_PER_CELL,
+      /*maxSegmentsPerCell*/ 255,
       /*maxSynapsesPerSegment*/ 3
       );
 


### PR DESCRIPTION
This change adds an `ExtendedTemporalMemory` class that supports external connections. It puts it in a new `nupic::experimental` namespace. In the Python bindings this is `nupic.bindings.experimental`.

This ETM doesn't yet support apical dendrites or "learn-on-one-cell".

**I recommend looking at the individual commits, not the PR as a whole.**

I aimed for clean code that avoids unnecessary computation. I avoided making copies of lists of cells -- I don't combine the "internal active cells" and "external active cells" into a separate "all active cells" list. This decision led me to rework the Connections `computeActivity` so that we could compute segment excitations without having to flatten all the active cells into a single list.

The `ExtendedTemporalMemory` looks a lot like the `TemporalMemory`. It doesn't inherit from it. It's a fork.

I didn't fork the `Connections` class. I think we'll be able to keep the Connections class compatible with research and release code. We can always revisit this decision later.

This is largely untested. It's research code. The plan is to run nupic.research Python tests on it.

Fixes #999 