### PR TITLE
Add apical dendrites to ExtendedTemporalMemory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -537,6 +537,7 @@ add_executable(${src_executable_gtests}
                test/unit/types/ExceptionTest.cpp
                test/unit/types/FractionTest.cpp
                test/unit/UnitTestMain.cpp
+               test/unit/utils/GroupByTest.cpp
                test/unit/utils/MovingAverageTest.cpp
                test/unit/utils/RandomTest.cpp
                test/unit/utils/WatcherTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -498,6 +498,7 @@ add_executable(${src_executable_gtests}
                test/unit/engine/NetworkFactoryTest.cpp
                test/unit/engine/UniformLinkPolicyTest.cpp
                test/unit/engine/YAMLUtilsTest.cpp
+               test/unit/experimental/ExtendedTemporalMemoryTest.cpp
                test/unit/math/DenseTensorUnitTest.cpp
                test/unit/math/DomainUnitTest.cpp
                test/unit/math/IndexUnitTest.cpp

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -860,7 +860,7 @@ static void learnOnCell(
                  prevActiveCells, externalCandidates,
                  permanenceIncrement, permanenceDecrement);
 
-    const UInt32 nGrowDesired = maxNewSynapseCount - bestMatching.overlap;
+    const Int32 nGrowDesired = maxNewSynapseCount - bestMatching.overlap;
     if (nGrowDesired > 0)
     {
       growSynapses(connections, rng,

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -1284,13 +1284,17 @@ vector<CellIdx> ExtendedTemporalMemory::getPredictiveCells() const
 {
   vector<CellIdx> predictiveCells;
 
+  // Workaround: on mingwpy Release builds, passing in "{}" to ExcitedColumns
+  // constructor leads to a segfault.
+  vector<UInt> columnsNone = {};
+
   // Use ExcitedColumns to group segments by column and cell. Don't trust the
   // ExcitedColumnData's "isActiveColumn", since we're not providing it the
   // active columns.
   for (const ExcitedColumnData& excitedColumn :
-         ExcitedColumns({}, activeBasalSegments_, matchingBasalSegments_,
-                        activeApicalSegments_, matchingApicalSegments_,
-                        cellsPerColumn_))
+         ExcitedColumns(columnsNone, activeBasalSegments_,
+                        matchingBasalSegments_, activeApicalSegments_,
+                        matchingApicalSegments_, cellsPerColumn_))
   {
     UInt32 maxDepolarization = 0;
     for (const DepolarizedCellData& c : DepolarizedCells(excitedColumn))

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -505,6 +505,6 @@ namespace nupic {
 
     } // end namespace extended_temporal_memory
   } // end namespace algorithms
-} // end namespace nta
+} // end namespace nupic
 
 #endif // NTA_EXTENDED_TEMPORAL_MEMORY_HPP

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -119,7 +119,7 @@ namespace nupic {
           Permanence permanenceIncrement = 0.10,
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
-          bool formInternalConnections = true,
+          bool formInternalBasalConnections = true,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
           UInt maxSynapsesPerSegment=255);
@@ -135,7 +135,7 @@ namespace nupic {
           Permanence permanenceIncrement = 0.10,
           Permanence permanenceDecrement = 0.10,
           Permanence predictedSegmentDecrement = 0.0,
-          bool formInternalConnections = true,
+          bool formInternalBasalConnections = true,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
           UInt maxSynapsesPerSegment=255);
@@ -184,11 +184,13 @@ namespace nupic {
          */
         void activateCells(
           const vector<UInt>& activeColumns,
-          const vector<CellIdx>& prevActiveExternalCells,
-          bool learn = true);
+          const vector<CellIdx>& prevActiveExternalCellsBasal,
+          const vector<CellIdx>& prevActiveExternalCellsApical,
+          bool learn);
 
         /**
-         * Calculate dendrite segment activity, using the current active cells.
+         * Calculate basal dendrite segment activity, using the current active
+         * cells.
          *
          * @param activeExternalCells
          * Active external cells that should be used for activating dendrites in
@@ -198,9 +200,37 @@ namespace nupic {
          * If true, segment activations will be recorded. This information is
          * used during segment cleanup.
          */
-        void activateDendrites(
+        void activateBasalDendrites(
           const vector<CellIdx>& activeExternalCells,
           bool learn = true);
+
+        /**
+         * Calculate apical dendrite segment activity, using the current active
+         * cells.
+         *
+         * @param activeExternalCells
+         * Active external cells that should be used for activating dendrites in
+         * this timestep.
+         *
+         * @param learn
+         * If true, segment activations will be recorded. This information is
+         * used during segment cleanup.
+         */
+        void activateApicalDendrites(
+          const vector<CellIdx>& activeExternalCells,
+          bool learn = true);
+
+        /**
+         * For backward-compatibility with TemporalMemory unit tests.
+         *
+         * Feeds input record through TM, performing inference and learning.
+         *
+         * @param activeColumnsSize Number of active columns
+         * @param activeColumns     Indices of active columns
+         * @param learn             Whether or not learning is enabled
+         */
+        virtual void compute(
+          UInt activeColumnsSize, const UInt activeColumns[], bool learn = true);
 
         /**
          * Feeds input record through TM, performing inference and learning.
@@ -208,25 +238,36 @@ namespace nupic {
          * @param activeColumnsUnsorted
          * A list of active column indices.
          *
-         * @param prevActiveExternalCells
-         * The external cells that were used to calculate the current segment
-         * excitation. This class doesn't save a copy of these cells because the
-         * caller is more flexible to find ways of keeping this list available
-         * without extra copying.
+         * @param prevActiveExternalCellsBasal
+         * The external cells that were used to calculate the current basal
+         * segment excitation. This class doesn't save a copy of these cells
+         * because the caller is more flexible to find ways of keeping this list
+         * available without extra copying.
          *
-         * @param activeExternalCells
-         * Active external cells that should be used for activating dendrites in
-         * this timestep.
+         * @param activeExternalCellsBasal
+         * Active external cells that should be used for activating basal
+         * dendrites in this timestep.
+         *
+         * @param prevActiveExternalCellsApical
+         * The external cells that were used to calculate the current apical
+         * segment excitation. This class doesn't save a copy of these cells
+         * because the caller is more flexible to find ways of keeping this list
+         * available without extra copying.
+         *
+         * @param activeExternalCellsApical
+         * Active external cells that should be used for activating apical
+         * dendrites in this timestep.
          *
          * @param learn
          * Whether or not learning is enabled
          */
         virtual void compute(
           const vector<UInt>& activeColumnsUnsorted,
-          const vector<CellIdx>& prevActiveExternalCells,
-          const vector<CellIdx>& activeExternalCells,
+          const vector<CellIdx>& prevActiveExternalCellsBasal,
+          const vector<CellIdx>& activeExternalCellsBasal,
+          const vector<CellIdx>& prevActiveExternalCellsApical,
+          const vector<CellIdx>& activeExternalCellsApical,
           bool learn = true);
-
 
         // ==============================
         //  Helper functions
@@ -269,15 +310,10 @@ namespace nupic {
         */
         vector<CellIdx> getWinnerCells() const;
 
-        /**
-        * Returns the indices of the matching cells.
-        *
-        * @returns (std::vector<CellIdx>) Vector of indices of matching cells.
-        */
-        vector<CellIdx> getMatchingCells() const;
-
-        vector<Segment> getActiveSegments() const;
-        vector<Segment> getMatchingSegments() const;
+        vector<Segment> getActiveBasalSegments() const;
+        vector<Segment> getMatchingBasalSegments() const;
+        vector<Segment> getActiveApicalSegments() const;
+        vector<Segment> getMatchingApicalSegments() const;
 
         /**
          * Returns the dimensions of the columns in the region.
@@ -343,10 +379,10 @@ namespace nupic {
         /**
          * Returns whether to form internal connections between cells.
          *
-         * @returns the formInternalConnections parameter
+         * @returns the formInternalBasalConnections parameter
          */
-        bool getFormInternalConnections() const;
-        void setFormInternalConnections(bool formInternalConnections);
+        bool getFormInternalBasalConnections() const;
+        void setFormInternalBasalConnections(bool formInternalBasalConnections);
 
         /**
          * Returns the permanence increment.
@@ -446,7 +482,7 @@ namespace nupic {
         UInt activationThreshold_;
         UInt minThreshold_;
         UInt maxNewSynapseCount_;
-        bool formInternalConnections_;
+        bool formInternalBasalConnections_;
         Permanence initialPermanence_;
         Permanence connectedPermanence_;
         Permanence permanenceIncrement_;
@@ -455,13 +491,16 @@ namespace nupic {
 
         vector<CellIdx> activeCells_;
         vector<CellIdx> winnerCells_;
-        vector<SegmentOverlap> activeSegments_;
-        vector<SegmentOverlap> matchingSegments_;
+        vector<SegmentOverlap> activeBasalSegments_;
+        vector<SegmentOverlap> matchingBasalSegments_;
+        vector<SegmentOverlap> activeApicalSegments_;
+        vector<SegmentOverlap> matchingApicalSegments_;
 
         Random rng_;
 
       public:
-        Connections connections;
+        Connections basalConnections;
+        Connections apicalConnections;
       };
 
     } // end namespace extended_temporal_memory

--- a/src/nupic/proto/ExtendedTemporalMemoryProto.capnp
+++ b/src/nupic/proto/ExtendedTemporalMemoryProto.capnp
@@ -18,28 +18,19 @@ struct ExtendedTemporalMemoryProto {
   maxNewSynapseCount @7 :UInt32;
   permanenceIncrement @8 :Float32;
   permanenceDecrement @9 :Float32;
+  formInternalBasalConnections @10 :Bool;
 
-  connections @10 :ConnectionsProto;
-  random @11 :RandomProto;
+  basalConnections @11 :ConnectionsProto;
+  apicalConnections @12 :ConnectionsProto;
+  random @13 :RandomProto;
 
   # Lists of indices
-  activeCells @12 :List(UInt32);
-
-  # Obsolete, information contained in activeSegmentOverlaps
-  predictiveCells @13 :List(UInt32);
-
-  # Obsolete, replaced by activeSegmentOverlaps
-  activeSegments @14 :List(UInt32);
-
+  activeCells @14 :List(UInt32);
   winnerCells @15 :List(UInt32);
 
-  # Obsolete, replaced by matchingSegmentOverlaps
-  matchingSegments @16 :List(UInt32);
-
-  # Obsolete, information contained in matchingSegmentOverlaps
-  matchingCells @17 :List(UInt32);
-
-  predictedSegmentDecrement @18 :Float32;
-  activeSegmentOverlaps @19 :List(SegmentOverlapProto);
-  matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
+  predictedSegmentDecrement @16 :Float32;
+  activeBasalSegmentOverlaps @17 :List(SegmentOverlapProto);
+  matchingBasalSegmentOverlaps @18 :List(SegmentOverlapProto);
+  activeApicalSegmentOverlaps @19 :List(SegmentOverlapProto);
+  matchingApicalSegmentOverlaps @20 :List(SegmentOverlapProto);
 }

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -29,7 +29,8 @@
 
 // GCC warns that `key` might be uninitialized in the `calculateNext_` methods.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
 namespace nupic
 {

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -1,0 +1,1241 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+#include <tuple>
+
+#include <nupic/utils/Log.hpp>
+
+namespace nupic
+{
+  /** @file
+   * Implements a group_by function.
+   *
+   * This is modeled after Python's itertools.groupby, but with the added
+   * ability to traverse multiple sequences. Similar to Python, it requires the
+   * input to be sorted according to the supplied key functions.
+   *
+   * There are two functions:
+   *
+   * - `group_by`, which takes in collections
+   * - `iter_group_by`, which takes in pairs of iterators
+   *
+   * Both functions take a key function for each sequence.
+   *
+   * These functions return an iterable object. The iterator returns a tuple
+   * containing the group_by key, followed by a begin and end iterator for each
+   * sequence. The sequences are traversed lazily as the iterator is advanced.
+   *
+   * Feel free to add new GroupBy7, GroupBy8, ..., GroupByN classes as needed.
+   */
+
+  // ==========================================================================
+  // 1 SEQUENCE
+  // ==========================================================================
+
+ template<typename Iterator0, typename KeyFn0,
+           typename Element0 = decltype(*std::declval<Iterator0>()),
+           typename KeyType = typename std::result_of<
+             KeyFn0(decltype(*std::declval<Iterator0>()))
+             >::type>
+  class GroupBy1
+  {
+  public:
+
+    GroupBy1(
+      Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0)
+    : begin0_(begin0), end0_(end0), keyFn0_(keyFn0)
+    {
+      NTA_ASSERT(std::is_sorted(begin0, end0,
+                                [&](const Element0& a, const Element0& b)
+                                {
+                                  return keyFn0(a) < keyFn0(b);
+                                }));
+    }
+
+    class Iterator
+    {
+    public:
+      Iterator(
+        Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0)
+        :current0_(begin0), end0_(end0), keyFn0_(keyFn0),
+         finished_(false)
+      {
+        calculateNext_();
+      }
+
+      bool operator !=(const Iterator& other)
+      {
+        return (finished_ != other.finished_ ||
+                current0_ != other.current0_);
+      }
+
+      const std::tuple<KeyType,
+                       Iterator0, Iterator0>& operator*() const
+      {
+        NTA_ASSERT(!finished_);
+        return v_;
+      }
+
+      const Iterator& operator++()
+      {
+        NTA_ASSERT(!finished_);
+        calculateNext_();
+        return *this;
+      }
+
+    private:
+
+      void calculateNext_()
+      {
+        if (current0_ != end0_)
+        {
+          KeyType key = keyFn0_(*current0_);
+          std::get<0>(v_) = key;
+
+          // Find all elements with this key.
+          std::get<1>(v_) = current0_;
+          while (current0_ != end0_ && keyFn0_(*current0_) == key)
+          {
+            current0_++;
+          }
+          std::get<2>(v_) = current0_;
+        }
+        else
+        {
+          finished_ = true;
+        }
+      }
+
+      std::tuple<KeyType,
+                 Iterator0, Iterator0> v_;
+
+      Iterator0 current0_;
+      Iterator0 end0_;
+      KeyFn0 keyFn0_;
+
+      bool finished_;
+    };
+
+    Iterator begin() const
+    {
+      return Iterator(begin0_, end0_, keyFn0_);
+    }
+
+    Iterator end() const
+    {
+      return Iterator(end0_, end0_, keyFn0_);
+    }
+
+  private:
+    Iterator0 begin0_;
+    Iterator0 end0_;
+    KeyFn0 keyFn0_;
+  };
+
+  template<typename Sequence0, typename KeyFn0>
+  GroupBy1<typename Sequence0::const_iterator, KeyFn0>
+  group_by(const Sequence0& sequence0, KeyFn0 keyFn0)
+  {
+    return {sequence0.begin(), sequence0.end(), keyFn0};
+  }
+
+  template<typename Iterator0, typename KeyFn0>
+  GroupBy1<Iterator0, KeyFn0>
+  iter_group_by(Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0)
+  {
+    return {begin0, end0, keyFn0};
+  }
+
+
+  // ==========================================================================
+  // 2 SEQUENCES
+  // ==========================================================================
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Element0 = decltype(*std::declval<Iterator0>()),
+           typename Element1 = decltype(*std::declval<Iterator1>()),
+           typename KeyType = typename std::result_of<
+             KeyFn0(decltype(*std::declval<Iterator0>()))
+             >::type>
+  class GroupBy2
+  {
+  public:
+
+    GroupBy2(
+      Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+      Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1)
+    : begin0_(begin0), end0_(end0), keyFn0_(keyFn0),
+      begin1_(begin1), end1_(end1), keyFn1_(keyFn1)
+    {
+      NTA_ASSERT(std::is_sorted(begin0, end0,
+                                [&](const Element0& a, const Element0& b)
+                                {
+                                  return keyFn0(a) < keyFn0(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin1, end1,
+                                [&](const Element1& a, const Element1& b)
+                                {
+                                  return keyFn1(a) < keyFn1(b);
+                                }));
+    }
+
+    class Iterator
+    {
+    public:
+      Iterator(
+        Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+        Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1)
+        :current0_(begin0), end0_(end0), keyFn0_(keyFn0),
+         current1_(begin1), end1_(end1), keyFn1_(keyFn1),
+         finished_(false)
+      {
+        calculateNext_();
+      }
+
+      bool operator !=(const Iterator& other)
+      {
+        return (finished_ != other.finished_ ||
+                current0_ != other.current0_ ||
+                current1_ != other.current1_);
+      }
+
+      const std::tuple<KeyType,
+                       Iterator0, Iterator0,
+                       Iterator1, Iterator1>& operator*() const
+      {
+        NTA_ASSERT(!finished_);
+        return v_;
+      }
+
+      const Iterator& operator++()
+      {
+        NTA_ASSERT(!finished_);
+        calculateNext_();
+        return *this;
+      }
+
+    private:
+
+      void calculateNext_()
+      {
+        if (current0_ != end0_ ||
+            current1_ != end1_)
+        {
+          // Find the lowest key.
+          KeyType key;
+          bool found = false;
+
+          if (current0_ != end0_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn0_(*current0_));
+            }
+            else
+            {
+              key = keyFn0_(*current0_);
+              found = true;
+            }
+          }
+
+          if (current1_ != end1_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn1_(*current1_));
+            }
+            else
+            {
+              key = keyFn1_(*current1_);
+              found = true;
+            }
+          }
+
+          NTA_ASSERT(found);
+          std::get<0>(v_) = key;
+
+          // Find all elements with this key.
+          std::get<1>(v_) = current0_;
+          while (current0_ != end0_ && keyFn0_(*current0_) == key)
+          {
+            current0_++;
+          }
+          std::get<2>(v_) = current0_;
+
+          std::get<3>(v_) = current1_;
+          while (current1_ != end1_ && keyFn1_(*current1_) == key)
+          {
+            current1_++;
+          }
+          std::get<4>(v_) = current1_;
+        }
+        else
+        {
+          finished_ = true;
+        }
+      }
+
+      std::tuple<KeyType,
+                 Iterator0, Iterator0,
+                 Iterator1, Iterator1> v_;
+
+      Iterator0 current0_;
+      Iterator0 end0_;
+      KeyFn0 keyFn0_;
+
+      Iterator1 current1_;
+      Iterator1 end1_;
+      KeyFn1 keyFn1_;
+
+      bool finished_;
+    };
+
+    Iterator begin() const
+    {
+      return Iterator(begin0_, end0_, keyFn0_,
+                      begin1_, end1_, keyFn1_);
+    }
+
+    Iterator end() const
+    {
+      return Iterator(end0_, end0_, keyFn0_,
+                      end1_, end1_, keyFn1_);
+    }
+
+  private:
+    Iterator0 begin0_;
+    Iterator0 end0_;
+    KeyFn0 keyFn0_;
+
+    Iterator1 begin1_;
+    Iterator1 end1_;
+    KeyFn1 keyFn1_;
+  };
+
+  template<typename Sequence0, typename KeyFn0,
+           typename Sequence1, typename KeyFn1>
+  GroupBy2<typename Sequence0::const_iterator, KeyFn0,
+           typename Sequence1::const_iterator, KeyFn1>
+  group_by(const Sequence0& sequence0, KeyFn0 keyFn0,
+           const Sequence1& sequence1, KeyFn1 keyFn1)
+  {
+    return {sequence0.begin(), sequence0.end(), keyFn0,
+            sequence1.begin(), sequence1.end(), keyFn1};
+  }
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1>
+  GroupBy2<Iterator0, KeyFn0,
+           Iterator1, KeyFn1>
+  iter_group_by(Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+                Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1)
+  {
+    return {begin0, end0, keyFn0,
+            begin1, end1, keyFn1};
+  }
+
+  // ==========================================================================
+  // 3 SEQUENCES
+  // ==========================================================================
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2,
+           typename Element0 = decltype(*std::declval<Iterator0>()),
+           typename Element1 = decltype(*std::declval<Iterator1>()),
+           typename Element2 = decltype(*std::declval<Iterator2>()),
+           typename KeyType = typename std::result_of<
+             KeyFn0(decltype(*std::declval<Iterator0>()))
+             >::type>
+  class GroupBy3
+  {
+  public:
+    GroupBy3(
+      Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+      Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+      Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2)
+    : begin0_(begin0), end0_(end0), keyFn0_(keyFn0),
+      begin1_(begin1), end1_(end1), keyFn1_(keyFn1),
+      begin2_(begin2), end2_(end2), keyFn2_(keyFn2)
+    {
+      NTA_ASSERT(std::is_sorted(begin0, end0,
+                                [&](const Element0& a, const Element0& b)
+                                {
+                                  return keyFn0(a) < keyFn0(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin1, end1,
+                                [&](const Element1& a, const Element1& b)
+                                {
+                                  return keyFn1(a) < keyFn1(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin2, end2,
+                                [&](const Element2& a, const Element2& b)
+                                {
+                                  return keyFn2(a) < keyFn2(b);
+                                }));
+    }
+
+    class Iterator
+    {
+    public:
+      Iterator(
+        Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+        Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+        Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2)
+        :current0_(begin0), end0_(end0), keyFn0_(keyFn0),
+         current1_(begin1), end1_(end1), keyFn1_(keyFn1),
+         current2_(begin2), end2_(end2), keyFn2_(keyFn2),
+         finished_(false)
+      {
+        calculateNext_();
+      }
+
+      bool operator !=(const Iterator& other)
+      {
+        return (finished_ != other.finished_ ||
+                current0_ != other.current0_ ||
+                current1_ != other.current1_ ||
+                current2_ != other.current2_);
+      }
+
+      const std::tuple<KeyType,
+                       Iterator0, Iterator0,
+                       Iterator1, Iterator1,
+                       Iterator2, Iterator2>& operator*() const
+      {
+        NTA_ASSERT(!finished_);
+        return v_;
+      }
+
+      const Iterator& operator++()
+      {
+        NTA_ASSERT(!finished_);
+        calculateNext_();
+        return *this;
+      }
+
+    private:
+
+      void calculateNext_()
+      {
+        if (current0_ != end0_ ||
+            current1_ != end1_ ||
+            current2_ != end2_)
+        {
+          // Find the lowest key.
+          KeyType key;
+          bool found = false;
+
+          if (current0_ != end0_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn0_(*current0_));
+            }
+            else
+            {
+              key = keyFn0_(*current0_);
+              found = true;
+            }
+          }
+
+          if (current1_ != end1_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn1_(*current1_));
+            }
+            else
+            {
+              key = keyFn1_(*current1_);
+              found = true;
+            }
+          }
+
+          if (current2_ != end2_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn2_(*current2_));
+            }
+            else
+            {
+              key = keyFn2_(*current2_);
+              found = true;
+            }
+          }
+
+          NTA_ASSERT(found);
+          std::get<0>(v_) = key;
+
+          // Find all elements with this key.
+          std::get<1>(v_) = current0_;
+          while (current0_ != end0_ && keyFn0_(*current0_) == key)
+          {
+            current0_++;
+          }
+          std::get<2>(v_) = current0_;
+
+          std::get<3>(v_) = current1_;
+          while (current1_ != end1_ && keyFn1_(*current1_) == key)
+          {
+            current1_++;
+          }
+          std::get<4>(v_) = current1_;
+
+          std::get<5>(v_) = current2_;
+          while (current2_ != end2_ && keyFn2_(*current2_) == key)
+          {
+            current2_++;
+          }
+          std::get<6>(v_) = current2_;
+        }
+        else
+        {
+          finished_ = true;
+        }
+      }
+
+      std::tuple<KeyType,
+                 Iterator0, Iterator0,
+                 Iterator1, Iterator1,
+                 Iterator2, Iterator2> v_;
+
+      Iterator0 current0_;
+      Iterator0 end0_;
+      KeyFn0 keyFn0_;
+
+      Iterator1 current1_;
+      Iterator1 end1_;
+      KeyFn1 keyFn1_;
+
+      Iterator2 current2_;
+      Iterator2 end2_;
+      KeyFn2 keyFn2_;
+
+      bool finished_;
+    };
+
+    Iterator begin() const
+    {
+      return Iterator(begin0_, end0_, keyFn0_,
+                      begin1_, end1_, keyFn1_,
+                      begin2_, end2_, keyFn2_);
+    }
+
+    Iterator end() const
+    {
+      return Iterator(end0_, end0_, keyFn0_,
+                      end1_, end1_, keyFn1_,
+                      end2_, end2_, keyFn2_);
+    }
+
+  private:
+    Iterator0 begin0_;
+    Iterator0 end0_;
+    KeyFn0 keyFn0_;
+
+    Iterator1 begin1_;
+    Iterator1 end1_;
+    KeyFn1 keyFn1_;
+
+    Iterator2 begin2_;
+    Iterator2 end2_;
+    KeyFn2 keyFn2_;
+  };
+
+  template<typename Sequence0, typename KeyFn0,
+           typename Sequence1, typename KeyFn1,
+           typename Sequence2, typename KeyFn2>
+  GroupBy3<typename Sequence0::const_iterator, KeyFn0,
+           typename Sequence1::const_iterator, KeyFn1,
+           typename Sequence2::const_iterator, KeyFn2>
+  group_by(const Sequence0& sequence0, KeyFn0 keyFn0,
+           const Sequence1& sequence1, KeyFn1 keyFn1,
+           const Sequence2& sequence2, KeyFn2 keyFn2)
+  {
+    return {sequence0.begin(), sequence0.end(), keyFn0,
+            sequence1.begin(), sequence1.end(), keyFn1,
+            sequence2.begin(), sequence2.end(), keyFn2};
+  }
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2>
+  GroupBy3<Iterator0, KeyFn0,
+           Iterator1, KeyFn1,
+           Iterator2, KeyFn2>
+  iter_group_by(
+    Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+    Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+    Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2)
+  {
+    return {begin0, end0, keyFn0,
+            begin1, end1, keyFn1,
+            begin2, end2, keyFn2};
+  }
+
+
+  // ==========================================================================
+  // 4 SEQUENCES
+  // ==========================================================================
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2,
+           typename Iterator3, typename KeyFn3,
+           typename Element0 = decltype(*std::declval<Iterator0>()),
+           typename Element1 = decltype(*std::declval<Iterator1>()),
+           typename Element2 = decltype(*std::declval<Iterator2>()),
+           typename Element3 = decltype(*std::declval<Iterator3>()),
+           typename KeyType = typename std::result_of<
+             KeyFn0(decltype(*std::declval<Iterator0>()))
+             >::type>
+  class GroupBy4
+  {
+  public:
+    GroupBy4(
+      Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+      Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+      Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+      Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3)
+    : begin0_(begin0), end0_(end0), keyFn0_(keyFn0),
+      begin1_(begin1), end1_(end1), keyFn1_(keyFn1),
+      begin2_(begin2), end2_(end2), keyFn2_(keyFn2),
+      begin3_(begin3), end3_(end3), keyFn3_(keyFn3)
+    {
+      NTA_ASSERT(std::is_sorted(begin0, end0,
+                                [&](const Element0& a, const Element0& b)
+                                {
+                                  return keyFn0(a) < keyFn0(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin1, end1,
+                                [&](const Element1& a, const Element1& b)
+                                {
+                                  return keyFn1(a) < keyFn1(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin2, end2,
+                                [&](const Element2& a, const Element2& b)
+                                {
+                                  return keyFn2(a) < keyFn2(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin3, end3,
+                                [&](const Element3& a, const Element3& b)
+                                {
+                                  return keyFn3(a) < keyFn3(b);
+                                }));
+    }
+
+    class Iterator
+    {
+    public:
+      Iterator(
+        Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+        Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+        Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+        Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3)
+        :current0_(begin0), end0_(end0), keyFn0_(keyFn0),
+         current1_(begin1), end1_(end1), keyFn1_(keyFn1),
+         current2_(begin2), end2_(end2), keyFn2_(keyFn2),
+         current3_(begin3), end3_(end3), keyFn3_(keyFn3),
+         finished_(false)
+      {
+        calculateNext_();
+      }
+
+      bool operator !=(const Iterator& other)
+      {
+        return (finished_ != other.finished_ ||
+                current0_ != other.current0_ ||
+                current1_ != other.current1_ ||
+                current2_ != other.current2_ ||
+                current3_ != other.current3_);
+      }
+
+      const std::tuple<KeyType,
+                       Iterator0, Iterator0,
+                       Iterator1, Iterator1,
+                       Iterator2, Iterator2,
+                       Iterator3, Iterator3>& operator*() const
+      {
+        NTA_ASSERT(!finished_);
+        return v_;
+      }
+
+      const Iterator& operator++()
+      {
+        NTA_ASSERT(!finished_);
+        calculateNext_();
+        return *this;
+      }
+
+    private:
+
+      void calculateNext_()
+      {
+        if (current0_ != end0_ ||
+            current1_ != end1_ ||
+            current2_ != end2_ ||
+            current3_ != end3_)
+        {
+          // Find the lowest key.
+          KeyType key;
+          bool found = false;
+
+          if (current0_ != end0_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn0_(*current0_));
+            }
+            else
+            {
+              key = keyFn0_(*current0_);
+              found = true;
+            }
+          }
+
+          if (current1_ != end1_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn1_(*current1_));
+            }
+            else
+            {
+              key = keyFn1_(*current1_);
+              found = true;
+            }
+          }
+
+          if (current2_ != end2_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn2_(*current2_));
+            }
+            else
+            {
+              key = keyFn2_(*current2_);
+              found = true;
+            }
+          }
+
+          if (current3_ != end3_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn3_(*current3_));
+            }
+            else
+            {
+              key = keyFn3_(*current3_);
+              found = true;
+            }
+          }
+
+          NTA_ASSERT(found);
+          std::get<0>(v_) = key;
+
+          // Find all elements with this key.
+          std::get<1>(v_) = current0_;
+          while (current0_ != end0_ && keyFn0_(*current0_) == key)
+          {
+            current0_++;
+          }
+          std::get<2>(v_) = current0_;
+
+          std::get<3>(v_) = current1_;
+          while (current1_ != end1_ && keyFn1_(*current1_) == key)
+          {
+            current1_++;
+          }
+          std::get<4>(v_) = current1_;
+
+          std::get<5>(v_) = current2_;
+          while (current2_ != end2_ && keyFn2_(*current2_) == key)
+          {
+            current2_++;
+          }
+          std::get<6>(v_) = current2_;
+
+          std::get<7>(v_) = current3_;
+          while (current3_ != end3_ && keyFn3_(*current3_) == key)
+          {
+            current3_++;
+          }
+          std::get<8>(v_) = current3_;
+        }
+        else
+        {
+          finished_ = true;
+        }
+      }
+
+      std::tuple<KeyType,
+                 Iterator0, Iterator0,
+                 Iterator1, Iterator1,
+                 Iterator2, Iterator2,
+                 Iterator3, Iterator3> v_;
+
+      Iterator0 current0_;
+      Iterator0 end0_;
+      KeyFn0 keyFn0_;
+
+      Iterator1 current1_;
+      Iterator1 end1_;
+      KeyFn1 keyFn1_;
+
+      Iterator2 current2_;
+      Iterator2 end2_;
+      KeyFn2 keyFn2_;
+
+      Iterator3 current3_;
+      Iterator3 end3_;
+      KeyFn3 keyFn3_;
+
+      bool finished_;
+    };
+
+    Iterator begin() const
+    {
+      return Iterator(begin0_, end0_, keyFn0_,
+                      begin1_, end1_, keyFn1_,
+                      begin2_, end2_, keyFn2_,
+                      begin3_, end3_, keyFn3_);
+    }
+
+    Iterator end() const
+    {
+      return Iterator(end0_, end0_, keyFn0_,
+                      end1_, end1_, keyFn1_,
+                      end2_, end2_, keyFn2_,
+                      end3_, end3_, keyFn3_);
+    }
+
+  private:
+    Iterator0 begin0_;
+    Iterator0 end0_;
+    KeyFn0 keyFn0_;
+
+    Iterator1 begin1_;
+    Iterator1 end1_;
+    KeyFn1 keyFn1_;
+
+    Iterator2 begin2_;
+    Iterator2 end2_;
+    KeyFn2 keyFn2_;
+
+    Iterator3 begin3_;
+    Iterator3 end3_;
+    KeyFn3 keyFn3_;
+  };
+
+  template<typename Sequence0, typename KeyFn0,
+           typename Sequence1, typename KeyFn1,
+           typename Sequence2, typename KeyFn2,
+           typename Sequence3, typename KeyFn3>
+  GroupBy4<typename Sequence0::const_iterator, KeyFn0,
+           typename Sequence1::const_iterator, KeyFn1,
+           typename Sequence2::const_iterator, KeyFn2,
+           typename Sequence3::const_iterator, KeyFn3>
+  group_by(const Sequence0& sequence0, KeyFn0 keyFn0,
+           const Sequence1& sequence1, KeyFn1 keyFn1,
+           const Sequence2& sequence2, KeyFn2 keyFn2,
+           const Sequence3& sequence3, KeyFn3 keyFn3)
+  {
+    return {sequence0.begin(), sequence0.end(), keyFn0,
+            sequence1.begin(), sequence1.end(), keyFn1,
+            sequence2.begin(), sequence2.end(), keyFn2,
+            sequence3.begin(), sequence3.end(), keyFn3};
+  }
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2,
+           typename Iterator3, typename KeyFn3>
+  GroupBy4<Iterator0, KeyFn0,
+           Iterator1, KeyFn1,
+           Iterator2, KeyFn2,
+           Iterator3, KeyFn3>
+  iter_group_by(
+    Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+    Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+    Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+    Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3)
+  {
+    return {begin0, end0, keyFn0,
+            begin1, end1, keyFn1,
+            begin2, end2, keyFn2,
+            begin3, end3, keyFn3};
+  }
+
+
+  // ==========================================================================
+  // 5 SEQUENCES
+  // ==========================================================================
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2,
+           typename Iterator3, typename KeyFn3,
+           typename Iterator4, typename KeyFn4,
+           typename Element0 = decltype(*std::declval<Iterator0>()),
+           typename Element1 = decltype(*std::declval<Iterator1>()),
+           typename Element2 = decltype(*std::declval<Iterator2>()),
+           typename Element3 = decltype(*std::declval<Iterator3>()),
+           typename Element4 = decltype(*std::declval<Iterator4>()),
+           typename KeyType = typename std::result_of<
+             KeyFn0(decltype(*std::declval<Iterator0>()))
+             >::type>
+  class GroupBy5
+  {
+  public:
+    GroupBy5(
+      Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+      Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+      Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+      Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3,
+      Iterator4 begin4, Iterator4 end4, KeyFn4 keyFn4)
+    : begin0_(begin0), end0_(end0), keyFn0_(keyFn0),
+      begin1_(begin1), end1_(end1), keyFn1_(keyFn1),
+      begin2_(begin2), end2_(end2), keyFn2_(keyFn2),
+      begin3_(begin3), end3_(end3), keyFn3_(keyFn3),
+      begin4_(begin4), end4_(end4), keyFn4_(keyFn4)
+    {
+      NTA_ASSERT(std::is_sorted(begin0, end0,
+                                [&](const Element0& a, const Element0& b)
+                                {
+                                  return keyFn0(a) < keyFn0(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin1, end1,
+                                [&](const Element1& a, const Element1& b)
+                                {
+                                  return keyFn1(a) < keyFn1(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin2, end2,
+                                [&](const Element2& a, const Element2& b)
+                                {
+                                  return keyFn2(a) < keyFn2(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin3, end3,
+                                [&](const Element3& a, const Element3& b)
+                                {
+                                  return keyFn3(a) < keyFn3(b);
+                                }));
+      NTA_ASSERT(std::is_sorted(begin4, end4,
+                                [&](const Element4& a, const Element4& b)
+                                {
+                                  return keyFn4(a) < keyFn4(b);
+                                }));
+    }
+
+    class Iterator
+    {
+    public:
+      Iterator(
+        Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+        Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+        Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+        Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3,
+        Iterator4 begin4, Iterator4 end4, KeyFn4 keyFn4)
+        :current0_(begin0), end0_(end0), keyFn0_(keyFn0),
+         current1_(begin1), end1_(end1), keyFn1_(keyFn1),
+         current2_(begin2), end2_(end2), keyFn2_(keyFn2),
+         current3_(begin3), end3_(end3), keyFn3_(keyFn3),
+         current4_(begin4), end4_(end4), keyFn4_(keyFn4),
+         finished_(false)
+      {
+        calculateNext_();
+      }
+
+      bool operator !=(const Iterator& other)
+      {
+        return (finished_ != other.finished_ ||
+                current0_ != other.current0_ ||
+                current1_ != other.current1_ ||
+                current2_ != other.current2_ ||
+                current3_ != other.current3_ ||
+                current4_ != other.current4_);
+      }
+
+      const std::tuple<KeyType,
+                       Iterator0, Iterator0,
+                       Iterator1, Iterator1,
+                       Iterator2, Iterator2,
+                       Iterator3, Iterator3,
+                       Iterator4, Iterator4>& operator*() const
+      {
+        NTA_ASSERT(!finished_);
+        return v_;
+      }
+
+      const Iterator& operator++()
+      {
+        NTA_ASSERT(!finished_);
+        calculateNext_();
+        return *this;
+      }
+
+    private:
+
+      void calculateNext_()
+      {
+        if (current0_ != end0_ ||
+            current1_ != end1_ ||
+            current2_ != end2_ ||
+            current3_ != end3_ ||
+            current4_ != end4_)
+        {
+          // Find the lowest key.
+          KeyType key;
+          bool found = false;
+
+          if (current0_ != end0_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn0_(*current0_));
+            }
+            else
+            {
+              key = keyFn0_(*current0_);
+              found = true;
+            }
+          }
+
+          if (current1_ != end1_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn1_(*current1_));
+            }
+            else
+            {
+              key = keyFn1_(*current1_);
+              found = true;
+            }
+          }
+
+          if (current2_ != end2_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn2_(*current2_));
+            }
+            else
+            {
+              key = keyFn2_(*current2_);
+              found = true;
+            }
+          }
+
+          if (current3_ != end3_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn3_(*current3_));
+            }
+            else
+            {
+              key = keyFn3_(*current3_);
+              found = true;
+            }
+          }
+
+          if (current4_ != end4_)
+          {
+            if (found)
+            {
+              key = std::min(key, keyFn4_(*current4_));
+            }
+            else
+            {
+              key = keyFn4_(*current4_);
+              found = true;
+            }
+          }
+
+          NTA_ASSERT(found);
+          std::get<0>(v_) = key;
+
+          // Find all elements with this key.
+          std::get<1>(v_) = current0_;
+          while (current0_ != end0_ && keyFn0_(*current0_) == key)
+          {
+            current0_++;
+          }
+          std::get<2>(v_) = current0_;
+
+          std::get<3>(v_) = current1_;
+          while (current1_ != end1_ && keyFn1_(*current1_) == key)
+          {
+            current1_++;
+          }
+          std::get<4>(v_) = current1_;
+
+          std::get<5>(v_) = current2_;
+          while (current2_ != end2_ && keyFn2_(*current2_) == key)
+          {
+            current2_++;
+          }
+          std::get<6>(v_) = current2_;
+
+          std::get<7>(v_) = current3_;
+          while (current3_ != end3_ && keyFn3_(*current3_) == key)
+          {
+            current3_++;
+          }
+          std::get<8>(v_) = current3_;
+
+          std::get<9>(v_) = current4_;
+          while (current4_ != end4_ && keyFn4_(*current4_) == key)
+          {
+            current4_++;
+          }
+          std::get<10>(v_) = current4_;
+        }
+        else
+        {
+          finished_ = true;
+        }
+      }
+
+      std::tuple<KeyType,
+                 Iterator0, Iterator0,
+                 Iterator1, Iterator1,
+                 Iterator2, Iterator2,
+                 Iterator3, Iterator3,
+                 Iterator4, Iterator4> v_;
+
+      Iterator0 current0_;
+      Iterator0 end0_;
+      KeyFn0 keyFn0_;
+
+      Iterator1 current1_;
+      Iterator1 end1_;
+      KeyFn1 keyFn1_;
+
+      Iterator2 current2_;
+      Iterator2 end2_;
+      KeyFn2 keyFn2_;
+
+      Iterator3 current3_;
+      Iterator3 end3_;
+      KeyFn3 keyFn3_;
+
+      Iterator4 current4_;
+      Iterator4 end4_;
+      KeyFn4 keyFn4_;
+
+      bool finished_;
+    };
+
+    Iterator begin() const
+    {
+      return Iterator(begin0_, end0_, keyFn0_,
+                      begin1_, end1_, keyFn1_,
+                      begin2_, end2_, keyFn2_,
+                      begin3_, end3_, keyFn3_,
+                      begin4_, end4_, keyFn4_);
+    }
+
+    Iterator end() const
+    {
+      return Iterator(end0_, end0_, keyFn0_,
+                      end1_, end1_, keyFn1_,
+                      end2_, end2_, keyFn2_,
+                      end3_, end3_, keyFn3_,
+                      end4_, end4_, keyFn4_);
+    }
+
+  private:
+    Iterator0 begin0_;
+    Iterator0 end0_;
+    KeyFn0 keyFn0_;
+
+    Iterator1 begin1_;
+    Iterator1 end1_;
+    KeyFn1 keyFn1_;
+
+    Iterator2 begin2_;
+    Iterator2 end2_;
+    KeyFn2 keyFn2_;
+
+    Iterator3 begin3_;
+    Iterator3 end3_;
+    KeyFn3 keyFn3_;
+
+    Iterator4 begin4_;
+    Iterator4 end4_;
+    KeyFn4 keyFn4_;
+  };
+
+  template<typename Sequence0, typename KeyFn0,
+           typename Sequence1, typename KeyFn1,
+           typename Sequence2, typename KeyFn2,
+           typename Sequence3, typename KeyFn3,
+           typename Sequence4, typename KeyFn4>
+  GroupBy5<typename Sequence0::const_iterator, KeyFn0,
+           typename Sequence1::const_iterator, KeyFn1,
+           typename Sequence2::const_iterator, KeyFn2,
+           typename Sequence3::const_iterator, KeyFn3,
+           typename Sequence4::const_iterator, KeyFn4>
+  group_by(const Sequence0& sequence0, KeyFn0 keyFn0,
+           const Sequence1& sequence1, KeyFn1 keyFn1,
+           const Sequence2& sequence2, KeyFn2 keyFn2,
+           const Sequence3& sequence3, KeyFn3 keyFn3,
+           const Sequence4& sequence4, KeyFn4 keyFn4)
+  {
+    return {sequence0.begin(), sequence0.end(), keyFn0,
+            sequence1.begin(), sequence1.end(), keyFn1,
+            sequence2.begin(), sequence2.end(), keyFn2,
+            sequence3.begin(), sequence3.end(), keyFn3,
+            sequence4.begin(), sequence4.end(), keyFn4};
+  }
+
+  template<typename Iterator0, typename KeyFn0,
+           typename Iterator1, typename KeyFn1,
+           typename Iterator2, typename KeyFn2,
+           typename Iterator3, typename KeyFn3,
+           typename Iterator4, typename KeyFn4>
+  GroupBy5<Iterator0, KeyFn0,
+           Iterator1, KeyFn1,
+           Iterator2, KeyFn2,
+           Iterator3, KeyFn3,
+           Iterator4, KeyFn4>
+  iter_group_by(
+    Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
+    Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
+    Iterator2 begin2, Iterator2 end2, KeyFn2 keyFn2,
+    Iterator3 begin3, Iterator3 end3, KeyFn3 keyFn3,
+    Iterator4 begin4, Iterator4 end4, KeyFn4 keyFn4)
+  {
+    return {begin0, end0, keyFn0,
+            begin1, end1, keyFn1,
+            begin2, end2, keyFn2,
+            begin3, end3, keyFn3,
+            begin4, end4, keyFn4};
+  }
+
+} // end namespace nupic

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -52,6 +52,9 @@ namespace nupic
    * containing the key, followed by a begin and end iterator for each
    * sequence. The sequences are traversed lazily as the iterator is advanced.
    *
