### PR TITLE
Re-add columnForCell to the SWIG bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Important notes:
 The Python dependencies (NumPy and pycapnp) can be installed with `pip`:
 
     pip install -r bindings/py/requirements.txt
+    pip install pycapnp==0.5.8
 
 ### Simple Source Installation (does not support incremental builds)
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1773,7 +1773,6 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::getWinnerCells;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::getMatchingCells;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::cellsForColumn;
-%ignore nupic::algorithms::temporal_memory::TemporalMemory::columnForCell;
 
 
 %include <nupic/algorithms/TemporalMemory.hpp>

--- a/src/nupic/bindings/experimental.i
+++ b/src/nupic/bindings/experimental.i
@@ -262,6 +262,5 @@ using namespace nupic;
 %ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getWinnerCells;
 %ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::getMatchingCells;
 %ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::cellsForColumn;
-%ignore nupic::experimental::extended_temporal_memory::ExtendedTemporalMemory::columnForCell;
 
 %include <nupic/experimental/ExtendedTemporalMemory.hpp>


### PR DESCRIPTION
The default SWIG implementation of columnForCell is now good enough. When I removed the custom implementation, I forgot to remove the %ignore directive.

Fixes #1011 