### PR TITLE
DEVOPS-116 proof-of-concept build of nupic.bindings manylinux wheel 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,12 @@ endif()
 
 
 #
+# Global NuPIC CMake options
+#
+option(NUPIC_BUILD_PYEXT_MODULES "Turn on building of python extension modules for nupic.bindings"
+       ON)
+
+#
 # Identify build type - local or deployment (Travis)
 # the variable NUPIC_DEPLOYMENT_BUILD must be set in travis CI scripts
 #

--- a/CommonCompilerConfig.cmake
+++ b/CommonCompilerConfig.cmake
@@ -43,35 +43,35 @@
 # EXTERNAL_CXX_FLAGS_UNOPTIMIZED: string of C++ flags without explicit optimization flags for 3rd-party sources.
 #
 # EXTERNAL_LINKER_FLAGS_UNOPTIMIZED: string of linker flags for linking 3rd-party executables
-#                      and shared libraries (DLLs) without explicit optimizations
+#                      and shared libraries (DLLs) without explicit optimization
 #                      settings. This property is for use with
 #                      EXTERNAL_C_FLAGS_UNOPTIMIZED and EXTERNAL_CXX_FLAGS_UNOPTIMIZED
-#
-# EXTERNAL_LINKER_FLAGS_UNOPTIMIZED: string of linker flags for linking 3rd-party executables
-#                      and shared libraries (DLLs) without optimizations that are
-#                      compatible with EXTERNAL_C_FLAGS_UNOPTIMIZED and EXTERNAL_CXX_FLAGS_UNOPTIMIZED
 #
 # EXTERNAL_LINKER_FLAGS_OPTIMIZED: string of linker flags for linking 3rd-party executables
 #                      and shared libraries (DLLs) with optimizations that are
 #                      compatible with EXTERNAL_C_FLAGS_OPTIMIZED and EXTERNAL_CXX_FLAGS_OPTIMIZED
 #
 # EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED: list of -D cmake definitions corresponding to
-#                      EXTERNAL_C_FLAGS_OPTIMIZED (e. g. use of gcc-ar and gcc-ranlib wrappers for gcc >= 4.9 
-#                      in combination with Link Time Optimization)                       
+#                      EXTERNAL_C_FLAGS_OPTIMIZED (e. g. use of gcc-ar and gcc-ranlib wrappers for gcc >= 4.9
+#                      in combination with Link Time Optimization)
 #
 # EXTERNAL_STATICLIB_CONFIGURE_DEFINITIONS_OPTIMIZED_STR: string variant of EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED
 #                      used for non-cmake builds
-#  
+#
 # INTERNAL_CXX_FLAGS_OPTIMIZED: string of C++ flags with explicit optimization flags for internal sources
 #
 # INTERNAL_LINKER_FLAGS_OPTIMIZED: string of linker flags for linking internal executables
 #                      and shared libraries (DLLs) with optimizations that are
 #                      compatible with INTERNAL_CXX_FLAGS_OPTIMIZED
 #
+# PYEXT_LINKER_FLAGS_OPTIMIZED: string of linker flags for linking python extension
+#                      shared libraries (DLLs) with optimizations that are
+#                      compatible with EXTERNAL_CXX_FLAGS_OPTIMIZED.
+#
 # CMAKE_AR: Name of archiving tool (ar) for static libraries. See cmake documentation
 #
 # CMAKE_RANLIB: Name of randomizing tool (ranlib) for static libraries. See cmake documentation
-#                    
+#
 # CMAKE_LINKER: updated, if needed; use ld.gold if available. See cmake
 #               documentation
 #
@@ -94,6 +94,7 @@ set(COMMON_COMPILER_DEFINITIONS_STR)
 set(INTERNAL_CXX_FLAGS_OPTIMIZED)
 set(INTERNAL_LINKER_FLAGS_OPTIMIZED)
 
+set(PYEXT_LINKER_FLAGS_OPTIMIZED)
 
 set(EXTERNAL_C_FLAGS_UNOPTIMIZED)
 set(EXTERNAL_C_FLAGS_OPTIMIZED)
@@ -124,9 +125,9 @@ if(CMAKE_MAJOR_VERSION GREATER 2)
   math(EXPR available_memory "${available_physical_memory}+${available_virtual_memory}")
   message(STATUS "CMAKE MEMORY=${available_memory}")
 
-  # Python bindings (particularly mathPYTHON_wrap.cxx) requires more than 
+  # Python bindings (particularly mathPYTHON_wrap.cxx) requires more than
   # 1GB of memory for compiling with GCC. Send a warning if available memory
-  # (physical plus virtual(swap)) is less than 1GB 
+  # (physical plus virtual(swap)) is less than 1GB
   if(${available_memory} LESS 1024)
     message(WARNING "Less than 1GB of memory available, compilation may run out of memory!")
   endif()
@@ -179,8 +180,18 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-   set(stdlib_common "${stdlib_common} -static-libgcc")
-   set(stdlib_cxx "${stdlib_cxx} -static-libstdc++")
+  if (${NUPIC_BUILD_PYEXT_MODULES} AND "${PLATFORM}" STREQUAL "linux")
+    # For python extensions on Linux, we want shared libgcc and
+    # libstdc++ in order to avoid memory management issues and other
+    # side-effects of static versions of those libs on various distros.
+    # NOTE There is no `-shared-libstdc++` flag; shared libstdc++ is given
+    # priority over its static counterpart implicitly when `-static-libstdc++`
+    # is omitted.
+    set(stdlib_common "${stdlib_common} -shared-libgcc")
+  else()
+    set(stdlib_common "${stdlib_common} -static-libgcc")
+    set(stdlib_cxx "${stdlib_cxx} -static-libstdc++")
+  endif()
 endif()
 
 
@@ -217,6 +228,8 @@ set(internal_compiler_warning_flags "")
 set(external_compiler_warning_flags "")
 set(cxx_flags_unoptimized "")
 set(shared_linker_flags_unoptimized "")
+set(fail_link_on_undefined_symbols_flags "")
+set(allow_link_with_undefined_symbols_flags "")
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   # MS Visual C
@@ -231,6 +244,13 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
 else()
   # LLVM Clang / Gnu GCC
   set(cxx_flags_unoptimized "${cxx_flags_unoptimized} ${stdlib_cxx} -std=c++11")
+
+  if (${NUPIC_BUILD_PYEXT_MODULES})
+    # Hide all symbols in DLLs except the ones with explicit visibility;
+    # see https://gcc.gnu.org/wiki/Visibility
+    set(cxx_flags_unoptimized "${cxx_flags_unoptimized} -fvisibility-inlines-hidden")
+    set(shared_compile_flags "${shared_compile_flags} -fvisibility=hidden")
+  endif()
 
   set(shared_compile_flags "${shared_compile_flags} ${stdlib_common} -fdiagnostics-show-option")
   set (internal_compiler_warning_flags "${internal_compiler_warning_flags} -Werror -Wextra -Wreturn-type -Wunused -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers")
@@ -258,23 +278,38 @@ else()
   set(shared_linker_flags_unoptimized "${shared_linker_flags_unoptimized} ${stdlib_common} ${stdlib_cxx}")
 endif()
 
-
+# Don't allow undefined symbols when linking executables
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-  set(shared_linker_flags_unoptimized "${shared_linker_flags_unoptimized} -Wl,--no-undefined")
+  set(fail_link_on_undefined_symbols_flags "-Wl,--no-undefined")
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-  set(shared_linker_flags_unoptimized "${shared_linker_flags_unoptimized} -Wl,-undefined,error")
+  set(fail_link_on_undefined_symbols_flags "-Wl,-undefined,error")
 endif()
+
+# Don't force python extensions to link to specific libpython during build:
+# python symbols are made available to extensions atomatically once loaded
+#
+# NOTE Windows DLLs are shared executables with their own main; they require
+# all symbols to resolve at link time.
+if(NOT "${PLATFORM}" STREQUAL "windows")
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    set(allow_link_with_undefined_symbols_flags "-Wl,--allow-shlib-undefined")
+  elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    set(allow_link_with_undefined_symbols_flags "-Wl,-undefined,dynamic_lookup")
+  endif()
+endif()
+
 
 # Compatibility with gcc >= 4.9 which requires the use of gcc's own wrappers for ar and ranlib in combination with LTO
 # works also with LTO disabled