+   * Note: It's called "group_by" and "iter_group_by" in snake_case because it's
+   * designed to feel like an STL function, like "is_sorted" or "iter_swap".
+   *
    * Feel free to add new GroupBy7, GroupBy8, ..., GroupByN classes as needed.
    */
 

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -29,7 +29,7 @@
 
 // GCC warns that `key` might be uninitialized in the `calculateNext_` methods.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wuninitialized"
 
 namespace nupic
 {

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -20,9 +20,16 @@
  * ----------------------------------------------------------------------
  */
 
+#ifndef NTA_GROUP_BY_HPP
+#define NTA_GROUP_BY_HPP
+
 #include <tuple>
 
 #include <nupic/utils/Log.hpp>
+
+// GCC warns that `key` might be uninitialized in the `calculateNext_` methods.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
 namespace nupic
 {
@@ -1239,3 +1246,7 @@ namespace nupic
   }
 
 } // end namespace nupic
+
+#pragma GCC diagnostic pop
+
+#endif // NTA_GROUP_BY_HPP

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -40,8 +40,8 @@ namespace nupic
    *
    * Both functions take a key function for each sequence.
    *
-   * These functions return an iterable object. The iterator returns a tuple
-   * containing the group_by key, followed by a begin and end iterator for each
+   * Both functions return an iterable object. The iterator returns a tuple
+   * containing the key, followed by a begin and end iterator for each
    * sequence. The sequences are traversed lazily as the iterator is advanced.
    *
    * Feel free to add new GroupBy7, GroupBy8, ..., GroupByN classes as needed.

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -24,6 +24,7 @@
 #define NTA_GROUP_BY_HPP
 
 #include <tuple>
