### PR TITLE
Updates bindings to handle SDR classifier

### DIFF
--- a/src/nupic/algorithms/FastClaClassifier.cpp
+++ b/src/nupic/algorithms/FastClaClassifier.cpp
@@ -54,7 +54,8 @@ namespace nupic
           const vector<UInt>& steps, Real64 alpha, Real64 actValueAlpha,
           UInt verbosity) : alpha_(alpha), actValueAlpha_(actValueAlpha),
           learnIteration_(0), recordNumMinusLearnIteration_(0),
-          maxBucketIdx_(0), version_(Version), verbosity_(verbosity)
+          maxBucketIdx_(0), version_(claClassifierVersion),
+          verbosity_(verbosity)
       {
         for (const auto & step : steps)
         {
@@ -440,7 +441,7 @@ namespace nupic
         NTA_CHECK(marker == "~FastCLAClassifier");
 
         // Update the version number.
-        version_ = Version;
+        version_ = claClassifierVersion;
       }
 
       void FastCLAClassifier::write(ClaClassifierProto::Builder& proto) const

--- a/src/nupic/algorithms/FastClaClassifier.hpp
+++ b/src/nupic/algorithms/FastClaClassifier.hpp
@@ -45,7 +45,7 @@ namespace nupic
     namespace cla_classifier
     {
 
-      const UInt Version = 1;
+      const UInt claClassifierVersion = 1;
 
       class BitHistory;
       class ClassifierResult;

--- a/src/nupic/algorithms/SDRClassifier.cpp
+++ b/src/nupic/algorithms/SDRClassifier.cpp
@@ -53,8 +53,8 @@ namespace nupic
           const vector<UInt>& steps, Real64 alpha, Real64 actValueAlpha,
           UInt verbosity) : steps_(steps), alpha_(alpha),
           actValueAlpha_(actValueAlpha), maxInputIdx_(0), maxBucketIdx_(0),
-          actualValues_({0.0}), actualValuesSet_({false}), version_(Version),
-          verbosity_(verbosity)
+          actualValues_({0.0}), actualValuesSet_({false}),
+          version_(sdrClassifierVersion), verbosity_(verbosity)
       {
         sort(steps_.begin(), steps_.end());
         if (steps_.size() > 0)
@@ -435,7 +435,7 @@ namespace nupic
         NTA_CHECK(marker == "~SDRClassifier");
 
         // Update the version number.
-        version_ = Version;
+        version_ = sdrClassifierVersion;
       }
 
       void SDRClassifier::write(SdrClassifierProto::Builder& proto) const 

--- a/src/nupic/algorithms/SDRClassifier.hpp
+++ b/src/nupic/algorithms/SDRClassifier.hpp
@@ -48,7 +48,7 @@ namespace nupic
     namespace sdr_classifier
     {
 
-      const UInt Version = 1;
+      const UInt sdrClassifierVersion = 1;
 
       typedef Dense<UInt, Real64> Matrix;
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -101,6 +101,7 @@ _ALGORITHMS = _algorithms
 #include <nupic/algorithms/ClassifierResult.hpp>
 #include <nupic/algorithms/Connections.hpp>
 #include <nupic/algorithms/FastClaClassifier.hpp>
+#include <nupic/algorithms/SDRClassifier.hpp>
 #include <nupic/algorithms/InSynapse.hpp>
 #include <nupic/algorithms/OutSynapse.hpp>
 #include <nupic/algorithms/SegmentUpdate.hpp>
@@ -133,6 +134,7 @@ using namespace nupic::algorithms::connections;
 using namespace nupic::algorithms::temporal_memory;
 using namespace nupic::algorithms::Cells4;
 using namespace nupic::algorithms::cla_classifier;
+using namespace nupic::algorithms::sdr_classifier;
 using namespace nupic;
 
 #define CHECKSIZE(var) \
@@ -1502,6 +1504,170 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
   %#else
     throw std::logic_error(
         "FastCLAClassifier.read is not implemented when compiled with CAPNP_LITE=1.");
+  %#endif
+  }
+
+}
+
+
+%include <nupic/algorithms/SDRClassifier.hpp>
+
+%pythoncode %{
+  import numpy
+%}
+
+%extend nupic::algorithms::sdr_classifier::SDRClassifier
+{
+  %pythoncode %{
+    VERSION = 1
+
+    def __init__(self, steps=(1,), alpha=0.001, actValueAlpha=0.3, verbosity=0):
+      self.this = _ALGORITHMS.new_SDRClassifier(
+          steps, alpha, actValueAlpha, verbosity)
+      self.valueToCategory = {}
+      self.version = SDRClassifier.VERSION
+
+    def compute(self, recordNum, patternNZ, classification, learn, infer):
+      isNone = False
+      noneSentinel = 3.14159
+
+      if type(classification["actValue"]) in (int, float):
+        actValue = classification["actValue"]
+        category = False
+      elif classification["actValue"] is None:
+        # Use the sentinel value so we know if it gets used in actualValues
+        # returned.
+        actValue = noneSentinel
+        # Turn learning off this step.
+        learn = False
+        category = False
+        # This does not get used when learning is disabled anyway.
+        classification["bucketIdx"] = 0
+        isNone = True
+      else:
+        actValue = int(classification["bucketIdx"])
+        category = True
+
+      result = self.convertedCompute(
+          recordNum, patternNZ, int(classification["bucketIdx"]),
+          actValue, category, learn, infer)
+
+      if isNone:
+        for i, v in enumerate(result["actualValues"]):
+          if v - noneSentinel < 0.00001:
+            result["actualValues"][i] = None
+      arrayResult = dict((k, numpy.array(v)) if k != "actualValues" else (k, v)
+                         for k, v in result.iteritems())
+
+      if self.valueToCategory or isinstance(classification["actValue"], basestring):
+        # Convert the bucketIdx back to the original value.
+        for i in xrange(len(arrayResult["actualValues"])):
+          if arrayResult["actualValues"][i] is not None:
+            arrayResult["actualValues"][i] = self.valueToCategory.get(int(
+                arrayResult["actualValues"][i]), classification["actValue"])
+
+        self.valueToCategory[actValue] = classification["actValue"]
+
+      return arrayResult
+
+    def __getstate__(self):
+      # Save the local attributes but override the C++ classifier with the
+      # string representation.
+      d = dict(self.__dict__)
+      d["this"] = self.getCState()
+      return d
+
+    def __setstate__(self, state):
+      # Create an empty C++ classifier and populate it from the serialized
+      # string.
+      self.this = _ALGORITHMS.new_SDRClassifier()
+      if isinstance(state, str):
+        self.loadFromString(state)
+        self.valueToCategory = {}
+      else:
+        assert state["version"] == 0
+        self.loadFromString(state["this"])
+        # Use the rest of the state to set local Python attributes.
+        del state["this"]
+        self.__dict__.update(state)
+
+    @classmethod
+    def read(cls, proto):
+      instance = cls()
+      instance.convertedRead(proto)
+      return instance
+  %}
+
+  void loadFromString(const std::string& inString)
+  {
+    std::istringstream inStream(inString);
+    self->load(inStream);
+  }
+
+  PyObject* getCState()
+  {
+    SharedPythonOStream py_s(self->persistentSize());
+    std::ostream& s = py_s.getStream();
+    // TODO: Consider writing floats as binary instead.
+    s.flags(ios::scientific);
+    s.precision(numeric_limits<double>::digits10 + 1);
+    self->save(s);
+    return py_s.close();
+  }
+
+  PyObject* convertedCompute(UInt recordNum, const vector<UInt>& patternNZ,
+                             UInt bucketIdx, Real64 actValue, bool category,
+                             bool learn, bool infer)
+  {
+    ClassifierResult result;
+    self->compute(recordNum, patternNZ, bucketIdx, actValue, category,
+                  learn, infer, &result);
+    PyObject* d = PyDict_New();
+    for (map<Int, vector<Real64>*>::const_iterator it = result.begin();
+         it != result.end(); ++it)
+    {
+      PyObject* key;
+      if (it->first == -1)
+      {
+        key = PyString_FromString("actualValues");
+      } else {
+        key = PyInt_FromLong(it->first);
+      }
+
+      PyObject* value = PyList_New(it->second->size());
+      for (UInt i = 0; i < it->second->size(); ++i)
+      {
+        PyObject* pyActValue = PyFloat_FromDouble(it->second->at(i));
+        PyList_SetItem(value, i, pyActValue);
+      }
+
+      PyDict_SetItem(d, key, value);
+      Py_DECREF(value);
+    }
+    return d;
+  }
+
+  inline void write(PyObject* pyBuilder) const
+  {
+  %#if !CAPNP_LITE
+    SdrClassifierProto::Builder proto =
+        getBuilder<SdrClassifierProto>(pyBuilder);
+    self->write(proto);
+  %#else
+    throw std::logic_error(
+        "SDRClassifier.write is not implemented when compiled with CAPNP_LITE=1.");
+  %#endif
+  }
+
+  inline void convertedRead(PyObject* pyReader)
+  {
+  %#if !CAPNP_LITE
+    SdrClassifierProto::Reader proto =
+        getReader<SdrClassifierProto>(pyReader);
+    self->read(proto);
+  %#else
+    throw std::logic_error(
+        "SDRClassifier.read is not implemented when compiled with CAPNP_LITE=1.");
   %#endif
   }
 


### PR DESCRIPTION
Fixes #1019 (and, a bit too late, numenta/nupic#3231) by updating the bindings to include the new C++ SDRClassifier, which will be ready to use after this PR is merged.

There is also a slight update in a global variable's name in both CLA and SDR classifiers, as they were conflicting in the generated bindings.

@rhyolight @scottpurdy 