### PR TITLE
DEVOPS-84 Fixup os x build

### DIFF
--- a/ci/bamboo/build-osx.sh
+++ b/ci/bamboo/build-osx.sh
@@ -2,13 +2,17 @@
 set -o errexit
 set -o xtrace
 
+# Fixup $PATH for --user installation
+export PATH=${HOME}/Library/Python/2.7/bin:${PATH}
+
 # Install pip
-python ci/bamboo/get-pip.py
+python ci/bamboo/get-pip.py --user --ignore-installed
 
 # Install python dependencies w/ pip
 pip install \
     --upgrade \
     --ignore-installed \
+    --user \
     --cache-dir /shared/pip-cache \
     --build /shared/pip-build \
     --no-clean \


### PR DESCRIPTION
This fixes the path so that the pip and py.test commands are in PATH.