### PR TITLE
Fixes indexing bug in SDRClassifier serialization

### DIFF
--- a/src/nupic/algorithms/SDRClassifier.cpp
+++ b/src/nupic/algorithms/SDRClassifier.cpp
@@ -488,7 +488,7 @@ namespace nupic
           {
             for (UInt j = 0; j <= maxBucketIdx_; ++j)
             {
-              weightProto.set(k, stepWeightMatrix.second.at(i, j));
+              weightProto.set(idx, stepWeightMatrix.second.at(i, j));
               idx++;
             }
           }


### PR DESCRIPTION
Fixes #1026.

This was a bug which needed a specific situation to reproduce (using a de-serialized classifier for multi-step prediction).

Sorry @scottpurdy, hopefully we should be done with this...