-IF(UNIX AND CMAKE_COMPILER_IS_GNUCXX AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9"))
+IF(UNIX AND CMAKE_COMPILER_IS_GNUCXX AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug") AND
+      (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9"))
     set(CMAKE_AR "gcc-ar")
     set(CMAKE_RANLIB "gcc-ranlib")
     # EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED contains duplicate settings for CMAKE_AR and CMAKE_RANLIB
     # This is a workaround for a CMAKE bug (https://gitlab.kitware.com/cmake/cmake/issues/15547) that prevents
     # the correct propagation of CMAKE_AR and CMAKE_RANLIB variables to all externals
     set(EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED -DCMAKE_AR:PATH=gcc-ar -DCMAKE_RANLIB:PATH=gcc-ranlib)
-    set(EXTERNAL_STATICLIB_CONFIGURE_DEFINITIONS_OPTIMIZED_STR AR=gcc-ar RANLIB=gcc-ranlib)
+    set(EXTERNAL_STATICLIB_CONFIGURE_DEFINITIONS_OPTIMIZED_STR "AR=gcc-ar RANLIB=gcc-ranlib")
 ENDIF()
 
 #
@@ -290,6 +325,11 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 
   if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR MINGW)
     set (build_type_specific_compile_flags "${build_type_specific_compile_flags} -Og")
+
+    # Enable diagnostic features of standard class templates, including ability
+    # to examine containers in gdb.
+    # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html
+    list(APPEND COMMON_COMPILER_DEFINITIONS -D_GLIBCXX_DEBUG)
   endif()
 
   # Disable optimizations
@@ -306,14 +346,18 @@ endif()
 set(INTERNAL_CXX_FLAGS_OPTIMIZED "${build_type_specific_compile_flags} ${shared_compile_flags} ${cxx_flags_unoptimized} ${internal_compiler_warning_flags} ${optimization_flags_cc}")
 
 set(complete_linker_flags_unoptimized "${build_type_specific_linker_flags} ${shared_linker_flags_unoptimized}")
+set(complete_linker_flags_unoptimized "${complete_linker_flags_unoptimized} ${fail_link_on_undefined_symbols_flags}")
 set(INTERNAL_LINKER_FLAGS_OPTIMIZED "${complete_linker_flags_unoptimized} ${optimization_flags_lt}")
-
 
 # Settings for third-party code and code generated by 3rd-party tools (e.g., Swig bindings)
 # (NOTE we omit the explicit compiler warning-related flags here to avoid
 #  polluting build output with warnings from code that we don't control)
 set(EXTERNAL_C_FLAGS_UNOPTIMIZED "${build_type_specific_compile_flags} ${shared_compile_flags} ${external_compiler_warning_flags}")
 set(EXTERNAL_C_FLAGS_OPTIMIZED "${EXTERNAL_C_FLAGS_UNOPTIMIZED} ${optimization_flags_cc}")
+
+set(PYEXT_LINKER_FLAGS_OPTIMIZED "${build_type_specific_linker_flags} ${shared_linker_flags_unoptimized}")
+set(PYEXT_LINKER_FLAGS_OPTIMIZED "${PYEXT_LINKER_FLAGS_OPTIMIZED} ${optimization_flags_lt}")
+set(PYEXT_LINKER_FLAGS_OPTIMIZED "${PYEXT_LINKER_FLAGS_OPTIMIZED} ${allow_link_with_undefined_symbols_flags}")
 
 set(EXTERNAL_CXX_FLAGS_UNOPTIMIZED "${build_type_specific_compile_flags} ${shared_compile_flags} ${external_compiler_warning_flags} ${cxx_flags_unoptimized}")
 set(EXTERNAL_CXX_FLAGS_OPTIMIZED "${EXTERNAL_CXX_FLAGS_UNOPTIMIZED} ${optimization_flags_cc}")
@@ -329,3 +373,17 @@ set(COMMON_COMPILER_DEFINITIONS_STR)
 foreach(compiler_definition ${COMMON_COMPILER_DEFINITIONS})
   set(COMMON_COMPILER_DEFINITIONS_STR "${COMMON_COMPILER_DEFINITIONS_STR} ${compiler_definition}")
 endforeach()
+
+message(STATUS "INTERNAL_CXX_FLAGS_OPTIMIZED=${INTERNAL_CXX_FLAGS_OPTIMIZED}")
+message(STATUS "INTERNAL_LINKER_FLAGS_OPTIMIZED=${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
+message(STATUS "EXTERNAL_C_FLAGS_UNOPTIMIZED=${EXTERNAL_C_FLAGS_UNOPTIMIZED}")
+message(STATUS "EXTERNAL_C_FLAGS_OPTIMIZED=${EXTERNAL_C_FLAGS_OPTIMIZED}")
+message(STATUS "PYEXT_LINKER_FLAGS_OPTIMIZED=${PYEXT_LINKER_FLAGS_OPTIMIZED}")
+message(STATUS "EXTERNAL_CXX_FLAGS_UNOPTIMIZED=${EXTERNAL_CXX_FLAGS_UNOPTIMIZED}")
+message(STATUS "EXTERNAL_CXX_FLAGS_OPTIMIZED=${EXTERNAL_CXX_FLAGS_OPTIMIZED}")
+message(STATUS "EXTERNAL_LINKER_FLAGS_UNOPTIMIZED=${EXTERNAL_LINKER_FLAGS_UNOPTIMIZED}")
+message(STATUS "EXTERNAL_LINKER_FLAGS_OPTIMIZED=${EXTERNAL_LINKER_FLAGS_OPTIMIZED}")
+message(STATUS "COMMON_COMPILER_DEFINITIONS=${COMMON_COMPILER_DEFINITIONS}")
+message(STATUS "COMMON_COMPILER_DEFINITIONS_STR=${COMMON_COMPILER_DEFINITIONS_STR}")
+message(STATUS "EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED=${EXTERNAL_STATICLIB_CMAKE_DEFINITIONS_OPTIMIZED}")
+message(STATUS "EXTERNAL_STATICLIB_CONFIGURE_DEFINITIONS_OPTIMIZED_STR=${EXTERNAL_STATICLIB_CONFIGURE_DEFINITIONS_OPTIMIZED_STR}")

--- a/CommonCompilerConfig.cmake
+++ b/CommonCompilerConfig.cmake
@@ -19,6 +19,7 @@
 # http://numenta.org/licenses/
 # -----------------------------------------------------------------------------
 
+
 # Configures common compiler/linker/loader settings for internal and external
 # sources.
 #

--- a/ci/bamboo/bootstrap-manylinux-prototype.sh
+++ b/ci/bamboo/bootstrap-manylinux-prototype.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+# Build nupic.bindings python extension using manylinux docker image.
+
 set -o errexit
 set -o xtrace
 
@@ -8,5 +31,6 @@ NUPIC_CORE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 DOCKER_IMAGE="quay.io/numenta/manylinux1_x86_64_centos6"
 
-docker run -ti --rm -v ${NUPIC_CORE_DIR}:/nupic.core ${DOCKER_IMAGE} /nupic.core/ci/bamboo/build-manylinux-prototype.sh
+docker run -ti --rm -v ${NUPIC_CORE_DIR}:/nupic.core ${DOCKER_IMAGE} \
+  /nupic.core/ci/bamboo/build-manylinux-prototype.sh
 

--- a/ci/bamboo/bootstrap-manylinux-prototype.sh
+++ b/ci/bamboo/bootstrap-manylinux-prototype.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o errexit
+set -o xtrace
+
+NUPIC_CORE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+#echo "NUPIC_CORE_DIR=${NUPIC_CORE_DIR}"
+
+DOCKER_IMAGE="quay.io/numenta/manylinux1_x86_64_centos6"
+
+docker run -ti --rm -v ${NUPIC_CORE_DIR}:/nupic.core ${DOCKER_IMAGE} /nupic.core/ci/bamboo/build-manylinux-prototype.sh
+

--- a/ci/bamboo/build-manylinux-prototype.sh
+++ b/ci/bamboo/build-manylinux-prototype.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
 
 # This script builds the manylinux x86_64 wide-unicode wheel per PEP-513. It
 # runs inside the manylinux1_x86_64 docker container (see
@@ -6,12 +26,6 @@
 # container has mapped its nupic.core root directory as a volume in the
 # container.
 #
-
-# Additional packages installed by .travis.yml that we might need
-#
-# cmake-data
-# python-virtualenv
-# python-numpy
 
 set -o errexit
 set -o xtrace
@@ -35,7 +49,10 @@ CXX="g++"
 PYBIN="/opt/python/cp27-cp27mu/bin"
 PATH="${PYBIN}:${PATH}"
 
-# Help python executable find its shared lib
+# Help python executable find its shared lib; unlike the community manylinux
+# docker image that builds statically-linked python, our custom manylinux image
+# builds python with libpython.so python library, because our current C++ tests
+# of python interfaces depending on having libpython.so.
 LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(dirname ${PYBIN})/lib"
 
 # Install pycapnp to get the headers capnp/helpers/checkCompiler.h, etc.

--- a/ci/bamboo/build-manylinux-prototype.sh
+++ b/ci/bamboo/build-manylinux-prototype.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# This script builds the manylinux x86_64 wide-unicode wheel per PEP-513. It
+# runs inside the manylinux1_x86_64 docker container (see
+# https://github.com/pypa/manylinux). Our bootstrap script that launched the
+# container has mapped its nupic.core root directory as a volume in the
+# container.
+#
+
+# Additional packages installed by .travis.yml that we might need
+#
+# cmake-data
+# python-virtualenv
+# python-numpy
+
+set -o errexit
+set -o xtrace
+
+# NUPIC_CORE env var may (or may not) be expected by nupic.core build.
+# TODO rename NUPIC_CORE env var to NUPIC_CORE_DIR if not needed for build
+NUPIC_CORE="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+echo "RUNNING MANYLINUX BUILD; NUPIC_CORE=${NUPIC_CORE}"
+
+# The manylinux image provides cmake28, but doesn't symlink it to cmake
+CMAKE="cmake28"
+${CMAKE} --version
+
+# manylinux provides the required gcc toolchain for building extensions
+CC="gcc"
+CXX="g++"
+
+# Add the python 2.7 binaries from manylinux image to PATH, overriding system
+# Python
+PYBIN="/opt/python/cp27-cp27mu/bin"
+PATH="${PYBIN}:${PATH}"
+
+# Help python executable find its shared lib
+LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(dirname ${PYBIN})/lib"
+
+# Install pycapnp to get the headers capnp/helpers/checkCompiler.h, etc.
+${PYBIN}/pip install pycapnp==0.5.8
+
+# Install nupic.bindings dependencies
+${PYBIN}/pip install \
+    -r ${NUPIC_CORE}/bindings/py/requirements.txt
+
+# Build and install nupic.bindings
+
+mkdir -p ${NUPIC_CORE}/build/scripts
+cd ${NUPIC_CORE}/build/scripts
+
+# Cause `find_package(PythonLibs REQUIRED)` to return the desired include
+# directory
+PYTHON_INCLUDE_DIR="/opt/python/cp27-cp27mu/include/python2.7"
+
+${CMAKE} ${NUPIC_CORE} \
+    -DPYTHON_LIBRARY="$(dirname ${PYBIN})/lib/libpython2.7.so" \
+    -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=../release \
+    -DPY_EXTENSIONS_DIR=${NUPIC_CORE}/bindings/py/nupic/bindings
+make install
+
+# Build the manylinux wheel. The resulting wheel is created in
+# bindings/py/dist. Example wheel name:
+# nupic.bindings-0.4.5.dev0-cp27-cp27mu-linux_x86_64.whl
+cd ${NUPIC_CORE}
+${PYBIN}/python setup.py bdist_wheel
+
+# Run the nupic.core C++ tests
+${PYBIN}/pip install ${NUPIC_CORE}/bindings/py/dist/nupic.bindings-0.4.5.dev0-cp27-cp27mu-linux_x86_64.whl
+cd ${NUPIC_CORE}/build/release/bin
+./connections_performance_test
+./cpp_region_test
+./helloregion
+./hello_sp_tp
+./prototest
+./py_region_test
+./unit_tests
+
+# Run the nupic.core python tests
+${PYBIN}/pip install -U pytest
+${PYBIN}/py.test --verbose ${NUPIC_CORE}/bindings/py/tests

--- a/external/Zlib.cmake
+++ b/external/Zlib.cmake
@@ -46,8 +46,12 @@ set(LIB_STATIC_Z_LOC "${zlib_install_lib_dir}/${STATIC_PRE}${zlib_output_root}${
 
 set(c_flags "${EXTERNAL_C_FLAGS_OPTIMIZED} ${COMMON_COMPILER_DEFINITIONS_STR}")
 
+set(zlib_patch_file "${CMAKE_SOURCE_DIR}/external/common/share/zlib/zlib.patch")
+
 ExternalProject_Add(ZStaticLib
     URL ${zlib_url}
+
+    PATCH_COMMAND patch -f -p1 --directory=<SOURCE_DIR> --input=${zlib_patch_file}
 
     UPDATE_COMMAND ""
 

--- a/external/common/share/zlib/README.md
+++ b/external/common/share/zlib/README.md
@@ -1,1 +1,7 @@
 zlib-1.2.8.tar.gz from http://www.zlib.net/
+
+Patch zlib sources to remove building of zlib DLL/.so and dependent executables to enable hiding of symbobls
+in nupic.bindings extension shared libs except those with explicit visibility (per https://gcc.gnu.org/wiki/Visibility).
+zlib sources don't set explicit visibility attributes on its API functions, thus dependent executables fail to link when
+we pass C_FLAGS that hide visibility by default. We only need the static lib, anyway.
+

--- a/external/common/share/zlib/zlib.patch
+++ b/external/common/share/zlib/zlib.patch
@@ -1,0 +1,149 @@
+diff -U 10 -r zlib-1.2.8/CMakeLists.txt mods/zlib-1.2.8/CMakeLists.txt
+--- zlib-1.2.8/CMakeLists.txt	2013-04-28 15:57:10.000000000 -0700
++++ mods/zlib-1.2.8/CMakeLists.txt	2016-07-21 15:37:41.000000000 -0700
+@@ -160,90 +160,92 @@
+ 	if(ZLIB_ASMS)
+ 		add_definitions(-DASMV -DASMINF)
+ 	endif()
+ endif()
+ 
+ # parse the full version number from zlib.h and include in ZLIB_FULL_VERSION
+ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
+ string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
+     "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
+ 
+-if(MINGW)
+-    # This gets us DLL resource information when compiling on MinGW.
+-    if(NOT CMAKE_RC_COMPILER)
+-        set(CMAKE_RC_COMPILER windres.exe)
+-    endif()
+-
+-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+-                       COMMAND ${CMAKE_RC_COMPILER}
+-                            -D GCC_WINDRES
+-                            -I ${CMAKE_CURRENT_SOURCE_DIR}
+-                            -I ${CMAKE_CURRENT_BINARY_DIR}
+-                            -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+-                            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
+-    set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
+-endif(MINGW)
++#if(MINGW)
++#    # This gets us DLL resource information when compiling on MinGW.
++#    if(NOT CMAKE_RC_COMPILER)
++#        set(CMAKE_RC_COMPILER windres.exe)
++#    endif()
++#
++#    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
++#                       COMMAND ${CMAKE_RC_COMPILER}
++#                            -D GCC_WINDRES
++#                            -I ${CMAKE_CURRENT_SOURCE_DIR}
++#                            -I ${CMAKE_CURRENT_BINARY_DIR}
++#                            -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
++#                            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
++#    set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
++#endif(MINGW)
+ 
+-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
++#add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+ add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+-set_target_properties(zlib PROPERTIES SOVERSION 1)
++#set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
++#set_target_properties(zlib PROPERTIES SOVERSION 1)
+ 
+-if(NOT CYGWIN)
+-    # This property causes shared libraries on Linux to have the full version
+-    # encoded into their final filename.  We disable this on Cygwin because
+-    # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
+-    # seems to be the default.
+-    #
+-    # This has no effect with MSVC, on that platform the version info for
+-    # the DLL comes from the resource file win32/zlib1.rc
+-    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
+-endif()
++#if(NOT CYGWIN)
++#    # This property causes shared libraries on Linux to have the full version
++#    # encoded into their final filename.  We disable this on Cygwin because
++#    # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
++#    # seems to be the default.
++#    #
++#    # This has no effect with MSVC, on that platform the version info for
++#    # the DLL comes from the resource file win32/zlib1.rc
++#    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
++#endif()
+ 
+ if(UNIX)
+     # On unix-like platforms the library is almost always called libz
+-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
+-   if(NOT APPLE)
+-     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+-   endif()
+-elseif(BUILD_SHARED_LIBS AND WIN32)
+-    # Creates zlib1.dll when building shared library version
+-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
++   #set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
++   set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME z)
++   #if(NOT APPLE)
++   #  set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
++   #endif()
++#elseif(BUILD_SHARED_LIBS AND WIN32)
++#    # Creates zlib1.dll when building shared library version
++#    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+ endif()
+ 
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
+-    install(TARGETS zlib zlibstatic
++    #install(TARGETS zlib zlibstatic
++    install(TARGETS zlibstatic
+         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+ endif()
+ if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
+ endif()
+ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+     install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")
+ endif()
+ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+ endif()
+ 
+ #============================================================================
+ # Example binaries
+ #============================================================================
+ 
+-add_executable(example test/example.c)
+-target_link_libraries(example zlib)
+-add_test(example example)
+-
+-add_executable(minigzip test/minigzip.c)
+-target_link_libraries(minigzip zlib)
+-
+-if(HAVE_OFF64_T)
+-    add_executable(example64 test/example.c)
+-    target_link_libraries(example64 zlib)
+-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+-    add_test(example64 example64)
+-
+-    add_executable(minigzip64 test/minigzip.c)
+-    target_link_libraries(minigzip64 zlib)
+-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+-endif()
++#add_executable(example test/example.c)
++#target_link_libraries(example zlib)
++#add_test(example example)
++
++#add_executable(minigzip test/minigzip.c)
++#target_link_libraries(minigzip zlib)
++
++#if(HAVE_OFF64_T)
++#    add_executable(example64 test/example.c)
++#    target_link_libraries(example64 zlib)
++#    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
++#    add_test(example64 example64)
++#
++#    add_executable(minigzip64 test/minigzip.c)
++#    target_link_libraries(minigzip64 zlib)
++#    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
++#endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -265,7 +265,6 @@ endif()
 set(src_lib_static_nupiccore_solo nupic_core_solo)
 
 set(src_common_libs
-  ${PYTHON_LIBRARIES}
   ${CAPNP_LINK_LIBRARIES})
 
 if("${PLATFORM}" STREQUAL "linux")
@@ -371,6 +370,11 @@ set(src_lib_static_nupiccore_compile_flags
 set(src_lib_static_nupiccore_link_flags
     "${INTERNAL_LINKER_FLAGS_OPTIMIZED} -static")
 
+message(STATUS "src_compile_flags = ${src_compile_flags}")
+message(STATUS "src_lib_static_nupiccore_compile_flags = ${src_lib_static_nupiccore_compile_flags}")
+message(STATUS "src_lib_static_nupiccore_link_flags = ${src_lib_static_nupiccore_link_flags}")
+message(STATUS "src_lib_static_nupiccore_solo_link_libs = ${src_lib_static_nupiccore_solo_link_libs}")
+
 add_library(${src_lib_static_nupiccore_solo} STATIC ${src_lib_static_nupiccore_srcs})
 add_dependencies(${src_lib_static_nupiccore_solo}
                  Apr1StaticLib
@@ -394,15 +398,19 @@ if(${NUPIC_IWYU})
     PROPERTIES CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
 endif()
 
-# Add new library to common libs for rest of targets.
-set(src_common_libs ${src_lib_static_nupiccore_solo} ${src_common_libs})
+# Common libs for test executables
+set(src_common_test_exe_libs
+    ${src_lib_static_nupiccore_solo}
+    ${src_common_libs}
+    ${PYTHON_LIBRARIES}
+)
 
 #
 # Setup test_cpp_region
 #
 set(src_executable_cppregiontest cpp_region_test)
 add_executable(${src_executable_cppregiontest} test/integration/CppRegionTest.cpp)
-target_link_libraries(${src_executable_cppregiontest} ${src_common_libs})
+target_link_libraries(${src_executable_cppregiontest} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_cppregiontest} PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_cppregiontest} PROPERTIES LINK_FLAGS "${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
 add_custom_target(tests_cpp_region
@@ -415,7 +423,7 @@ add_custom_target(tests_cpp_region
 #
 set(src_executable_pyregiontest py_region_test)
 add_executable(${src_executable_pyregiontest} test/integration/PyRegionTest.cpp)
-target_link_libraries(${src_executable_pyregiontest} ${src_common_libs})
+target_link_libraries(${src_executable_pyregiontest} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_pyregiontest}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_pyregiontest}
@@ -425,14 +433,13 @@ add_custom_target(tests_py_region
                   DEPENDS ${src_executable_pyregiontest}
                   VERBATIM)
 
-
 #
 # Setup test_connections_performance
 #
 set(src_executable_connectionsperformancetest connections_performance_test)
 add_executable(${src_executable_connectionsperformancetest}
                test/integration/ConnectionsPerformanceTest.cpp)
-target_link_libraries(${src_executable_connectionsperformancetest} ${src_common_libs})
+target_link_libraries(${src_executable_connectionsperformancetest} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_connectionsperformancetest}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_connectionsperformancetest}
@@ -447,36 +454,36 @@ add_custom_target(tests_connections_performance
 #
 set(src_executable_helloregion helloregion)
 add_executable(${src_executable_helloregion} examples/regions/HelloRegions.cpp)
-target_link_libraries(${src_executable_helloregion} ${src_common_libs})
+target_link_libraries(${src_executable_helloregion} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_helloregion}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_helloregion}
                       PROPERTIES LINK_FLAGS "${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
-add_dependencies(${src_executable_helloregion} ${src_common_libs})
+add_dependencies(${src_executable_helloregion} ${src_common_test_exe_libs})
 
 #
 # Setup prototest example
 #
 set(src_executable_prototest prototest)
 add_executable(${src_executable_prototest} examples/prototest.cpp)
-target_link_libraries(${src_executable_prototest} ${src_common_libs})
+target_link_libraries(${src_executable_prototest} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_prototest}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_prototest}
                       PROPERTIES LINK_FLAGS "${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
-add_dependencies(${src_executable_prototest} ${src_common_libs})
+add_dependencies(${src_executable_prototest} ${src_common_test_exe_libs})
 
 #
 # Setup HelloSP_TP example
 #
 set(src_executable_hellosptp hello_sp_tp)
 add_executable(${src_executable_hellosptp} examples/algorithms/HelloSP_TP.cpp)
-target_link_libraries(${src_executable_hellosptp} ${src_common_libs})
+target_link_libraries(${src_executable_hellosptp} ${src_common_test_exe_libs})
 set_target_properties(${src_executable_hellosptp}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags})
 set_target_properties(${src_executable_hellosptp}
                       PROPERTIES LINK_FLAGS "${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
-add_dependencies(${src_executable_hellosptp} ${src_common_libs})
+add_dependencies(${src_executable_hellosptp} ${src_common_test_exe_libs})
 
 
 #
@@ -532,7 +539,7 @@ add_executable(${src_executable_gtests}
                test/unit/utils/WatcherTest.cpp)
 target_link_libraries(${src_executable_gtests}
                       ${src_lib_static_gtest}
-                      ${src_common_libs})
+                      ${src_common_test_exe_libs})
 set_target_properties(${src_executable_gtests}
                       PROPERTIES COMPILE_FLAGS ${src_compile_flags}
                                  LINK_FLAGS "${INTERNAL_LINKER_FLAGS_OPTIMIZED}")
@@ -540,7 +547,7 @@ add_custom_target(tests_unit
                   COMMAND ${src_executable_gtests}
                   DEPENDS ${src_executable_gtests}
                   VERBATIM)
-add_dependencies(${src_executable_gtests} ${src_lib_static_gtest} ${src_common_libs})
+add_dependencies(${src_executable_gtests} ${src_lib_static_gtest} ${src_common_test_exe_libs})
 
 #
 # tests_all just calls other targets
@@ -605,161 +612,186 @@ endif()
 add_custom_target(LibStaticNupicCoreCombinedTarget
                   DEPENDS ${src_lib_static_nupiccore_combined})
 
-#
-# Call SWIG to generate wrapper code for Python.
-#
-include(UseSWIG)
+if (${NUPIC_BUILD_PYEXT_MODULES})
+  #
+  # Call SWIG to generate wrapper code for Python.
+  #
+  include(UseSWIG)
 
-# Set the output location for the language modules that are created.
-set(CMAKE_SWIG_OUTDIR ${PROJECT_BINARY_DIR})
+  message(STATUS "PYEXT_LINKER_FLAGS_OPTIMIZED = ${PYEXT_LINKER_FLAGS_OPTIMIZED}")
+  message(STATUS "CMAKE_CXX_COMPILER_ID        = ${CMAKE_CXX_COMPILER_ID}")
 
-# Make sure the directory exists for the generated C++ files.
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/nupic/bindings)
+  # Set the output location for the language modules that are created.
+  set(CMAKE_SWIG_OUTDIR ${PROJECT_BINARY_DIR})
 
-# SWIG options from:
-# https://github.com/swig/swig/blob/master/Source/Modules/python.cxx#L111
-set(src_swig_flags
-    -features
-    autodoc=0,directors=0
-    -noproxyimport
-    -keyword
-    -modern
-    -modernargs
-    -noproxydel
-    -fvirtual
-    -fastunpack
-    -nofastproxy
-    -fastquery
-    -outputtuple
-    -castmode
-    -nosafecstrings
-    -w402
-    -w503
-    -w511
-    -w302
-    -w362
-    -w312
-    -w389
-    -DSWIG_PYTHON_LEGACY_BOOL
-    -I${SWIG_DIR}/python
-    -I${SWIG_DIR}
-    ${src_compiler_definitions}
-)
+  # Make sure the directory exists for the generated C++ files.
+  file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/nupic/bindings)
 
-set(src_swig_support_files
-    nupic/py_support/NumpyVector.cpp
-    nupic/py_support/PyArray.cpp
-    nupic/py_support/PyHelpers.cpp
-    nupic/py_support/PythonStream.cpp
-    nupic/bindings/PySparseTensor.cpp
-)
+  # TODO ZZZ set COMPILE_FLAGS on swig targets
 
-set(src_swig_link_libraries
-    ${src_lib_static_nupiccore_combined}
-    ${PYTHON_LIBRARIES}
-    ${src_common_os_libs})
+  # SWIG options from:
+  # https://github.com/swig/swig/blob/master/Source/Modules/python.cxx#L111
+  set(src_swig_flags
+      -c++
+      -features
+      autodoc=0,directors=0
+      -noproxyimport
+      -keyword
+      -modern
+      -modernargs
+      -noproxydel
+      -fvirtual
+      -fastunpack
+      -nofastproxy
+      -fastquery
+      -outputtuple
+      -castmode
+      -nosafecstrings
+      -w402
+      -w503
+      -w511
+      -w302
+      -w362
+      -w312
+      -w389
+      -DSWIG_PYTHON_LEGACY_BOOL
+      -I${SWIG_DIR}/python
+      -I${SWIG_DIR}
+      ${src_compiler_definitions}
+  )
 
+  message(STATUS "src_swig_flags = ${src_swig_flags}")
 
-set(src_swig_link_libraries
-    ${src_swig_link_libraries}
-    ${CAPNP_LINK_LIBRARIES})
+  # Tell swig which command-line options to use, allowing user to override
+  set(CMAKE_SWIG_FLAGS ${src_swig_flags} ${CMAKE_SWIG_FLAGS})
 
-# Algorithms
-set(src_swig_algorithms_files nupic/bindings/algorithms.i)
-set_source_files_properties(${src_swig_algorithms_files} PROPERTIES
-                            CPLUSPLUS ON
-                            SWIG_MODULE_NAME algorithms
-                            SWIG_FLAGS "${src_swig_flags}")
-set(src_swig_algorithms algorithms)
-# Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${src_swig_algorithms}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
-# Create custom command for generating files from SWIG.
-swig_add_module(${src_swig_algorithms} python
-                ${src_swig_support_files}
-                ${src_swig_algorithms_files})
-list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
-swig_link_libraries(${src_swig_algorithms}
-                    ${src_swig_link_libraries})
+  set(src_swig_support_files
+      nupic/py_support/NumpyVector.cpp
+      nupic/py_support/PyArray.cpp
+      nupic/py_support/PyHelpers.cpp
+      nupic/py_support/PythonStream.cpp
+      nupic/bindings/PySparseTensor.cpp
+  )
 
-# Engine
-set(src_swig_engine_files nupic/bindings/engine_internal.i)
-set_source_files_properties(${src_swig_engine_files} PROPERTIES
-                            CPLUSPLUS ON
-                            SWIG_MODULE_NAME engine_internal
-                            SWIG_FLAGS "${src_swig_flags}")
-set(src_swig_engine engine_internal)
-# Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${src_swig_engine}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
-# Create custom command for generating files from SWIG.
-swig_add_module(${src_swig_engine} python
-                ${src_swig_support_files}
-                ${src_swig_engine_files})
-list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
-swig_link_libraries(${src_swig_engine}
-                    ${src_swig_link_libraries})
+  # NOTE Python extensions shouldn't be linking agains libpython; symbols should
+  # be available automatically when python loads the extension.
+  set(src_swig_link_libraries
+      ${src_lib_static_nupiccore_combined}
+      ${src_common_os_libs})
 
-# Experimental
-set(src_swig_experimental_files nupic/bindings/experimental.i)
-set_source_files_properties(${src_swig_experimental_files} PROPERTIES
-                            CPLUSPLUS ON
-                            SWIG_MODULE_NAME experimental
-                            SWIG_FLAGS "${src_swig_flags}")
-set(src_swig_experimental experimental)
-# Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${src_swig_experimental}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
-# Create custom command for generating files from SWIG.
-swig_add_module(${src_swig_experimental} python
-                ${src_swig_support_files}
-                ${src_swig_experimental_files})
-list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
-swig_link_libraries(${src_swig_experimental}
-                    ${src_swig_link_libraries})
+  if("${PLATFORM}" STREQUAL "windows")
+    # Windows DLLs are shared executables with their own main; they require
+    # all symbols to resolve at link time, so we have to add libpython for this
+    # platform
+    list(APPEND src_swig_link_libraries ${PYTHON_LIBRARIES})
+  endif()
 
-# Math
-set(src_swig_math_files nupic/bindings/math.i)
-set_source_files_properties(${src_swig_math_files} PROPERTIES
-                            CPLUSPLUS ON
-                            SWIG_MODULE_NAME math
-                            SWIG_FLAGS "${src_swig_flags}")
-set(src_swig_math math)
-# Make sure we don't attempt to execute the swig executable until it is built.
-set(SWIG_MODULE_${src_swig_math}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
-# Create custom command for generating files from SWIG.
-swig_add_module(${src_swig_math} python
-                ${src_swig_support_files}
-                ${src_swig_math_files})
-list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
-swig_link_libraries(${src_swig_math}
-                    ${src_swig_link_libraries})
+  set(src_swig_link_libraries
+      ${src_swig_link_libraries}
+      ${CAPNP_LINK_LIBRARIES})
 
-set_source_files_properties(${src_swig_generated_files} PROPERTIES
-                            GENERATED TRUE)
-set_source_files_properties(${src_swig_generated_files}
-                            PROPERTIES
-                            COMPILE_FLAGS ${swig_generated_file_compile_flags}
-                            LINK_FLAGS ${EXTERNAL_LINKER_FLAGS_OPTIMIZED})
+  message(STATUS "src_swig_link_libraries = ${src_swig_link_libraries}")
 
-set_source_files_properties(${src_swig_support_files}
-                            PROPERTIES
-                            COMPILE_FLAGS ${src_compile_flags}
-                            LINK_FLAGS ${EXTERNAL_LINKER_FLAGS_OPTIMIZED})
+  # Algorithms
+  set(src_swig_algorithms_files nupic/bindings/algorithms.i)
+  set_source_files_properties(${src_swig_algorithms_files} PROPERTIES
+                              CPLUSPLUS ON
+                              SWIG_MODULE_NAME algorithms)
+  set(src_swig_algorithms algorithms)
+  # Make sure we don't attempt to execute the swig executable until it is built.
+  set(SWIG_MODULE_${src_swig_algorithms}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
+  # Create custom command for generating files from SWIG.
+  swig_add_module(${src_swig_algorithms} python
+                  ${src_swig_support_files}
+                  ${src_swig_algorithms_files})
+  list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
+  swig_link_libraries(${src_swig_algorithms}
+                      ${src_swig_link_libraries})
+  set_target_properties(${SWIG_MODULE_${src_swig_algorithms}_REAL_NAME} PROPERTIES
+                        LINK_FLAGS "${PYEXT_LINKER_FLAGS_OPTIMIZED}")
 
-# If a path is specified, copy extensions files to proper location.
-if (PY_EXTENSIONS_DIR)
-  install(TARGETS
-          ${SWIG_MODULE_${src_swig_algorithms}_REAL_NAME}
-          ${SWIG_MODULE_${src_swig_engine}_REAL_NAME}
-          ${SWIG_MODULE_${src_swig_experimental}_REAL_NAME}
-          ${SWIG_MODULE_${src_swig_math}_REAL_NAME}
-          LIBRARY DESTINATION ${PY_EXTENSIONS_DIR})
-  install(FILES
-          ${PROJECT_BINARY_DIR}/algorithms.py
-          ${PROJECT_BINARY_DIR}/engine_internal.py
-          ${PROJECT_BINARY_DIR}/experimental.py
-          ${PROJECT_BINARY_DIR}/math.py
-          DESTINATION ${PY_EXTENSIONS_DIR})
-endif(PY_EXTENSIONS_DIR)
+  # Engine
+  set(src_swig_engine_files nupic/bindings/engine_internal.i)
+  set_source_files_properties(${src_swig_engine_files} PROPERTIES
+                              CPLUSPLUS ON
+                              SWIG_MODULE_NAME engine_internal)
+  set(src_swig_engine engine_internal)
+  # Make sure we don't attempt to execute the swig executable until it is built.
+  set(SWIG_MODULE_${src_swig_engine}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
+  # Create custom command for generating files from SWIG.
+  swig_add_module(${src_swig_engine} python
+                  ${src_swig_support_files}
+                  ${src_swig_engine_files})
+  list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
+  swig_link_libraries(${src_swig_engine}
+                      ${src_swig_link_libraries})
+  set_target_properties(${SWIG_MODULE_${src_swig_engine}_REAL_NAME} PROPERTIES
+                        LINK_FLAGS "${PYEXT_LINKER_FLAGS_OPTIMIZED}")
 
+  # Experimental
+  set(src_swig_experimental_files nupic/bindings/experimental.i)
+  set_source_files_properties(${src_swig_experimental_files} PROPERTIES
+                              CPLUSPLUS ON
+                              SWIG_MODULE_NAME experimental)
+  set(src_swig_experimental experimental)
+  # Make sure we don't attempt to execute the swig executable until it is built.
+  set(SWIG_MODULE_${src_swig_experimental}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
+  # Create custom command for generating files from SWIG.
+  swig_add_module(${src_swig_experimental} python
+                  ${src_swig_support_files}
+                  ${src_swig_experimental_files})
+  list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
+  swig_link_libraries(${src_swig_experimental}
+                      ${src_swig_link_libraries})
+  set_target_properties(${SWIG_MODULE_${src_swig_experimental}_REAL_NAME} PROPERTIES
+                        LINK_FLAGS "${PYEXT_LINKER_FLAGS_OPTIMIZED}")
+
+  # Math
+  set(src_swig_math_files nupic/bindings/math.i)
+  set_source_files_properties(${src_swig_math_files} PROPERTIES
+                              CPLUSPLUS ON
+                              SWIG_MODULE_NAME math)
+  set(src_swig_math math)
+  # Make sure we don't attempt to execute the swig executable until it is built.
+  set(SWIG_MODULE_${src_swig_math}_EXTRA_DEPS Swig LibStaticNupicCoreCombinedTarget)
+  # Create custom command for generating files from SWIG.
+  swig_add_module(${src_swig_math} python
+                  ${src_swig_support_files}
+                  ${src_swig_math_files})
+  list(APPEND src_swig_generated_files ${swig_generated_file_fullname})
+  swig_link_libraries(${src_swig_math}
+                      ${src_swig_link_libraries})
+  set_target_properties(${SWIG_MODULE_${src_swig_math}_REAL_NAME} PROPERTIES
+                        LINK_FLAGS "${PYEXT_LINKER_FLAGS_OPTIMIZED}")
+
+  set_source_files_properties(${src_swig_generated_files} PROPERTIES
+                              GENERATED TRUE)
+
+  set_source_files_properties(${src_swig_generated_files}
+                              PROPERTIES
+                              COMPILE_FLAGS ${swig_generated_file_compile_flags})
+
+  set_source_files_properties(${src_swig_support_files}
+                              PROPERTIES
+                              COMPILE_FLAGS ${src_compile_flags})
+
+  # If a path is specified, copy extensions files to proper location.
+  if (PY_EXTENSIONS_DIR)
+    install(TARGETS
+            ${SWIG_MODULE_${src_swig_algorithms}_REAL_NAME}
+            ${SWIG_MODULE_${src_swig_engine}_REAL_NAME}
+            ${SWIG_MODULE_${src_swig_experimental}_REAL_NAME}
+            ${SWIG_MODULE_${src_swig_math}_REAL_NAME}
+            LIBRARY DESTINATION ${PY_EXTENSIONS_DIR})
+    install(FILES
+            ${PROJECT_BINARY_DIR}/algorithms.py
+            ${PROJECT_BINARY_DIR}/engine_internal.py
+            ${PROJECT_BINARY_DIR}/experimental.py
+            ${PROJECT_BINARY_DIR}/math.py
+            DESTINATION ${PY_EXTENSIONS_DIR})
+  endif(PY_EXTENSIONS_DIR)
+
+endif() # ${NUPIC_BUILD_PYEXT_MODULES}
 
 #
 # Install targets into CMAKE_INSTALL_PREFIX

--- a/src/nupic/math/ArrayAlgo.hpp
+++ b/src/nupic/math/ArrayAlgo.hpp
@@ -33,7 +33,7 @@
 #include <iterator>
 #include <algorithm>
 
-#if defined(NTA_OS_WINDOWS) && defined(NTA_COMPILER_MSVC) 
+#if defined(NTA_OS_WINDOWS) && defined(NTA_COMPILER_MSVC)
   #include <array>
   #include <intrin.h>
 #endif
@@ -45,11 +45,11 @@
 namespace nupic {
 
   //--------------------------------------------------------------------------------
-  // Checks whether the SSE supports the operations we need, i.e. SSE3 and SSE4. 
+  // Checks whether the SSE supports the operations we need, i.e. SSE3 and SSE4.
   // Returns highest SSE level supported by the CPU: 1, 2, 3 or 41 or 42. It also
   // returns -1 if SSE is not present at all.
   //
-  // Refer to Intel manuals for details. Basically, after call to cpuid, the 
+  // Refer to Intel manuals for details. Basically, after call to cpuid, the
   // interesting bits are set to 1 in either ecx or edx:
   // If 25th bit of edx is 1, we have sse: 2^25 = 33554432 = 1<<25
   // If 26th bit of edx is 1, we have sse2.
@@ -60,7 +60,7 @@ namespace nupic {
   static int checkSSE()
   {
     unsigned int        c = 0, d = 0;
-    const unsigned int SSE = 1<<25, 
+    const unsigned int SSE = 1<<25,
             SSE2  = 1<<26,
             SSE3  = 1<<0,
             SSE41 = 1<<19,
@@ -130,13 +130,13 @@ namespace nupic {
     if (c & SSE42) ret = 42;
 
     return ret;
-  } 
+  }
 
   //--------------------------------------------------------------------------------
   // Highest SSE level supported by the CPU: 1, 2, 3 or 41 or 42.
-  // Note that the asm routines are written for gcc only so far, so we turn them 
+  // Note that the asm routines are written for gcc only so far, so we turn them
   // off for all platforms except darwin86. Also, they won't work properly on 64 bits
-  // platforms for now. 
+  // platforms for now.
   //--------------------------------------------------------------------------------
   static const int SSE_LEVEL = checkSSE();
 
@@ -225,7 +225,7 @@ namespace nupic {
   // DENSE isZero
   //--------------------------------------------------------------------------------
   /**
-   * Scans a binary 0/1 vector to decide whether it is uniformly zero, 
+   * Scans a binary 0/1 vector to decide whether it is uniformly zero,
    * or if it contains non-zeros (4X faster than C++ loop).
    *
    * If vector x is not aligned on a 16 bytes boundary, the function
@@ -246,7 +246,7 @@ namespace nupic {
 
     // This test can be moved to compile time using a template with an int
     // parameter, and partial specializations that will match the static
-    // const int SSE_LEVEL. 
+    // const int SSE_LEVEL.
     if (SSE_LEVEL >= 41) { // ptest is a SSE 4.1 instruction
 
     // On win32, the asm syntax is not correct.
@@ -254,13 +254,13 @@ namespace nupic {
 
       // n is the total number of floats to process.
       // n1 is the number of floats we can process in parallel using SSE.
-      // If x is not aligned on a 4 bytes boundary, we eschew all asm. 
+      // If x is not aligned on a 4 bytes boundary, we eschew all asm.
       int result = 0;
       int n = (int)(x_end - x);
       int n1 = 0;
       if (((long)x) % 16 == 0)
         n1 = 8 * (n / 8); // we are going to process 2x4 floats at a time
-    
+
       if (n1 > 0) {
 
         __asm__ __volatile__(
@@ -278,7 +278,7 @@ namespace nupic {
                      "addl $16, %%esp\n\t" // deallocate 4 floats on the stack
 
                      "0:\n\t"
-                     // esi and edi point to the same x, but staggered, so 
+                     // esi and edi point to the same x, but staggered, so
                      // that we can load 2x4 bytes into xmm0 and xmm1
                      "movaps (%%edi), %%xmm0\n\t" // move 4 floats from x
                      "movaps (%%esi), %%xmm1\n\t" // move another 4 floats from same x
@@ -286,30 +286,30 @@ namespace nupic {
                      "jne 1f\n\t" // jump if ZF = 0, some bit is not zero
                      "ptest %%xmm4, %%xmm1\n\t"   // ptest second 4 floats, in xmm1
                      "jne 1f\n\t" // jump if ZF = 0, some bit is not zero
-                   
+
                      "addl $32, %%edi\n\t"  // jump over 4 floats
                      "addl $32, %%esi\n\t"  // and another 4 floats here
                      "subl $8, %%ecx\n\t" // processed 8 floats
                      "ja 0b\n\t"
-                   
+
                      "movl $0, %0\n\t" // didn't find anything, result = 0 (int)
                      "jmp 2f\n\t" // exit
-                   
+
                      "1:\n\t" // found something
                      "movl $0x1, %0\n\t" // result = 1 (int)
-                   
+
                      "2:\n\t" // exit
                      "popa\n\t" // restore all registers
-                   
+
                      : "=m" (result), "=D" (x)
                      : "D" (x), "S" (x + 4), "c" (n1)
                      :
                      );
-      
+
         if (result == 1)
           return false;
       } // n1>0 end
-      
+
       // Complete computation by iterating over "stragglers" one by one.
       for (int i = n1; i != n; ++i)
         if (*(x+i) > 0)
@@ -390,7 +390,7 @@ namespace nupic {
 #endif
 
     } else { // not SSE4.2
-    
+
       for (; x != x_end; ++x)
         if (*x > 0)
           return false;
@@ -402,7 +402,7 @@ namespace nupic {
   /**
    * 10X faster than function just above.
    */
-  inline bool 
+  inline bool
   is_zero_01(const ByteVector& x, size_t begin, size_t end)
   {
     const Byte* x_beg = &x[begin];
@@ -412,20 +412,20 @@ namespace nupic {
 
     // This test can be moved to compile time using a template with an int
     // parameter, and partial specializations that will match the static
-    // const int SSE_LEVEL. 
+    // const int SSE_LEVEL.
     if (SSE_LEVEL >= 41) { // ptest is a SSE 4.1 instruction
 
 #if defined(NTA_ASM) && defined(NTA_ARCH_32) && !defined(NTA_OS_WINDOWS)
 
       // n is the total number of floats to process.
       // n1 is the number of floats we can process in parallel using SSE.
-      // If x is not aligned on a 4 bytes boundary, we eschew all asm. 
+      // If x is not aligned on a 4 bytes boundary, we eschew all asm.
       int result = 0;
       int n = (int)(x_end - x_beg);
       int n1 = 0;
       if (((long)x_beg) % 16 == 0)
         n1 = 32 * (n / 32); // we are going to process 32 bytes at a time
-    
+
       if (n1 > 0) {
 
         __asm__ __volatile__(
@@ -443,7 +443,7 @@ namespace nupic {
                      "addl $16, %%esp\n\t" // deallocate 4 floats on the stack
 
                      "0:\n\t"
-                     // esi and edi point to the same x, but staggered, so 
+                     // esi and edi point to the same x, but staggered, so
                      // that we can load 2x4 bytes into xmm0 and xmm1
                      "movaps (%%edi), %%xmm0\n\t" // move 4 floats from x
                      "movaps (%%esi), %%xmm1\n\t" // move another 4 floats from same x
@@ -451,30 +451,30 @@ namespace nupic {
                      "jne 1f\n\t" // jump if ZF = 0, some bit is not zero
                      "ptest %%xmm4, %%xmm1\n\t"   // ptest second 4 floats, in xmm1
                      "jne 1f\n\t" // jump if ZF = 0, some bit is not zero
-                   
+
                      "addl $32, %%edi\n\t"  // jump 32 bytes (16 in xmm0 + 16 in xmm1)
                      "addl $32, %%esi\n\t"  // and another 32 bytes
                      "subl $32, %%ecx\n\t" // processed 32 bytes
                      "ja 0b\n\t"
-                   
+
                      "movl $0, %0\n\t" // didn't find anything, result = 0 (int)
                      "jmp 2f\n\t" // exit
-                   
+
                      "1:\n\t" // found something
                      "movl $0x1, %0\n\t" // result = 1 (int)
-                   
+
                      "2:\n\t" // exit
                      "popa\n\t" // restore all registers
-                   
+
                      : "=m" (result), "=D" (x_beg)
                      : "D" (x_beg), "S" (x_beg + 16), "c" (n1)
                      :
                      );
-      
+
         if (result == 1)
           return false;
       }
-      
+
       // Complete computation by iterating over "stragglers" one by one.
       for (int i = n1; i != n; ++i)
         if (*(x_beg+i) > 0)
@@ -548,7 +548,7 @@ namespace nupic {
       return true;
 #endif
     } else {   // SSE 4.1
-    
+
       for (; x_beg != x_end; ++x_beg)
         if (*x_beg > 0)
           return false;
@@ -590,7 +590,7 @@ namespace nupic {
       std::cout << ' ';
     }
   }
-  
+
   //--------------------------------------------------------------------------------
   // N BYTES
   //--------------------------------------------------------------------------------
@@ -613,16 +613,16 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * For more bytes for alignment on x86 with darwin: darwin32 always allocates on 
+   * For more bytes for alignment on x86 with darwin: darwin32 always allocates on
    * 16 bytes boundaries, so the three pointers in the STL vectors (of 32 bits each
-   * in -m32), become: 3 * 4 + 4 = 16 bytes. The capacity similarly needs to be 
+   * in -m32), become: 3 * 4 + 4 = 16 bytes. The capacity similarly needs to be
    * adjusted for aligment. On other platforms, the alignment might be different.
    *
    * NOTE/WARNING: this is really "accurate" only on darwin32. And even, it's probably
    * only approximate.
    */
   template <typename T>
-  inline size_t n_bytes(const std::vector<T>& a, size_t alignment =16) 
+  inline size_t n_bytes(const std::vector<T>& a, size_t alignment =16)
   {
     size_t n1 = a.capacity() * sizeof(T);
     if (n1 % alignment != 0)
@@ -695,7 +695,7 @@ namespace nupic {
     append(a, b);
     return b;
   }
-  
+
   //--------------------------------------------------------------------------------
   template <typename T>
   inline void append(const std::set<T>& a, std::set<T>& b)
@@ -732,15 +732,15 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   // Deriving from std::map to add frequently used functionality
-  template <typename K, typename V, typename C =std::less<K>, 
+  template <typename K, typename V, typename C =std::less<K>,
             typename A =std::allocator<std::pair<const K, V> > >
   struct dict : public std::map<K,V,C,A>
   {
-    inline bool has_key(const K& key) const 
+    inline bool has_key(const K& key) const
     {
       return is_in(key, *this);
     }
-    
+
     // Often useful for histograms, where V is an integral type
     inline void increment(const K& key, const V& init =1)
     {
@@ -761,13 +761,13 @@ namespace nupic {
     /*
     // Returns an existing value for the key, if it is in the dict already,
     // or creates one and returns it. (operator[] on std::map does that?)
-    inline V& operator(const K& key) 
-    { 
+    inline V& operator(const K& key)
+    {
       iterator it = this->find(key);
       if (key == end) {
-        (*this)[key] = V(); 
-        return (*this)[key]; 
-      } else 
+        (*this)[key] = V();
+        return (*this)[key];
+      } else
         return *it;
     }
     */
@@ -780,11 +780,11 @@ namespace nupic {
   struct vector_init_list
   {
     std::vector<T>& v;
-    
+
     inline vector_init_list(std::vector<T>& v_ref) : v(v_ref) {}
     inline vector_init_list(const vector_init_list& o) : v(o.v) {}
 
-    inline vector_init_list& operator=(const vector_init_list& o) 
+    inline vector_init_list& operator=(const vector_init_list& o)
     { v(o.v); return *this; }
 
     template <typename T2>
@@ -794,7 +794,7 @@ namespace nupic {
       return *this;
     }
   };
-  
+
   //--------------------------------------------------------------------------------
   template <typename T, typename T2>
   inline vector_init_list<T> operator+=(std::vector<T>& v, const T2& x)
@@ -810,11 +810,11 @@ namespace nupic {
   struct set_init_list
   {
     std::set<T>& v;
-    
+
     inline set_init_list(std::set<T>& v_ref) : v(v_ref) {}
     inline set_init_list(const set_init_list& o) : v(o.v) {}
 
-    inline set_init_list& operator=(const set_init_list& o) 
+    inline set_init_list& operator=(const set_init_list& o)
     { v(o.v); return *this; }
 
     template <typename T2>
@@ -824,7 +824,7 @@ namespace nupic {
       return *this;
     }
   };
-  
+
   //--------------------------------------------------------------------------------
   template <typename T, typename T2>
   inline set_init_list<T> operator+=(std::set<T>& v, const T2& x)
@@ -906,25 +906,27 @@ namespace nupic {
   template <typename It>
   inline bool is_sorted(It begin, It end, bool ascending =true, bool unique =true)
   {
-    for (It prev = begin, it = ++begin; it < end; ++it, ++prev)
+    if (begin < end) {
+      for (It prev = begin, it = ++begin; it < end; ++it, ++prev)
 
-      if (ascending) {
-        if (unique) {
-          if (*prev >= *it) 
-            return false;
+        if (ascending) {
+          if (unique) {
+            if (*prev >= *it)
+						  return false;
+          } else {
+            if (*prev > *it)
+              return false;
+          }
         } else {
-          if (*prev > *it) 
-            return false;
-        }
-      } else {
-        if (unique) {
-          if (*prev <= *it)
-            return false;
-        } else {
-          if (*prev < *it)
-            return false;
-        }
+          if (unique) {
+            if (*prev <= *it)
+              return false;
+          } else {
+            if (*prev < *it)
+              return false;
+          }
       }
+    }
 
     return true;
   }
@@ -948,7 +950,7 @@ namespace nupic {
         return false;
     return true;
   }
-  
+
   //--------------------------------------------------------------------------------
   template <typename T>
   inline bool operator!=(const std::vector<T>& a, const std::vector<T>& b)
@@ -1002,8 +1004,8 @@ namespace nupic {
   //--------------------------------------------------------------------------------
   /**
    * Proxy for an insert iterator that allows inserting at the second element when
-   * iterating over a container of pairs, while setting the first element to the 
-   * current index value (watch out if iterator passed to constructor is not 
+   * iterating over a container of pairs, while setting the first element to the
+   * current index value (watch out if iterator passed to constructor is not
    * pointing to the beginning of the container!)
    */
   template <typename Iterator>
@@ -1016,7 +1018,7 @@ namespace nupic {
     Iterator it;
     size_t i;
 
-    inline inserter_second_incrementer_first(Iterator _it) 
+    inline inserter_second_incrementer_first(Iterator _it)
       : it(_it), i(0) {}
     inline second_type& operator*() { return it->second; }
     inline void operator++() { it->first = i++; ++it; }
@@ -1034,8 +1036,8 @@ namespace nupic {
   {
     size_t n1 = x.size(), n2 = y.nnz, i1 = 0, i2 = 0;
     T2 s = 0;
-    
-    while (i1 != n1 && i2 != n2) 
+
+    while (i1 != n1 && i2 != n2)
       if (x[i1] < y[i2]) {
         ++i1;
       } else if (y[i2] < x[i1]) {
@@ -1056,7 +1058,7 @@ namespace nupic {
       result += *x * *y;
     return result;
   }
-  
+
   //--------------------------------------------------------------------------------
   // copy
   //--------------------------------------------------------------------------------
@@ -1116,7 +1118,7 @@ namespace nupic {
       y[i] = x[i].first;
     y.nnz = x.nnz;
   }
-  
+
   //--------------------------------------------------------------------------------
   // TO DENSE
   //--------------------------------------------------------------------------------
@@ -1137,7 +1139,7 @@ namespace nupic {
     // TODO: make faster with single pass?
     // (but if's for all the elements might be slower)
     std::fill(dense, dense_end, (value_type) 0);
-    
+
     for (; ind != ind_end; ++ind)
       *(dense + *ind) = (value_type) 1;
   }
@@ -1173,7 +1175,7 @@ namespace nupic {
   inline void to_dense_1st_01(const SparseVector<I,T>& x, OutIt y, OutIt y_end)
   {
     typedef typename std::iterator_traits<OutIt>::value_type value_type;
-    
+
     std::fill(y, y_end, (value_type) 0);
 
     for (size_t i = 0; i != x.nnz; ++i)
@@ -1182,7 +1184,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   template <typename T, typename OutIt>
-  inline void 
+  inline void
   to_dense_01(size_t n, const std::vector<T>& buffer, OutIt y, OutIt y_end)
   {
     NTA_ASSERT(n <= buffer.size());
@@ -1190,7 +1192,7 @@ namespace nupic {
     typedef typename std::iterator_traits<OutIt>::value_type value_type;
 
     std::fill(y, y_end, (value_type) 0);
-    
+
     const T* b = &buffer[0], *b_end = b + n;
     for (; b != b_end; ++b) {
       NTA_ASSERT(*b < (size_t)(y_end - y));
@@ -1297,7 +1299,7 @@ namespace nupic {
 
     typename Buffer<T>::iterator it2 = buffer.begin();
 
-    for (It it = begin; it != end; ++it) 
+    for (It it = begin; it != end; ++it)
       if (*it != 0) {
         *it2++ = (T)(it - begin);
       }
@@ -1357,16 +1359,16 @@ namespace nupic {
   /**
    * Given a vector of indices, removes the elements of a at those indices (indices
    * before any removal is carried out), where a is a vector of pairs.
-   * 
+   *
    * Need to pass in non-empty vector of sorted, unique indices to delete.
    */
   // TODO: remove this? Should be covered just below??
   template <typename I, typename T1, typename T2>
-  inline void 
+  inline void
   remove_for_pairs(const std::vector<I>& del, std::vector<std::pair<T1, T2> >& a)
   {
     NTA_ASSERT(std::set<I>(del.begin(),del.end()).size() == del.size());
-    
+
     if (del.empty())
       return;
 
@@ -1382,7 +1384,7 @@ namespace nupic {
       }
     }
 
-    while (old < a.size()) 
+    while (old < a.size())
       a[cur++] = a[old++];
 
     a.resize(a.size() - del.size());
@@ -1390,21 +1392,21 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * Remove several elements from a vector, the elements to remove being specified 
-   * by their index (in del). After this call, a's size is reduced. Requires 
+   * Remove several elements from a vector, the elements to remove being specified
+   * by their index (in del). After this call, a's size is reduced. Requires
    * default constructor on T to be defined (for resize). O(n).
    */
   template <typename I, typename T>
-  inline void 
+  inline void
   remove_at(const std::vector<I>& del, std::vector<T>& a)
   {
     NTA_ASSERT(std::set<I>(del.begin(),del.end()).size() == del.size());
-    
+
     if (del.empty())
       return;
-    
+
     size_t old = del[0] + 1, cur = del[0], d = 1;
-    
+
     while (old < a.size() && d < del.size()) {
       if (old == (size_t) del[d]) {
         ++d; ++old;
@@ -1414,13 +1416,13 @@ namespace nupic {
         a[cur++] = a[old++];
       }
     }
-    
-    while (old < a.size()) 
+
+    while (old < a.size())
       a[cur++] = a[old++];
-    
+
     a.resize(a.size() - del.size());
   }
-  
+
   //--------------------------------------------------------------------------------
   /**
    * Finds index of elt in ref, and removes corresponding element of a.
@@ -1474,11 +1476,11 @@ namespace nupic {
   // DIFFERENCES
   //--------------------------------------------------------------------------------
   /**
-   * Returns a vector that contains the indices of the positions where x and y 
+   * Returns a vector that contains the indices of the positions where x and y
    * have different values.
    */
   template <typename T>
-  inline void 
+  inline void
   find_all_differences(const std::vector<T>& x, const std::vector<T>& y,
                        std::vector<size_t>& diffs)
   {
@@ -2223,7 +2225,7 @@ namespace nupic {
     std::random_shuffle(aa.begin(), aa.end());
     std::copy(aa.begin(), aa.begin() + b.size(), b.begin());
   }
-  
+
   //--------------------------------------------------------------------------------
   template <typename T>
   inline void random_binary(float proba, std::vector<T>& x)
@@ -2242,9 +2244,9 @@ namespace nupic {
    * of the non-zero bits.
    */
   template <typename T1, typename T2>
-  inline void 
-  random_pair_sample(size_t nrows, size_t ncols, size_t nnzpr, 
-                     std::vector<std::pair<T1, T2> >& a, 
+  inline void
+  random_pair_sample(size_t nrows, size_t ncols, size_t nnzpr,
+                     std::vector<std::pair<T1, T2> >& a,
                      const T2& init_nz_val,
                      int seed =-1,
                      bool sorted =true)
@@ -2262,7 +2264,7 @@ namespace nupic {
     nupic::Random rng(seed == -1 ? rand() : seed);
 #endif
 
-    std::vector<size_t> x(ncols); 
+    std::vector<size_t> x(ncols);
     for (size_t i = 0; i != ncols; ++i)
       x[i] = i;
     for (size_t i = 0; i != nrows; ++i) {
@@ -2280,23 +2282,23 @@ namespace nupic {
    * Generates a matrix of random (index,value) pairs from [0..ncols], with
    * nnzpr numbers per row, and n columns [generates a constant sparse matrix
    * with constant number of non-zeros per row]. This uses a 2D Gaussian distribution
-   * for the on bits of each coincidence. That is, each coincidence is seen as a 
+   * for the on bits of each coincidence. That is, each coincidence is seen as a
    * folded 2D array, and a 2D Gaussian is used to distribute the on bits of each
    * coincidence.
-   * 
+   *
    * Each row is seen as an image of size (ncols / rf_x) by rf_x.
-   * 'sigma' is the parameter of the Gaussian, which is centered at the center of 
+   * 'sigma' is the parameter of the Gaussian, which is centered at the center of
    * the image. Uses a symmetric Gaussian, specified only by the location of its
-   * max and a single sigma parameter (no Sigma matrix). We use the symmetry of the 
-   * 2d gaussian to simplify computations. The conditional distribution obtained 
+   * max and a single sigma parameter (no Sigma matrix). We use the symmetry of the
+   * 2d gaussian to simplify computations. The conditional distribution obtained
    * from the 2d gaussian by fixing y is again a gaussian, with parameters than can
    * be easily deduced from the original 2d gaussian.
    */
   template <typename T1, typename T2>
-  inline void 
+  inline void
   gaussian_2d_pair_sample(size_t nrows, size_t ncols, size_t nnzpr, size_t rf_x,
                           T2 sigma,
-                          std::vector<std::pair<T1, T2> >& a, 
+                          std::vector<std::pair<T1, T2> >& a,
                           const T2& init_nz_val,
                           int seed =-1,
                           bool sorted =true)
@@ -2320,7 +2322,7 @@ namespace nupic {
     Gaussian2D<float> sg2d(c_x, c_y, sigma*sigma, 0, 0, sigma*sigma);
     std::vector<float> z(ncols);
 
-    // Renormalize because we've lost some mass 
+    // Renormalize because we've lost some mass
     // with a compact domain of definition.
     float s = 0;
     for (size_t j = 0; j != ncols; ++j)
@@ -2352,7 +2354,7 @@ namespace nupic {
       for (size_t j = 0; j != nnzpr; ++j, ++it)
         a[offset + j] = std::pair<T1,T2>(*it, init_nz_val);
     }
-    
+
     /*
     for (size_t i = 0; i != counts.size(); ++i)
       std::cout << counts[i] << " ";
@@ -2521,7 +2523,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * Given a threshold and a dense vector x, returns another dense vectors with 1's 
+   * Given a threshold and a dense vector x, returns another dense vectors with 1's
    * where the value of x is > threshold, and 0 elsewhere. Also returns the count
    * of 1's.
    */
@@ -2541,7 +2543,7 @@ namespace nupic {
       if (*x > threshold) {
         *y = 1;
         ++count;
-      } else 
+      } else
         *y = 0;
 
     return count;
@@ -2555,7 +2557,7 @@ namespace nupic {
   /**
    * Given a dense 2D array of 0 and 1, return a vector that has as many rows as x
    * a 1 wherever x as a non-zero row, and a 0 elsewhere. I.e. the result is the
-   * indicator of non-zero rows. Gets fast by not scanning a row more than is 
+   * indicator of non-zero rows. Gets fast by not scanning a row more than is
    * necessary, i.e. stops as soon as a 1 is found on the row.
    */
   template <typename InputIterator, typename OutputIterator>
@@ -2574,23 +2576,23 @@ namespace nupic {
         NTA_ASSERT(x[i] == 0 || x[i] == 1);
 #endif
     }
-    
+
     for (nupic::UInt32 r = 0; r != nrows; ++r, ++y) {
-      
+
       InputIterator it = x + r * ncols, it_end = it + ncols;
       nupic::UInt32 found = 0;
 
-      while (it != it_end && found == 0) 
+      while (it != it_end && found == 0)
         found = nupic::UInt32(*it++);
-      
+
       *y = found;
     }
   }
 
   //--------------------------------------------------------------------------------
   /**
-   * Given a dense 2D array of 0 and 1, return the number of rows that have 
-   * at least one non-zero. Gets fast by not scanning a row more than is 
+   * Given a dense 2D array of 0 and 1, return the number of rows that have
+   * at least one non-zero. Gets fast by not scanning a row more than is
    * necessary, i.e. stops as soon as a 1 is found on the row.
    */
   template <typename InputIterator>
@@ -2607,17 +2609,17 @@ namespace nupic {
         NTA_ASSERT(x[i] == 0 || x[i] == 1);
 #endif
     }
-    
+
     nupic::UInt32 count = 0;
-    
+
     for (nupic::UInt32 r = 0; r != nrows; ++r) {
-      
+
       InputIterator it = x + r * ncols, it_end = it + ncols;
       nupic::UInt32 found = 0;
 
-      while (it != it_end && found == 0) 
+      while (it != it_end && found == 0)
         found = nupic::UInt32(*it++);
-      
+
       count += found;
     }
 
@@ -2628,7 +2630,7 @@ namespace nupic {
   /**
    * Given a dense 2D array of 0 and 1 x, return a vector that has as many cols as x
    * a 1 wherever x as a non-zero col, and a 0 elsewhere. I.e. the result is the
-   * indicator of non-zero cols. Gets fast by not scanning a row more than is 
+   * indicator of non-zero cols. Gets fast by not scanning a row more than is
    * necessary, i.e. stops as soon as a 1 is found on the col.
    */
   template <typename InputIterator, typename OutputIterator>
@@ -2647,11 +2649,11 @@ namespace nupic {
         NTA_ASSERT(x[i] == 0 || x[i] == 1);
 #endif
     }
-    
+
     nupic::UInt32 N = nrows*ncols;
-    
+
     for (nupic::UInt32 c = 0; c != ncols; ++c, ++y) {
-      
+
       InputIterator it = x + c, it_end = it + N;
       nupic::UInt32 found = 0;
 
@@ -2659,16 +2661,16 @@ namespace nupic {
         found = nupic::UInt32(*it);
         it += ncols;
       }
-      
+
       *y = found;
     }
   }
 
   //--------------------------------------------------------------------------------
   /**
-   * Given a dense 2D array of 0 and 1, return the number of columns that have 
+   * Given a dense 2D array of 0 and 1, return the number of columns that have
    * at least one non-zero.
-   * Gets fast by not scanning a col more than is necessary, i.e. stops as soon as 
+   * Gets fast by not scanning a col more than is necessary, i.e. stops as soon as
    * a 1 is found on the col.
    */
   template <typename InputIterator>
@@ -2685,12 +2687,12 @@ namespace nupic {
         NTA_ASSERT(x[i] == 0 || x[i] == 1);
 #endif
     }
-    
+
     nupic::UInt32 count = 0;
     nupic::UInt32 N = nrows*ncols;
-    
+
     for (nupic::UInt32 c = 0; c != ncols; ++c) {
-      
+
       InputIterator it = x + c, it_end = it + N;
       nupic::UInt32 found = 0;
 
@@ -2698,7 +2700,7 @@ namespace nupic {
         found = nupic::UInt32(*it);
         it += ncols;
       }
-      
+
       count += found;
     }
 
@@ -2980,7 +2982,7 @@ namespace nupic {
   /**
    * Euclidean norm.
    */
-  
+
   //--------------------------------------------------------------------------------
   template <typename It>
   inline typename std::iterator_traits<It>::value_type
@@ -2998,10 +3000,10 @@ namespace nupic {
 
     for (; begin != end; ++begin)
       lp2(n, *begin);
-   
+
     if (take_root)
       n = lp2.root(n);
-    
+
     return n;
   }
 
@@ -3120,7 +3122,7 @@ namespace nupic {
     else
       return lp_norm(p, begin, end, take_root);
   }
-  
+
   //--------------------------------------------------------------------------------
   /**
    */
@@ -3240,7 +3242,7 @@ namespace nupic {
   {
     normalize_max(x.begin(), x.end(), n);
   }
-  
+
   //--------------------------------------------------------------------------------
   /**
    * Fills the container with a range of values.
@@ -3755,9 +3757,9 @@ namespace nupic {
    * is probably very good for the CPU front-end.
    *
    * This is not as general as a count_gt that would be parameterized on the type
-   * of the elements in the range, and it requires passing in a Python arrays 
+   * of the elements in the range, and it requires passing in a Python arrays
    * that are .astype(float32).
-   * 
+   *
    * Doesn't work on win32.
    */
   inline nupic::UInt32
@@ -3765,14 +3767,14 @@ namespace nupic {
   {
     NTA_ASSERT(begin <= end);
 
-    // Need this, because the asm syntax is not correct for win32, 
+    // Need this, because the asm syntax is not correct for win32,
     // we simply can't compile the code as is on win32.
 
-    // Need this, because even on darwin32 (which is darwin86), some older machines might 
+    // Need this, because even on darwin32 (which is darwin86), some older machines might
     // not have the right SSE instructions.
     if (SSE_LEVEL >= 3) {
 
-      // Compute offsets into array [begin..end): 
+      // Compute offsets into array [begin..end):
       // start is the first 4 bytes aligned address (to start movaps)
       // n0 is the number of floats before we reach start and can use parallel
       //  xmm operations
@@ -3910,20 +3912,20 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * Counts the number of values greater than or equal to a given threshold in a 
+   * Counts the number of values greater than or equal to a given threshold in a
    *  given range.
    *
    * This is not as general as a count_gt that would be parameterized on the type
-   * of the elements in the range, and it requires passing in a Python arrays 
+   * of the elements in the range, and it requires passing in a Python arrays
    * that are .astype(float32).
-   * 
+   *
    */
   inline nupic::UInt32
   count_gte(nupic::Real32* begin, nupic::Real32* end, nupic::Real32 threshold)
   {
     NTA_ASSERT(begin <= end);
 
-    return std::count_if(begin, end, 
+    return std::count_if(begin, end,
                          std::bind2nd(std::greater_equal<nupic::Real32>(),
                          threshold));
   }
@@ -3955,7 +3957,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * TODO: Use SSE. Maybe requires having our own vector<bool> so that we can avoid 
+   * TODO: Use SSE. Maybe requires having our own vector<bool> so that we can avoid
    * the shenanigans with the bit references and iterators.
    */
   template <>
@@ -3977,13 +3979,13 @@ namespace nupic {
         ++count;
     return count;
   }
-  
+
   //--------------------------------------------------------------------------------
   /**
    * Counts the number of values less than a given threshold in a given range.
    */
   template <typename It>
-  inline size_t 
+  inline size_t
   count_lt(It begin, It end, const typename std::iterator_traits<It>::value_type& thres)
   {
     typedef typename std::iterator_traits<It>::value_type value_type;
@@ -4032,13 +4034,13 @@ namespace nupic {
   //--------------------------------------------------------------------------------
   /**
    * Computes the sum of the elements in a range.
-   * 
+   *
 	 * Note: a previous version used veclib on Mac's and vDSP. vDSP is much faster
 	 * than C++, even optimized by gcc, but for now this works
 	 * only with float (rather than double), and only on darwin86. With these
 	 * restrictions the speed-up is usually better than 5X over optimized C++.
 	 * vDSP also handles unaligned vectors correctly, and has good performance
-	 * also when the vectors are small, not just when they are big. 
+	 * also when the vectors are small, not just when they are big.
    */
   inline nupic::Real32 sum(nupic::Real32* begin, nupic::Real32* end)
   {
@@ -4073,7 +4075,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   template <typename T1, typename T2, typename T3>
-  inline void sum(const std::vector<T1>& a, const std::vector<T2>& b, 
+  inline void sum(const std::vector<T1>& a, const std::vector<T2>& b,
                   size_t begin, size_t end, std::vector<T3>& c)
   {
     for (size_t i = begin; i != end; ++i)
@@ -4322,7 +4324,7 @@ namespace nupic {
    * in order of increasing indices.
    */
   template <typename I, typename T>
-  inline void 
+  inline void
   multiply_val(T val, const Buffer<I>& indices, SparseVector<I,T>& x)
   {
     I n1 = indices.nnz, n2 = x.nnz, i1 = 0, i2 =0;
@@ -4947,7 +4949,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   // DENSE LOGICAL AND/OR
-  //-------------------------------------------------------------------------------- 
+  //--------------------------------------------------------------------------------
   /**
    * For each corresponding elements of x and y, put the logical and of those two
    * elements at the corresponding position in z. This is faster than the numpy
@@ -4974,7 +4976,7 @@ namespace nupic {
       NTA_ASSERT(x_end - x == z_end - z);
     }
 
-    // See comments in count_gt. We need both conditional compilation and 
+    // See comments in count_gt. We need both conditional compilation and
     // SSE_LEVEL check.
 #if !defined(NTA_OS_WINDOWS) && defined(NTA_ASM)
 
@@ -4990,13 +4992,13 @@ namespace nupic {
         n1 = 16 * (n / 16);
 
       // If we are not aligned on 4 bytes, n1 == 0, and we simply
-      // skip the asm. 
-      if (n1 > 0) { 
+      // skip the asm.
+      if (n1 > 0) {
 
   #if defined(NTA_ARCH_32)
         __asm__ __volatile__(
                      "pusha\n\t"                   // save all registers
-                 
+
                      "0:\n\t"
                      "movaps (%%esi), %%xmm0\n\t"  // move 4 floats of x to xmm0
                      "andps (%%edi), %%xmm0\n\t"   // parallel and with 4 floats of y
@@ -5011,18 +5013,18 @@ namespace nupic {
                      "movaps %%xmm1, 16(%%ecx)\n\t"// and next 4 floats
                      "movaps %%xmm2, 32(%%ecx)\n\t"// and next 4 floats
                      "movaps %%xmm3, 48(%%ecx)\n\t"// and next 4: moved 16 floats to z
-                 
+
                      "addl $64, %%esi\n\t"         // increment pointer into x by 16 floats
                      "addl $64, %%edi\n\t"         // increment pointer into y
                      "addl $64, %%ecx\n\t"         // increment pointer into z
                      "subl $16, %%edx\n\t"         // we've processed 16 floats
                      "ja 0b\n\t"                   // loop
-                 
+
                      "popa\n\t"                    // restore registers
-               
-                     : 
+
+                     :
                      : "S" (x), "D" (y), "c" (z), "d" (n1)
-                     : 
+                     :
                      );
 
   #else
@@ -5067,13 +5069,13 @@ namespace nupic {
   #endif
       }
 
-      // Finish up for stragglers in case the array length was not 
+      // Finish up for stragglers in case the array length was not
       // evenly divisible by 4
       for (int i = n1; i != n; ++i)
         *(z+i) = *(x+i) && *(y+i);
 
     } else {
-    
+
       for (; x != x_end; ++x, ++y, ++z)
         *z = (*x) && (*y);
 
@@ -5108,13 +5110,13 @@ namespace nupic {
       int n1 = 0;
       if (((long)x) % 16 == 0 && ((long)y) % 16 == 0)
         n1 = 16 * (n / 16);
-    
+
       if (n1 > 0) {
 
   #if defined(NTA_ARCH_32)
         __asm__ __volatile__(
                      "pusha\n\t"
-                 
+
                      "0:\n\t"
                      "movaps (%%esi), %%xmm0\n\t"
                      "movaps 16(%%esi), %%xmm1\n\t"
@@ -5132,14 +5134,14 @@ namespace nupic {
                      "addl $64, %%esi\n\t"
                      "addl $64, %%edi\n\t"
                      "subl $16, %%edx\n\t"
-                     "prefetch (%%esi)\n\t"                 
+                     "prefetch (%%esi)\n\t"
                      "ja 0b\n\t"
-                 
+
                      "popa\n\t"
-               
-                     : 
+
+                     :
                      : "S" (x), "D" (y), "d" (n1)
-                     : 
+                     :
                      );
 
   #else //64bit
@@ -5185,7 +5187,7 @@ namespace nupic {
         *(y+i) = *(x+i) && *(y+i);
 
     } else {
-    
+
       for (; x != x_end; ++x, ++y)
         *y = (*x) && *(y);
     }
@@ -5197,8 +5199,8 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   /**
-   * A specialization tuned for unsigned char. 
-   * TODO: keep only one code that computes the right offsets based on 
+   * A specialization tuned for unsigned char.
+   * TODO: keep only one code that computes the right offsets based on
    * the iterator value type?
    * TODO: vectorize, but watch out for alignments
    */
@@ -5233,7 +5235,7 @@ namespace nupic {
   }
 
   //--------------------------------------------------------------------------------
-  inline void 
+  inline void
   logical_or(size_t n, const ByteVector& x, const ByteVector& y, ByteVector& z)
   {
     for (size_t i = 0; i != n; ++i)
@@ -5416,7 +5418,7 @@ namespace nupic {
     typedef typename P::second_type F;
 
     typedef select1st<std::pair<I,F> > sel1st;
-    
+
     if (direction == -1) {
       std::sort(x_begin, x_end, predicate_compose<std::greater<I>, sel1st>());
     } else {
@@ -5426,7 +5428,7 @@ namespace nupic {
 
   //--------------------------------------------------------------------------------
   template <typename I, typename F>
-  inline void sort_on_first(size_t n, std::vector<std::pair<I,F> >& x, 
+  inline void sort_on_first(size_t n, std::vector<std::pair<I,F> >& x,
                             int direction =1)
   {
     sort_on_first(x.begin(), x.begin() + n, direction);
@@ -5465,7 +5467,7 @@ namespace nupic {
             typename OutputIterator,
             typename Order>
   inline void
-  partial_sort_2nd(size_type k, 
+  partial_sort_2nd(size_type k,
                    InputIterator in_begin, InputIterator in_end,
                    OutputIterator out_begin, Order)
   {
@@ -5544,20 +5546,20 @@ namespace nupic {
    * In place.
    */
   template <typename I0, typename I, typename T>
-  inline void 
+  inline void
   partial_argsort(I0 k, SparseVector<I,T>& x, int direction =-1)
   {
     {
-      NTA_ASSERT(0 < k);   
+      NTA_ASSERT(0 < k);
       NTA_ASSERT(k <= x.size());
       NTA_ASSERT(direction == -1 || direction == 1);
     }
-    
+
     typedef I size_type;
     typedef T value_type;
-    
+
     if (direction == -1) {
-      
+
       greater_2nd_no_ties<size_type, value_type> order;
       std::partial_sort(x.begin(), x.begin() + k, x.begin() + x.nnz, order);
 
@@ -5575,7 +5577,7 @@ namespace nupic {
   static SparseVector<size_t, float> partial_argsort_buffer;
 
   //--------------------------------------------------------------------------------
-  // A partial argsort that can use an already allocated buffer to avoid creating 
+  // A partial argsort that can use an already allocated buffer to avoid creating
   // a data structure each time it's called. Assumes that the elements to be sorted
   // are nupic::Real32, or at least that they have the same size.
   //
@@ -5585,7 +5587,7 @@ namespace nupic {
   // If direction is 1, the sort is in increasing order.
   //
   // The result is returned in the first k positions of the buffer for speed.
-  // 
+  //
   // Uses a pre-allocated buffer to avoid allocating memory each time a sort
   // is needed.
   //--------------------------------------------------------------------------------
@@ -5622,19 +5624,19 @@ namespace nupic {
     }
 
     partial_argsort(k, buff, direction);
-    
-    for (size_type i = 0; i != k; ++i) 
+
+    for (size_type i = 0; i != k; ++i)
       sorted[i] = buff[i].first;
   }
 
   //--------------------------------------------------------------------------------
   /**
-   * Specialized partial argsort with selective random noise for breaking ties, to 
+   * Specialized partial argsort with selective random noise for breaking ties, to
    * speed-up FDR C SP.
    */
   template <typename InIter, typename OutIter>
-  inline void 
-  partial_argsort_rnd_tie_break(size_t k, 
+  inline void
+  partial_argsort_rnd_tie_break(size_t k,
                                 InIter begin, InIter end,
                                 OutIter sorted, OutIter sorted_end,
                                 Random& rng,
@@ -5671,10 +5673,10 @@ namespace nupic {
       std::partial_sort(buff.begin(), buff.begin() + k, buff.begin() + buff.nnz, order);
     } else {
       greater_2nd_rnd_ties<size_type, value_type, Random> order(rng);
-      std::partial_sort(buff.begin(), buff.begin() + k, buff.begin() + buff.nnz, order);      
+      std::partial_sort(buff.begin(), buff.begin() + k, buff.begin() + buff.nnz, order);
     }
-    
-    for (size_type i = 0; i != k; ++i) 
+
+    for (size_type i = 0; i != k; ++i)
       sorted[i] = buff[i].first;
   }
 
@@ -5682,14 +5684,14 @@ namespace nupic {
   // QUANTIZE
   //--------------------------------------------------------------------------------
   template <typename It1>
-  inline void 
+  inline void
   update_with_indices_of_non_zeros(nupic::UInt32 segment_size,
                                    It1 input_begin, It1 input_end,
-                                   It1 prev_begin, It1 prev_end, 
+                                   It1 prev_begin, It1 prev_end,
                                    It1 curr_begin, It1 curr_end)
   {
     typedef nupic::UInt32 size_type;
-    
+
     size_type input_size = (size_type)(input_end - input_begin);
 
     std::fill(curr_begin, curr_end, 0);
@@ -5711,7 +5713,7 @@ namespace nupic {
         }
       }
 
-      if (all_zero) 
+      if (all_zero)
         std::fill(curr_begin + begin, curr_begin + end, 1);
     }
   }
@@ -5863,33 +5865,33 @@ namespace nupic {
   // Dendritic tree activation
   //
   // Given a window size, a threshold, an array of indices and a vector of values,
-  // scans the vector of values with a sliding window on each row of the array of 
-  // indices, and as soon as the activation in one window is above the threshold, 
+  // scans the vector of values with a sliding window on each row of the array of
+  // indices, and as soon as the activation in one window is above the threshold,
   // declare that the corresponding line of the array of indices has "fired". Real
   // dendrites branch, but we are not modelling that here. Learning of the synapses,
   // i.e. populating the list of indices for each neuron, is not done here. Here,
-  // we just compute which neurons fire in a collection of neurons, given the 
-  // synaspes on the dendrites for each neuron. 
+  // we just compute which neurons fire in a collection of neurons, given the
+  // synaspes on the dendrites for each neuron.
   //
   // The array of indices represents multiple neurons, one per row, and each row
   // represents multiple segments of the dendritic tree of each neuron. However,
   // the indices are not contiguous (a dendritic segment looks at random positions
   // in its input vector). As soon as the activation in any window in any segment
   // of the dendritic tree reaches the threshold, the neuron fires. Indices are added
-  // to the list of indices for a given neuron in a specific order, tying position to 
+  // to the list of indices for a given neuron in a specific order, tying position to
   // to time of activation of the synapses: the farther away the synapses, the earlier
-  // the signal was. 
+  // the signal was.
   //
   // ncells and max_dendrite_size are the number of rows and columns, respectively,
   // of the indices matrix. If ncells is 10,000, max_dendrite_size would be,
   // typically, 100, meaning that a given neuron has synapses in its dendritic
   // tree with at most 100 other neurons. Those synapses are learnt, so during
   // learning, there are actually less than 100 synapses in the dendritic tree.
-  // 
+  //
   // window_size is the size of the sliding window, i.e. the number of indices
-  // we use to sum up activation in dendritic neighborhood. In biology, activation 
-  // might be "superlinear" for synapses further down the dendrite. 
-  // 
+  // we use to sum up activation in dendritic neighborhood. In biology, activation
+  // might be "superlinear" for synapses further down the dendrite.
+  //
   // threshold is the value which, if reached in any given dendritic neighborhood,
   // triggers activation of the neuron.
   //
@@ -5900,7 +5902,7 @@ namespace nupic {
   // neuron. If ncells is 10,000, the values of the indices range from 0 to 9,999.
   //
   // input and input_end are a pointer to the vector of input, and one past the end
-  // of that vector. That vector is of size ncells. The inputs are real valued. 
+  // of that vector. That vector is of size ncells. The inputs are real valued.
   //
   // output and output_end are a pointer to the vector of output, and one past the
   // end of that vector. That vector is of size ncells. That vector contains either
@@ -5911,7 +5913,7 @@ namespace nupic {
   //--------------------------------------------------------------------------------
   /*
   template <typename I, typename S, typename T>
-  inline void 
+  inline void
   dendritic_activation(S nsegs, S max_dendrite_size,
                        S window_size, T threshold,
                        S* indices, S* indices_end,
@@ -5939,21 +5941,21 @@ namespace nupic {
         NTA_ASSERT(n_indices[c] == 0 || window_size <= n_indices[c]);
 #endif
     } // End pre-conditions
-    
+
     for (size_type seg = 0; seg != nsegs; ++seg) {
 
       output[seg] = (int) -1;
-    
-      if (n_indices[seg] == 0) 
+
+      if (n_indices[seg] == 0)
         continue;
 
       // w_end is how far we can move the window down the dendritic segment
       value_type activation = 0;
       size_type seg_start = seg*max_dendrite_size;
-    
-      for (size_type i = 0; i != window_size; ++i) 
+
+      for (size_type i = 0; i != window_size; ++i)
         activation += input[indices[seg_start + i]];
-    
+
       if (activation >= threshold) {
 
         output[seg] = (int) 0;
@@ -5985,28 +5987,28 @@ namespace nupic {
        // }
 
        // size_type w_end = n_indices[cell] - window_size + 1;
-      
+
        // for (size_type w_start = 0; w_start < w_end; ++w_start) {
-        
+
        // size_type w_end1 = w_start + window_size;
        // value_type activation = 0;
-        
+
        // // Maintain activation with +/-
-       // for (size_type i = w_start; i < w_end1; ++i) 
-       // activation += input[indices[cell*max_dendrite_size+i]];        
-        
+       // for (size_type i = w_start; i < w_end1; ++i)
+       // activation += input[indices[cell*max_dendrite_size+i]];
+
        // if (activation >= threshold) {
        // *output = (int) w_start;
        // break;
        // }
-        
+
        // *output = (int) -1;
        // }
        // }
-    
+
   }
 */
-  
+
   //--------------------------------------------------------------------------------
 } // end namespace nupic
 


### PR DESCRIPTION
CC @scottpurdy 

Fixes #1025

NOTES: 
1. The manylinux wheel generated by this PR passes all [nupic tests](https://github.com/numenta/nupic/tree/master/tests) on Ubuntu 14.04, but hangs some of the tests that use capnp serialization in the nupic.bindings extension on Ubuntu 16.04 as described on https://mail.python.org/pipermail/wheel-builders/2016-July/000199.html.
 1.1 The hang will be addressed by a separate PR per issue #1013
2. Contains several other useful fixes for issues that I encountered along the way that blocked progress of this PR (see commit notes for details).


This proof-of-concept enables a build of a nupic.bindings manylinux wheel by executing 
```[sudo] ci/bamboo/bootstrap-manylinux-prototype.sh```
from the root of the nupic.core repo. After the command completes, the generated wheel may be found in `bindings/py/dist/` having a name like `nupic.bindings-0.4.5.dev0-cp27-cp27mu-linux_x86_64.whl`.

This build makes use of numenta's custom manylinux docker image based on centos6 (versus centos5 of the stock manylinux docker image) that provides the necessary system headers for building capnp lib, which uses signalfd, pipe2, etc. that are not part of centos5. See https://github.com/numenta/manylinux/pull/1.