+#include <algorithm> // is_sorted
 
 #include <nupic/utils/Log.hpp>
 

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -1,0 +1,1325 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Implementation of unit tests for ExtendedTemporalMemory
+ */
+
+#include <cstring>
+#include <fstream>
+#include <stdio.h>
+#include <nupic/math/StlIo.hpp>
+#include <nupic/types/Types.hpp>
+#include <nupic/utils/Log.hpp>
+
+#include <nupic/experimental/ExtendedTemporalMemory.hpp>
+#include "gtest/gtest.h"
+
+using namespace nupic::experimental::extended_temporal_memory;
+using namespace std;
+
+#define EPSILON 0.0000001
+
+namespace {
+  void check_tm_eq(const ExtendedTemporalMemory& tm1,
+                   const ExtendedTemporalMemory& tm2)
+  {
+    ASSERT_EQ(tm1.numberOfColumns(), tm2.numberOfColumns());
+    ASSERT_EQ(tm1.getCellsPerColumn(), tm2.getCellsPerColumn());
+    ASSERT_EQ(tm1.getActivationThreshold(), tm2.getActivationThreshold());
+    ASSERT_EQ(tm1.getMinThreshold(), tm2.getMinThreshold());
+    ASSERT_EQ(tm1.getMaxNewSynapseCount(), tm2.getMaxNewSynapseCount());
+    ASSERT_NEAR(tm1.getInitialPermanence(), tm2.getInitialPermanence(), EPSILON);
+    ASSERT_NEAR(tm1.getConnectedPermanence(), tm2.getConnectedPermanence(), EPSILON);
+    ASSERT_NEAR(tm1.getPermanenceIncrement(), tm2.getPermanenceIncrement(), EPSILON);
+    ASSERT_NEAR(tm1.getPermanenceDecrement(), tm2.getPermanenceDecrement(), EPSILON);
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testInitInvalidParams)
+  {
+    // Invalid columnDimensions
+    vector<UInt> columnDim = {};
+    ExtendedTemporalMemory tm1;
+    EXPECT_THROW(tm1.initialize(columnDim, 32), exception);
+
+    // Invalid cellsPerColumn
+    columnDim.push_back(2048);
+    EXPECT_THROW(tm1.initialize(columnDim, 0), exception);
+  }
+
+  /**
+   * When a predicted column is activated, only the predicted cells in the
+   * columns should be activated.
+   */
+  TEST(ExtendedTemporalMemoryTest, ActivateCorrectlyPredictiveCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> expectedActiveCells = {4};
+
+    Segment activeSegment =
+      tm.basalConnections.createSegment(expectedActiveCells[0]);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_EQ(expectedActiveCells, tm.getActiveCells());
+  }
+
+  /**
+   * When an unpredicted column is activated, every cell in the column should
+   * become active.
+   */
+  TEST(ExtendedTemporalMemoryTest, BurstUnpredictedColumns)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt activeColumns[1] = {0};
+    const vector<CellIdx> burstingCells = {0, 1, 2, 3};
+
+    tm.compute(1, activeColumns, true);
+
+    EXPECT_EQ(burstingCells, tm.getActiveCells());
+  }
+
+  /**
+   * When the ExtendedTemporalMemory receives zero active columns, it should still
+   * compute the active cells, winner cells, and predictive cells. All should be
+   * empty.
+   */
+  TEST(ExtendedTemporalMemoryTest, ZeroActiveColumns)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    // Make some cells predictive.
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> expectedActiveCells = {4};
+
+    Segment segment = tm.basalConnections.createSegment(expectedActiveCells[0]);
+    tm.basalConnections.createSynapse(segment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(segment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(segment, previousActiveCells[2], 0.5);
+    tm.basalConnections.createSynapse(segment, previousActiveCells[3], 0.5);
+
+    tm.compute(1, previousActiveColumns, true);
+    ASSERT_FALSE(tm.getActiveCells().empty());
+    ASSERT_FALSE(tm.getWinnerCells().empty());
+    ASSERT_FALSE(tm.getPredictiveCells().empty());
+
+    const UInt zeroColumns[0] = {};
+    tm.compute(0, zeroColumns, true);
+
+    EXPECT_TRUE(tm.getActiveCells().empty());
+    EXPECT_TRUE(tm.getWinnerCells().empty());
+    EXPECT_TRUE(tm.getPredictiveCells().empty());
+  }
+
+  /**
+   * All predicted active cells are winner cells, even when learning is
+   * disabled.
+   */
+  TEST(ExtendedTemporalMemoryTest, PredictedActiveCellsAreAlwaysWinners)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> expectedWinnerCells = {4, 6};
+
+    Segment activeSegment1 =
+      tm.basalConnections.createSegment(expectedWinnerCells[0]);
+    tm.basalConnections.createSynapse(activeSegment1, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment1, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment1, previousActiveCells[2], 0.5);
+
+    Segment activeSegment2 =
+      tm.basalConnections.createSegment(expectedWinnerCells[1]);
+    tm.basalConnections.createSynapse(activeSegment2, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment2, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment2, previousActiveCells[2], 0.5);
+
+    tm.compute(numActiveColumns, previousActiveColumns, false);
+    tm.compute(numActiveColumns, activeColumns, false);
+
+    EXPECT_EQ(expectedWinnerCells, tm.getWinnerCells());
+  }
+
+  /**
+   * One cell in each bursting column is a winner cell, even when learning is
+   * disabled.
+   */
+  TEST(ExtendedTemporalMemoryTest, ChooseOneWinnerCellInBurstingColumn)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt activeColumns[1] = {0};
+    const set<CellIdx> burstingCells = {0, 1, 2, 3};
+
+    tm.compute(1, activeColumns, false);
+
+    vector<CellIdx> winnerCells = tm.getWinnerCells();
+    ASSERT_EQ(1, winnerCells.size());
+    EXPECT_TRUE(burstingCells.find(winnerCells[0]) != burstingCells.end());
+  }
+
+  /**
+   * Active segments on predicted active cells should be reinforced. Active
+   * synapses should be reinforced, inactive synapses should be punished.
+   */
+  TEST(ExtendedTemporalMemoryTest, ReinforceCorrectlyActiveSegments)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.08,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> activeCells = {5};
+    const CellIdx activeCell = 5;
+
+    Segment activeSegment = tm.basalConnections.createSegment(activeCell);
+    Synapse activeSynapse1 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    Synapse activeSynapse2 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    Synapse activeSynapse3 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    Synapse inactiveSynapse =
+      tm.basalConnections.createSynapse(activeSegment, 81, 0.5);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_NEAR(0.6, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.6, tm.basalConnections.dataForSynapse(activeSynapse2).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.6, tm.basalConnections.dataForSynapse(activeSynapse3).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.42, tm.basalConnections.dataForSynapse(inactiveSynapse).permanence,
+                EPSILON);
+  }
+
+  /**
+   * Active segments on predicted active cells should not grow new synapses.
+   */
+  TEST(ExtendedTemporalMemoryTest, NoGrowthOnCorrectlyActiveSegments)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> activeCells = {5};
+    const CellIdx activeCell = 5;
+
+    Segment activeSegment = tm.basalConnections.createSegment(activeCell);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_EQ(3, tm.basalConnections.numSynapses(activeSegment));
+  }
+
+  /**
+   * The best matching segment in a bursting column should be reinforced. Active
+   * synapses should be strengthened, and inactive synapses should be weakened.
+   */
+  TEST(ExtendedTemporalMemoryTest, ReinforceSelectedMatchingSegmentInBurstingColumn)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.08,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> burstingCells = {4, 5, 6, 7};
+
+    Segment selectedMatchingSegment =
+      tm.basalConnections.createSegment(burstingCells[0]);
+    Synapse activeSynapse1 =
+      tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                        previousActiveCells[0], 0.3);
+    Synapse activeSynapse2 =
+      tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                        previousActiveCells[1], 0.3);
+    Synapse activeSynapse3 =
+      tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                        previousActiveCells[2], 0.3);
+    Synapse inactiveSynapse =
+      tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                        81, 0.3);
+
+    // Add some competition.
+    Segment otherMatchingSegment =
+      tm.basalConnections.createSegment(burstingCells[1]);
+    tm.basalConnections.createSynapse(otherMatchingSegment,
+                                      previousActiveCells[0], 0.3);
+    tm.basalConnections.createSynapse(otherMatchingSegment,
+                                      previousActiveCells[1], 0.3);
+    tm.basalConnections.createSynapse(otherMatchingSegment,
+                                      81, 0.3);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_NEAR(0.4, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.4, tm.basalConnections.dataForSynapse(activeSynapse2).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.4, tm.basalConnections.dataForSynapse(activeSynapse3).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.22, tm.basalConnections.dataForSynapse(inactiveSynapse).permanence,
+                EPSILON);
+  }
+
+  /**
+   * When a column bursts, don't reward or punish matching-but-not-selected
+   * segments.
+   */
+  TEST(ExtendedTemporalMemoryTest, NoChangeToNonselectedMatchingSegmentsInBurstingColumn)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.08,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt previousActiveColumns[1] = {0};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> burstingCells = {4, 5, 6, 7};
+
+    Segment selectedMatchingSegment =
+      tm.basalConnections.createSegment(burstingCells[0]);
+    tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                      previousActiveCells[0], 0.3);
+    tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                      previousActiveCells[1], 0.3);
+    tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                      previousActiveCells[2], 0.3);
+    tm.basalConnections.createSynapse(selectedMatchingSegment,
+                                      81, 0.3);
+
+    Segment otherMatchingSegment =
+      tm.basalConnections.createSegment(burstingCells[1]);
+    Synapse activeSynapse1 =
+      tm.basalConnections.createSynapse(otherMatchingSegment,
+                                        previousActiveCells[0], 0.3);
+    Synapse activeSynapse2 =
+      tm.basalConnections.createSynapse(otherMatchingSegment,
+                                        previousActiveCells[1], 0.3);
+    Synapse inactiveSynapse =
+      tm.basalConnections.createSynapse(otherMatchingSegment,
+                                        81, 0.3);
+
+    tm.compute(1, previousActiveColumns, true);
+    tm.compute(1, activeColumns, true);
+
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(activeSynapse2).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(inactiveSynapse).permanence,
+                EPSILON);
+  }
+
+  /**
+   * When a predicted column is activated, don't reward or punish
+   * matching-but-not-active segments anywhere in the column.
+   */
+  TEST(ExtendedTemporalMemoryTest, NoChangeToMatchingSegmentsInPredictedActiveColumn)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt previousActiveColumns[1] = {0};
+    const UInt activeColumns[1] = {1};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const vector<CellIdx> expectedActiveCells = {4};
+    const vector<CellIdx> otherBurstingCells = {5, 6, 7};
+
+    Segment activeSegment =
+      tm.basalConnections.createSegment(expectedActiveCells[0]);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
+
+    Segment matchingSegmentOnSameCell =
+      tm.basalConnections.createSegment(expectedActiveCells[0]);
+    Synapse synapse1 =
+      tm.basalConnections.createSynapse(matchingSegmentOnSameCell,
+                                        previousActiveCells[0], 0.3);
+    Synapse synapse2 =
+      tm.basalConnections.createSynapse(matchingSegmentOnSameCell,
+                                        previousActiveCells[1], 0.3);
+
+    Segment matchingSegmentOnOtherCell =
+      tm.basalConnections.createSegment(otherBurstingCells[0]);
+    Synapse synapse3 =
+      tm.basalConnections.createSynapse(matchingSegmentOnOtherCell,
+                                        previousActiveCells[0], 0.3);
+    Synapse synapse4 =
+      tm.basalConnections.createSynapse(matchingSegmentOnOtherCell,
+                                        previousActiveCells[1], 0.3);
+
+    tm.compute(1, previousActiveColumns, true);
+    ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
+    tm.compute(1, activeColumns, true);
+
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(synapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(synapse2).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(synapse3).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(synapse4).permanence,
+                EPSILON);
+  }
+
+  /**
+   * When growing a new segment, if there are no previous winner cells, don't
+   * even grow the segment. It will never match.
+   */
+  TEST(ExtendedTemporalMemoryTest, NoNewSegmentIfNotEnoughWinnerCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 2,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt zeroColumns[0] = {};
+    const UInt activeColumns[1] = {0};
+
+    tm.compute(0, zeroColumns);
+    tm.compute(1, activeColumns);
+
+    EXPECT_EQ(0, tm.basalConnections.numSegments());
+  }
+
+  /**
+   * When growing a new segment, if the number of previous winner cells is above
+   * maxNewSynapseCount, grow maxNewSynapseCount synapses.
+   */
+  TEST(ExtendedTemporalMemoryTest, NewSegmentAddSynapsesToSubsetOfWinnerCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 2,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt previousActiveColumns[3] = {0, 1, 2};
+    const UInt activeColumns[1] = {4};
+
+    tm.compute(3, previousActiveColumns);
+
+    vector<CellIdx> prevWinnerCells = tm.getWinnerCells();
+    ASSERT_EQ(3, prevWinnerCells.size());
+
+    tm.compute(1, activeColumns);
+
+    vector<CellIdx> winnerCells = tm.getWinnerCells();
+    ASSERT_EQ(1, winnerCells.size());
+    vector<Segment> segments = tm.basalConnections.segmentsForCell(winnerCells[0]);
+    ASSERT_EQ(1, segments.size());
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(segments[0]);
+    ASSERT_EQ(2, synapses.size());
+    for (Synapse synapse : synapses)
+    {
+      SynapseData synapseData = tm.basalConnections.dataForSynapse(synapse);
+      EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+      EXPECT_TRUE(synapseData.presynapticCell == prevWinnerCells[0] ||
+                  synapseData.presynapticCell == prevWinnerCells[1] ||
+                  synapseData.presynapticCell == prevWinnerCells[2]);
+    }
+
+  }
+
+  /**
+   * When growing a new segment, if the number of previous winner cells is below
+   * maxNewSynapseCount, grow synapses to all of the previous winner cells.
+   */
+  TEST(ExtendedTemporalMemoryTest, NewSegmentAddSynapsesToAllWinnerCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt previousActiveColumns[3] = {0, 1, 2};
+    const UInt activeColumns[1] = {4};
+
+    tm.compute(3, previousActiveColumns);
+
+    vector<CellIdx> prevWinnerCells = tm.getWinnerCells();
+    ASSERT_EQ(3, prevWinnerCells.size());
+
+    tm.compute(1, activeColumns);
+
+    vector<CellIdx> winnerCells = tm.getWinnerCells();
+    ASSERT_EQ(1, winnerCells.size());
+    vector<Segment> segments = tm.basalConnections.segmentsForCell(winnerCells[0]);
+    ASSERT_EQ(1, segments.size());
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(segments[0]);
+    ASSERT_EQ(3, synapses.size());
+
+    vector<CellIdx> presynapticCells;
+    for (Synapse synapse : synapses)
+    {
+      SynapseData synapseData = tm.basalConnections.dataForSynapse(synapse);
+      EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+      presynapticCells.push_back(synapseData.presynapticCell);
+    }
+    std::sort(presynapticCells.begin(), presynapticCells.end());
+    EXPECT_EQ(prevWinnerCells, presynapticCells);
+  }
+
+  /**
+   * When adding synapses to a matching segment, the final number of active
+   * synapses on the segment should be maxNewSynapseCount, assuming there are
+   * enough previous winner cells available to connect to.
+   */
+  TEST(ExtendedTemporalMemoryTest, MatchingSegmentAddSynapsesToSubsetOfWinnerCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 1,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    // Use 1 cell per column so that we have easy control over the winner cells.
+    const UInt previousActiveColumns[4] = {0, 1, 2, 3};
+    const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {4};
+
+    Segment matchingSegment = tm.basalConnections.createSegment(4);
+    tm.basalConnections.createSynapse(matchingSegment, 0, 0.5);
+
+    tm.compute(4, previousActiveColumns);
+
+    ASSERT_EQ(prevWinnerCells, tm.getWinnerCells());
+
+    tm.compute(1, activeColumns);
+
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(matchingSegment);
+    ASSERT_EQ(3, synapses.size());
+    for (SynapseIdx i = 1; i < synapses.size(); i++)
+    {
+      SynapseData synapseData = tm.basalConnections.dataForSynapse(synapses[i]);
+      EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+      EXPECT_TRUE(synapseData.presynapticCell == prevWinnerCells[1] ||
+                  synapseData.presynapticCell == prevWinnerCells[2] ||
+                  synapseData.presynapticCell == prevWinnerCells[3]);
+    }
+  }
+
+  /**
+   * When adding synapses to a matching segment, if the number of previous
+   * winner cells is lower than (maxNewSynapseCount - nActiveSynapsesOnSegment),
+   * grow synapses to all the previous winner cells.
+   */
+  TEST(ExtendedTemporalMemoryTest, MatchingSegmentAddSynapsesToAllWinnerCells)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 1,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    // Use 1 cell per column so that we have easy control over the winner cells.
+    const UInt previousActiveColumns[2] = {0, 1};
+    const vector<CellIdx> prevWinnerCells = {0, 1};
+    const UInt activeColumns[1] = {4};
+
+    Segment matchingSegment = tm.basalConnections.createSegment(4);
+    tm.basalConnections.createSynapse(matchingSegment, 0, 0.5);
+
+    tm.compute(2, previousActiveColumns);
+
+    ASSERT_EQ(prevWinnerCells, tm.getWinnerCells());
+
+    tm.compute(1, activeColumns);
+
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(matchingSegment);
+    ASSERT_EQ(2, synapses.size());
+
+    SynapseData synapseData = tm.basalConnections.dataForSynapse(synapses[1]);
+    EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+    EXPECT_EQ(prevWinnerCells[1], synapseData.presynapticCell);
+  }
+
+  /**
+   * When a synapse is punished for contributing to a wrong prediction, if its
+   * permanence falls to 0 it should be destroyed.
+   */
+  TEST(ExtendedTemporalMemoryTest, DestroyWeakSynapseOnWrongPrediction)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {2};
+    const CellIdx expectedActiveCell = 5;
+
+    Segment activeSegment = tm.basalConnections.createSegment(expectedActiveCell);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    Synapse weakActiveSynapse =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[3], 0.015);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_TRUE(tm.basalConnections.dataForSynapse(weakActiveSynapse).destroyed);
+  }
+
+  /**
+   * When a synapse is punished for not contributing to a right prediction, if
+   * its permanence falls to 0 it should be destroyed.
+   */
+  TEST(ExtendedTemporalMemoryTest, DestroyWeakSynapseOnActiveReinforce)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {1};
+    const CellIdx activeCell = 5;
+
+    Segment activeSegment = tm.basalConnections.createSegment(activeCell);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    Synapse weakInactiveSynapse =
+      tm.basalConnections.createSynapse(activeSegment, 81, 0.09);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_TRUE(tm.basalConnections.dataForSynapse(weakInactiveSynapse).destroyed);
+  }
+
+  /**
+   * When a segment adds synapses and it runs over maxSynapsesPerSegment, it
+   * should make room by destroying synapses with the lowest permanence.
+   */
+  TEST(ExtendedTemporalMemoryTest, RecycleWeakestSynapseToMakeRoomForNewSynapse)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 1,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.02,
+      /*permanenceDecrement*/ 0.02,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42,
+      /*maxSegmentsPerCell*/ 255,
+      /*maxSynapsesPerSegment*/ 3
+      );
+
+    // Use 1 cell per column so that we have easy control over the winner cells.
+    const UInt previousActiveColumns[3] = {0, 1, 2};
+    const vector<CellIdx> prevWinnerCells = {0, 1, 2};
+    const UInt activeColumns[1] = {4};
+
+    Segment matchingSegment = tm.basalConnections.createSegment(4);
+    tm.basalConnections.createSynapse(matchingSegment, 81, 0.6);
+
+    // Still the weakest after adding permanenceIncrement.
+    Synapse weakestSynapse =
+      tm.basalConnections.createSynapse(matchingSegment, 0, 0.11);
+
+    tm.compute(3, previousActiveColumns);
+
+    ASSERT_EQ(prevWinnerCells, tm.getWinnerCells());
+
+    tm.compute(1, activeColumns);
+
+    // Note that it destroys the weak active synapse, not the strong inactive
+    // synapse.
+    SynapseData synapseData = tm.basalConnections.dataForSynapse(weakestSynapse);
+    EXPECT_NE(0, synapseData.presynapticCell);
+    EXPECT_FALSE(synapseData.destroyed);
+    EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+  }
+
+  /**
+   * When a cell adds a segment and it runs over maxSegmentsPerCell, it should
+   * make room by destroying the least recently active segment.
+   */
+  TEST(ExtendedTemporalMemoryTest, RecycleLeastRecentlyActiveSegmentToMakeRoomForNewSegment)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.50,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.02,
+      /*permanenceDecrement*/ 0.02,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42,
+      /*maxSegmentsPerCell*/ 2
+      );
+
+    const UInt previousActiveColumns1[3] = {0, 1, 2};
+    const UInt previousActiveColumns2[3] = {3, 4, 5};
+    const UInt previousActiveColumns3[3] = {6, 7, 8};
+    const UInt activeColumns[1] = {9};
+
+    tm.compute(3, previousActiveColumns1);
+    tm.compute(1, activeColumns);
+
+    ASSERT_EQ(1, tm.basalConnections.numSegments(9));
+    Segment oldestSegment = tm.basalConnections.segmentsForCell(9)[0];
+
+    tm.reset();
+    tm.compute(3, previousActiveColumns2);
+    tm.compute(1, activeColumns);
+
+    ASSERT_EQ(2, tm.basalConnections.numSegments(9));
+
+    tm.reset();
+    tm.compute(3, previousActiveColumns3);
+    tm.compute(1, activeColumns);
+
+    ASSERT_EQ(2, tm.basalConnections.numSegments(9));
+
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(oldestSegment);
+    ASSERT_EQ(3, synapses.size());
+    set<CellIdx> presynapticCells;
+    for (Synapse synapse : synapses)
+    {
+      SynapseData synapseData = tm.basalConnections.dataForSynapse(synapse);
+      presynapticCells.insert(synapseData.presynapticCell);
+    }
+
+    const set<CellIdx> expected = {6, 7, 8};
+    EXPECT_EQ(expected, presynapticCells);
+  }
+
+  /**
+   * When a segment's number of synapses falls to 0, the segment should be
+   * destroyed.
+   */
+  TEST(ExtendedTemporalMemoryTest, DestroySegmentsWithTooFewSynapsesToBeMatching)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {2};
+    const CellIdx expectedActiveCell = 5;
+
+    Segment matchingSegment = tm.basalConnections.createSegment(expectedActiveCell);
+    tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[0], 0.015);
+    tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[1], 0.015);
+    tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[2], 0.015);
+    tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[3], 0.015);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_TRUE(tm.basalConnections.dataForSegment(matchingSegment).destroyed);
+    EXPECT_EQ(0, tm.basalConnections.numSegments(expectedActiveCell));
+  }
+
+  /**
+   * When a column with a matching segment isn't activated, punish the matching
+   * segment.
+   *
+   * To exercise the implementation:
+   *
+   *  - Use cells before, between, and after the active columns.
+   *  - Use segments that are matching-but-not-active and matching-and-active.
+   */
+  TEST(ExtendedTemporalMemoryTest, PunishMatchingSegmentsInInactiveColumns)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt numActiveColumns = 1;
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[1] = {1};
+    const CellIdx previousInactiveCell = 81;
+
+    Segment activeSegment = tm.basalConnections.createSegment(42);
+    Synapse activeSynapse1 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
+    Synapse activeSynapse2 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
+    Synapse activeSynapse3 =
+      tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
+    Synapse inactiveSynapse1 =
+      tm.basalConnections.createSynapse(activeSegment, previousInactiveCell, 0.5);
+
+    Segment matchingSegment = tm.basalConnections.createSegment(43);
+    Synapse activeSynapse4 =
+      tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[0], 0.5);
+    Synapse activeSynapse5 =
+      tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[1], 0.5);
+    Synapse inactiveSynapse2 =
+      tm.basalConnections.createSynapse(matchingSegment, previousInactiveCell, 0.5);
+
+    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, activeColumns, true);
+
+    EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse2).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse3).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse4).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse5).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.50, tm.basalConnections.dataForSynapse(inactiveSynapse1).permanence,
+                EPSILON);
+    EXPECT_NEAR(0.50, tm.basalConnections.dataForSynapse(inactiveSynapse2).permanence,
+                EPSILON);
+  }
+
+  /**
+   * In a bursting column with no matching segments, a segment should be added
+   * to the cell with the fewest segments. When there's a tie, choose randomly.
+   */
+  TEST(ExtendedTemporalMemoryTest, AddSegmentToCellWithFewestSegments)
+  {
+    bool grewOnCell1 = false;
+    bool grewOnCell2 = false;
+    for (UInt seed = 0; seed < 100; seed++)
+    {
+      ExtendedTemporalMemory tm(
+        /*columnDimensions*/ {32},
+        /*cellsPerColumn*/ 4,
+        /*activationThreshold*/ 3,
+        /*initialPermanence*/ 0.2,
+        /*connectedPermanence*/ 0.50,
+        /*minThreshold*/ 2,
+        /*maxNewSynapseCount*/ 4,
+        /*permanenceIncrement*/ 0.10,
+        /*permanenceDecrement*/ 0.10,
+        /*predictedSegmentDecrement*/ 0.02,
+        /*formInternalBasalConnections*/ true,
+        /*seed*/ seed
+        );
+
+      // enough for 4 winner cells
+      const UInt previousActiveColumns[4] ={1, 2, 3, 4};
+      const UInt activeColumns[1] = {0};
+      const vector<CellIdx> previousActiveCells =
+        {4, 5, 6, 7}; // (there are more)
+      vector<CellIdx> nonmatchingCells = {0, 3};
+      vector<CellIdx> activeCells = {0, 1, 2, 3};
+
+      Segment segment1 = tm.basalConnections.createSegment(nonmatchingCells[0]);
+      tm.basalConnections.createSynapse(segment1, previousActiveCells[0], 0.5);
+      Segment segment2 = tm.basalConnections.createSegment(nonmatchingCells[1]);
+      tm.basalConnections.createSynapse(segment2, previousActiveCells[1], 0.5);
+
+      tm.compute(4, previousActiveColumns, true);
+      tm.compute(1, activeColumns, true);
+
+      ASSERT_EQ(activeCells, tm.getActiveCells());
+
+      EXPECT_EQ(3, tm.basalConnections.numSegments());
+      EXPECT_EQ(1, tm.basalConnections.segmentsForCell(0).size());
+      EXPECT_EQ(1, tm.basalConnections.segmentsForCell(3).size());
+      EXPECT_EQ(1, tm.basalConnections.numSynapses(segment1));
+      EXPECT_EQ(1, tm.basalConnections.numSynapses(segment2));
+
+      Segment grownSegment;
+      vector<Segment> segments = tm.basalConnections.segmentsForCell(1);
+      if (segments.empty())
+      {
+        vector<Segment> segments2 = tm.basalConnections.segmentsForCell(2);
+        EXPECT_FALSE(segments2.empty());
+        grewOnCell2 = true;
+        segments.insert(segments.end(), segments2.begin(), segments2.end());
+      }
+      else
+      {
+        grewOnCell1 = true;
+      }
+
+      ASSERT_EQ(1, segments.size());
+      vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(segments[0]);
+      EXPECT_EQ(4, synapses.size());
+
+      set<CellIdx> columnChecklist(previousActiveColumns, previousActiveColumns+4);
+
+      for (Synapse synapse : synapses)
+      {
+        SynapseData synapseData = tm.basalConnections.dataForSynapse(synapse);
+        EXPECT_NEAR(0.2, synapseData.permanence, EPSILON);
+
+        UInt32 column = (UInt)tm.columnForCell(synapseData.presynapticCell);
+        auto position = columnChecklist.find(column);
+        EXPECT_NE(columnChecklist.end(), position);
+        columnChecklist.erase(position);
+      }
+      EXPECT_TRUE(columnChecklist.empty());
+    }
+
+    EXPECT_TRUE(grewOnCell1);
+    EXPECT_TRUE(grewOnCell2);
+  }
+
+  /**
+   * With learning disabled, generate some predicted active columns, predicted
+   * inactive columns, and nonpredicted active columns. The connections should
+   * not change.
+   */
+  TEST(ExtendedTemporalMemoryTest, ConnectionsNeverChangeWhenLearningDisabled)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    const UInt previousActiveColumns[1] = {0};
+    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
+    const UInt activeColumns[2] = {
+      1, // predicted
+      2  // bursting
+    };
+    const CellIdx previousInactiveCell = 81;
+    const vector<CellIdx> expectedActiveCells = {4};
+
+    Segment correctActiveSegment =
+      tm.basalConnections.createSegment(expectedActiveCells[0]);
+    tm.basalConnections.createSynapse(correctActiveSegment,
+                                      previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(correctActiveSegment,
+                                      previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(correctActiveSegment,
+                                      previousActiveCells[2], 0.5);
+
+    Segment wrongMatchingSegment = tm.basalConnections.createSegment(43);
+    tm.basalConnections.createSynapse(wrongMatchingSegment,
+                                      previousActiveCells[0], 0.5);
+    tm.basalConnections.createSynapse(wrongMatchingSegment,
+                                      previousActiveCells[1], 0.5);
+    tm.basalConnections.createSynapse(wrongMatchingSegment,
+                                      previousInactiveCell, 0.5);
+
+    Connections before = tm.basalConnections;
+
+    tm.compute(1, previousActiveColumns, false);
+    tm.compute(2, activeColumns, false);
+
+    EXPECT_EQ(before, tm.basalConnections);
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testColumnForCell1D)
+  {
+    ExtendedTemporalMemory tm;
+    tm.initialize(vector<UInt>{2048}, 5);
+
+    ASSERT_EQ(0, tm.columnForCell(0));
+    ASSERT_EQ(0, tm.columnForCell(4));
+    ASSERT_EQ(1, tm.columnForCell(5));
+    ASSERT_EQ(2047, tm.columnForCell(10239));
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testColumnForCell2D)
+  {
+    ExtendedTemporalMemory tm;
+    tm.initialize(vector<UInt>{64, 64}, 4);
+
+    ASSERT_EQ(0, tm.columnForCell(0));
+    ASSERT_EQ(0, tm.columnForCell(3));
+    ASSERT_EQ(1, tm.columnForCell(4));
+    ASSERT_EQ(4095, tm.columnForCell(16383));
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testColumnForCellInvalidCell)
+  {
+    ExtendedTemporalMemory tm;
+    tm.initialize(vector<UInt>{64, 64}, 4);
+
+    EXPECT_NO_THROW(tm.columnForCell(16383));
+    EXPECT_THROW(tm.columnForCell(16384), std::exception);
+    EXPECT_THROW(tm.columnForCell(-1), std::exception);
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testNumberOfColumns)
+  {
+    ExtendedTemporalMemory tm;
+    tm.initialize(vector<UInt>{64, 64}, 32);
+
+    int numOfColumns = tm.numberOfColumns();
+    ASSERT_EQ(numOfColumns, 64 * 64);
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testNumberOfCells)
+  {
+    ExtendedTemporalMemory tm;
+    tm.initialize(vector<UInt>{64, 64}, 32);
+
+    Int numberOfCells = tm.numberOfCells();
+    ASSERT_EQ(numberOfCells, 64 * 64 * 32);
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testSaveLoad)
+  {
+    const char* filename = "ExtendedTemporalMemorySerialization.tmp";
+    ExtendedTemporalMemory tm1, tm2;
+    vector<UInt> columnDim;
+    UInt numColumns = 12;
+
+    columnDim.push_back(numColumns);
+    tm1.initialize(columnDim);
+
+    ofstream outfile;
+    outfile.open(filename, ios::binary);
+    tm1.save(outfile);
+    outfile.close();
+
+    ifstream infile(filename, ios::binary);
+    tm2.load(infile);
+    infile.close();
+
+    check_tm_eq(tm1, tm2);
+
+    int ret = ::remove(filename);
+    ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
+  }
+
+  TEST(ExtendedTemporalMemoryTest, testWrite)
+  {
+    ExtendedTemporalMemory tm1, tm2;
+
+    tm1.initialize({ 100 }, 4, 7, 0.37, 0.58, 4, 18, 0.23, 0.08, 0.0, 91);
+
+    // Run some data through before serializing
+    /*
+      PatternMachine patternMachine = PatternMachine(100, 4);
+      SequenceMachine sequenceMachine = SequenceMachine(self.patternMachine);
+      Sequence sequence = self.sequenceMachine.generateFromNumbers(range(5));
+    */
+    vector<vector<UInt>> sequence =
+      {
+        { 83, 53, 70, 45 },
+        { 8, 65, 67, 59 },
+        { 25, 98, 99, 39 },
+        { 66, 11, 78, 14 },
+        { 96, 87, 69, 95 } };
+
+    for (UInt i = 0; i < 3; i++)
+    {
+      for (vector<UInt> pattern : sequence)
+        tm1.compute(pattern.size(), pattern.data());
+    }
+
+    // Write and read back the proto
+    stringstream ss;
+    tm1.write(ss);
+    tm2.read(ss);
+
+    // Check that the two temporal memory objects have the same attributes
+    check_tm_eq(tm1, tm2);
+
+    tm1.compute(sequence[0].size(), sequence[0].data());
+    tm2.compute(sequence[0].size(), sequence[0].data());
+    ASSERT_EQ(tm1.getActiveCells(), tm2.getActiveCells());
+    ASSERT_EQ(tm1.getWinnerCells(), tm2.getWinnerCells());
+    ASSERT_EQ(tm1.basalConnections, tm2.basalConnections);
+
+    tm1.compute(sequence[3].size(), sequence[3].data());
+    tm2.compute(sequence[3].size(), sequence[3].data());
+    ASSERT_EQ(tm1.getActiveCells(), tm2.getActiveCells());
+
+    ASSERT_EQ(tm1.getActiveBasalSegments(), tm2.getActiveBasalSegments());
+    ASSERT_EQ(tm1.getMatchingBasalSegments(), tm2.getMatchingBasalSegments());
+
+    ASSERT_EQ(tm1.getWinnerCells(), tm2.getWinnerCells());
+    ASSERT_EQ(tm1.basalConnections, tm2.basalConnections);
+
+    check_tm_eq(tm1, tm2);
+  }
+}

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -1140,6 +1140,53 @@ namespace {
   }
 
   /**
+   * When the best matching segment has more than maxNewSynapseCount matching
+   * synapses, don't grow new synapses. This test is specifically aimed at
+   * unexpected behavior with negative numbers and unsigned integers.
+   */
+  TEST(ExtendedTemporalMemoryTest, MaxNewSynapseCountOverflow)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.2,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.02,
+      /*formInternalBasalConnections*/ true,
+      /*seed*/ 42
+      );
+
+    Segment segment = tm.basalConnections.createSegment(8);
+    tm.basalConnections.createSynapse(segment, 0, 0.2);
+    tm.basalConnections.createSynapse(segment, 1, 0.2);
+    tm.basalConnections.createSynapse(segment, 2, 0.2);
+    tm.basalConnections.createSynapse(segment, 3, 0.2);
+    tm.basalConnections.createSynapse(segment, 4, 0.2);
+    Synapse sampleSynapse = tm.basalConnections.createSynapse(segment, 5, 0.2);
+    tm.basalConnections.createSynapse(segment, 6, 0.2);
+    tm.basalConnections.createSynapse(segment, 7, 0.2);
+
+    const UInt previousActiveColumns[4] = {0, 1, 3, 4};
+    tm.compute(4, previousActiveColumns);
+
+    ASSERT_EQ(1, tm.getMatchingBasalSegments().size());
+
+    const UInt activeColumns[1] = {2};
+    tm.compute(1, activeColumns);
+
+    // Make sure the segment has learned.
+    ASSERT_NEAR(0.3, tm.basalConnections.dataForSynapse(sampleSynapse).permanence,
+                EPSILON);
+
+    EXPECT_EQ(8, tm.basalConnections.numSynapses(segment));
+  }
+
+  /**
    * With learning disabled, generate some predicted active columns, predicted
    * inactive columns, and nonpredicted active columns. The connections should
    * not change.

--- a/src/test/unit/utils/GroupByTest.cpp
+++ b/src/test/unit/utils/GroupByTest.cpp
@@ -34,6 +34,12 @@ using std::vector;
 using nupic::group_by;
 using nupic::iter_group_by;
 
+// GCC warns that `key` might be uninitialized when initializing the
+// `actualValue`
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 namespace {
 
   struct ReturnValue1 {
@@ -498,3 +504,5 @@ namespace {
     EXPECT_EQ(expectedValues.size(), i);
   }
 }
+
+#pragma GCC diagnostic pop

--- a/src/test/unit/utils/GroupByTest.cpp
+++ b/src/test/unit/utils/GroupByTest.cpp
@@ -1,0 +1,500 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Implementation of unit tests for group_by
+ */
+
+#include <nupic/utils/GroupBy.hpp>
+#include "gtest/gtest.h"
+
+using std::tuple;
+using std::tie;
+using std::vector;
+
+using nupic::group_by;
+using nupic::iter_group_by;
+
+namespace {
+
+  struct ReturnValue1 {
+    int key;
+    vector<int> results0;
+  };
+
+  TEST(GroupByTest, OneSequence)
+  {
+    const vector<int> sequence0 = {7, 12, 12, 16};
+
+    auto identity = [](int a) { return a; };
+
+    const vector<ReturnValue1> expectedValues = {
+      {7, {7}},
+      {12, {12, 12}},
+      {16, {16}}
+    };
+
+    //
+    // group_by
+    //
+    size_t i = 0;
+    for (auto data : group_by(sequence0, identity))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0;
+
+      tie(key,
+          begin0, end0) = data;
+
+      const ReturnValue1 actualValue =
+        {key, {begin0, end0}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+
+      i++;
+    }
+
+    //
+    // iter_group_by
+    //
+    i = 0;
+    for (auto data : iter_group_by(
+           sequence0.begin(), sequence0.end(), identity))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0;
+
+      tie(key,
+          begin0, end0) = data;
+
+      const ReturnValue1 actualValue =
+        {key, {begin0, end0}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+
+      i++;
+    }
+
+    EXPECT_EQ(expectedValues.size(), i);
+  }
+
+
+
+  struct ReturnValue2 {
+    int key;
+    vector<int> results0;
+    vector<int> results1;
+  };
+
+  TEST(GroupByTest, TwoSequences)
+  {
+    const vector<int> sequence0 = {7, 12, 16};
+    const vector<int> sequence1 = {3, 4, 5};
+
+    auto identity = [](int a) { return a; };
+    auto times3 = [](int a) { return a*3; };
+
+    const vector<ReturnValue2> expectedValues = {
+      {7, {7}, {}},
+      {9, {}, {3}},
+      {12, {12}, {4}},
+      {15, {}, {5}},
+      {16, {16}, {}}
+    };
+
+    //
+    // group_by
+    //
+    size_t i = 0;
+    for (auto data : group_by(sequence0, identity,
+                              sequence1, times3))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1) = data;
+
+      const ReturnValue2 actualValue =
+        {key, {begin0, end0}, {begin1, end1}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+
+      i++;
+    }
+
+    //
+    // iter_group_by
+    //
+    i = 0;
+    for (auto data : iter_group_by(
+           sequence0.begin(), sequence0.end(), identity,
+           sequence1.begin(), sequence1.end(), times3))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1) = data;
+
+      const ReturnValue2 actualValue =
+        {key, {begin0, end0}, {begin1, end1}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+
+      i++;
+    }
+
+    EXPECT_EQ(expectedValues.size(), i);
+  }
+
+
+
+  struct ReturnValue3 {
+    int key;
+    vector<int> results0;
+    vector<int> results1;
+    vector<int> results2;
+  };
+
+  TEST(GroupByTest, ThreeSequences)
+  {
+    const vector<int> sequence0 = {7, 12, 16};
+    const vector<int> sequence1 = {3, 4, 5};
+    const vector<int> sequence2 = {3, 3, 4, 5};
+
+    auto identity = [](int a) { return a; };
+    auto times3 = [](int a) { return a*3; };
+    auto times4 = [](int a) { return a*4; };
+
+    const vector<ReturnValue3> expectedValues = {
+      {7, {7}, {}, {}},
+      {9, {}, {3}, {}},
+      {12, {12}, {4}, {3, 3}},
+      {15, {}, {5}, {}},
+      {16, {16}, {}, {4}},
+      {20, {}, {}, {5}}
+    };
+
+    //
+    // group_by
+    //
+    size_t i = 0;
+    for (auto data : group_by(sequence0, identity,
+                              sequence1, times3,
+                              sequence2, times4))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2) = data;
+
+      const ReturnValue3 actualValue =
+        {key, {begin0, end0}, {begin1, end1}, {begin2, end2}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+
+      i++;
+    }
+
+    //
+    // iter_group_by
+    //
+    i = 0;
+    for (auto data : iter_group_by(
+           sequence0.begin(), sequence0.end(), identity,
+           sequence1.begin(), sequence1.end(), times3,
+           sequence2.begin(), sequence2.end(), times4))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2) = data;
+
+      const ReturnValue3 actualValue =
+        {key, {begin0, end0}, {begin1, end1}, {begin2, end2}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+
+      i++;
+    }
+
+    EXPECT_EQ(expectedValues.size(), i);
+  }
+
+
+  struct ReturnValue4 {
+    int key;
+    vector<int> results0;
+    vector<int> results1;
+    vector<int> results2;
+    vector<int> results3;
+  };
+
+  TEST(GroupByTest, FourSequences)
+  {
+    const vector<int> sequence0 = {7, 12, 16};
+    const vector<int> sequence1 = {3, 4, 5};
+    const vector<int> sequence2 = {3, 3, 4, 5};
+    const vector<int> sequence3 = {3, 3, 4, 5};
+
+    auto identity = [](int a) { return a; };
+    auto times3 = [](int a) { return a*3; };
+    auto times4 = [](int a) { return a*4; };
+    auto times5 = [](int a) { return a*5; };
+
+    const vector<ReturnValue4> expectedValues = {
+      {7, {7}, {}, {}, {}},
+      {9, {}, {3}, {}, {}},
+      {12, {12}, {4}, {3, 3}, {}},
+      {15, {}, {5}, {}, {3, 3}},
+      {16, {16}, {}, {4}, {}},
+      {20, {}, {}, {5}, {4}},
+      {25, {}, {}, {}, {5}}
+    };
+
+    //
+    // group_by
+    //
+    size_t i = 0;
+    for (auto data : group_by(sequence0, identity,
+                              sequence1, times3,
+                              sequence2, times4,
+                              sequence3, times5))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2,
+        begin3, end3;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2,
+          begin3, end3) = data;
+
+      const ReturnValue4 actualValue =
+        {key, {begin0, end0}, {begin1, end1}, {begin2, end2}, {begin3, end3}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+      EXPECT_EQ(expectedValues[i].results3, actualValue.results3);
+
+      i++;
+    }
+
+    //
+    // iter_group_by
+    //
+    i = 0;
+    for (auto data : iter_group_by(
+           sequence0.begin(), sequence0.end(), identity,
+           sequence1.begin(), sequence1.end(), times3,
+           sequence2.begin(), sequence2.end(), times4,
+           sequence3.begin(), sequence3.end(), times5))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2,
+        begin3, end3;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2,
+          begin3, end3) = data;
+
+      const ReturnValue4 actualValue =
+        {key, {begin0, end0}, {begin1, end1}, {begin2, end2}, {begin3, end3}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+      EXPECT_EQ(expectedValues[i].results3, actualValue.results3);
+
+      i++;
+    }
+
+    EXPECT_EQ(expectedValues.size(), i);
+  }
+
+
+
+  struct ReturnValue5 {
+    int key;
+    vector<int> results0;
+    vector<int> results1;
+    vector<int> results2;
+    vector<int> results3;
+    vector<int> results4;
+  };
+
+  TEST(GroupByTest, FiveSequences)
+  {
+    const vector<int> sequence0 = {7, 12, 16};
+    const vector<int> sequence1 = {3, 4, 5};
+    const vector<int> sequence2 = {3, 3, 4, 5};
+    const vector<int> sequence3 = {3, 3, 4, 5};
+    const vector<int> sequence4 = {2, 2, 3};
+
+    auto identity = [](int a) { return a; };
+    auto times3 = [](int a) { return a*3; };
+    auto times4 = [](int a) { return a*4; };
+    auto times5 = [](int a) { return a*5; };
+    auto times6 = [](int a) { return a*6; };
+
+    const vector<ReturnValue5> expectedValues = {
+      {7, {7}, {}, {}, {}, {}},
+      {9, {}, {3}, {}, {}, {}},
+      {12, {12}, {4}, {3, 3}, {}, {2, 2}},
+      {15, {}, {5}, {}, {3, 3}, {}},
+      {16, {16}, {}, {4}, {}, {}},
+      {18, {}, {}, {}, {}, {3}},
+      {20, {}, {}, {5}, {4}, {}},
+      {25, {}, {}, {}, {5}, {}}
+    };
+
+    //
+    // group_by
+    //
+    size_t i = 0;
+    for (auto data : group_by(sequence0, identity,
+                              sequence1, times3,
+                              sequence2, times4,
+                              sequence3, times5,
+                              sequence4, times6))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2,
+        begin3, end3,
+        begin4, end4;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2,
+          begin3, end3,
+          begin4, end4) = data;
+
+      const ReturnValue5 actualValue =
+        {key,
+         {begin0, end0}, {begin1, end1},
+         {begin2, end2}, {begin3, end3},
+         {begin4, end4}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+      EXPECT_EQ(expectedValues[i].results3, actualValue.results3);
+      EXPECT_EQ(expectedValues[i].results4, actualValue.results4);
+
+      i++;
+    }
+
+    //
+    // iter_group_by
+    //
+    i = 0;
+    for (auto data : iter_group_by(
+           sequence0.begin(), sequence0.end(), identity,
+           sequence1.begin(), sequence1.end(), times3,
+           sequence2.begin(), sequence2.end(), times4,
+           sequence3.begin(), sequence3.end(), times5,
+           sequence4.begin(), sequence4.end(), times6))
+    {
+      int key;
+      vector<int>::const_iterator
+        begin0, end0,
+        begin1, end1,
+        begin2, end2,
+        begin3, end3,
+        begin4, end4;
+
+      tie(key,
+          begin0, end0,
+          begin1, end1,
+          begin2, end2,
+          begin3, end3,
+          begin4, end4) = data;
+
+      const ReturnValue5 actualValue =
+        {key,
+         {begin0, end0}, {begin1, end1},
+         {begin2, end2}, {begin3, end3},
+         {begin4, end4}};
+
+      EXPECT_EQ(expectedValues[i].key, actualValue.key);
+      EXPECT_EQ(expectedValues[i].results0, actualValue.results0);
+      EXPECT_EQ(expectedValues[i].results1, actualValue.results1);
+      EXPECT_EQ(expectedValues[i].results2, actualValue.results2);
+      EXPECT_EQ(expectedValues[i].results3, actualValue.results3);
+      EXPECT_EQ(expectedValues[i].results4, actualValue.results4);
+
+      i++;
+    }
+
+    EXPECT_EQ(expectedValues.size(), i);
+  }
+}


### PR DESCRIPTION
The SWIG bindings give it an identical interface to the current Python ExtendedTemporalMemory.

Introduces the distinction "basal" vs "apical".

Additional changes:

- Rework getLeastUsedCell to be non-allocating.
- Put ExcitedColumns in a namespace so that it doesn't collide with the one in TemporalMemory.
- Fix a serialization bug that is also in TemporalMemory. save and load weren't writing and reading in the same order.
- Fix a bad bug with external cells: I wasn't shifting their index during activateDendrites
- Copy-paste a set of ExtendedTemporalMemory unit tests


This passes the [extensive_etm_test](https://github.com/numenta/nupic.research/blob/5230a39e3adf9f62aa16d146ad8415d0bfb9f7da/tests/extended_temporal_memory/extensive_etm_test.py), with the following caveats:

- It doesn't support learnOnOneCell, so it doesn't pass testE12, testE13, testE14, testE15, testE16, testE17, or testO10
- It doesn't pass test A9 or testA11,  but neither does the Python ETM after fixing bugs https://github.com/numenta/nupic.research/issues/583 and https://github.com/numenta/nupic.research/issues/584

Fixes #1015