### PR TITLE
Only activate cols with overlap with input vector.

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1177,9 +1177,9 @@ void SpatialPooler::inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
   Real arbitration = *max_element(overlaps.begin(), overlaps.end()) / 1000.0;
   vector<UInt> neighbors;
   for (UInt column = 0; column < numColumns_; column++) {
-    getNeighborsND_(column, columnDimensions_, inhibitionRadius_, false,
-                    neighbors);
     if (overlaps[column] > 0) {
+      getNeighborsND_(column, columnDimensions_, inhibitionRadius_, false,
+                      neighbors);
       UInt numActive = (UInt) (0.5 + (density * (neighbors.size() + 1)));
       UInt numBigger = 0;
       for (auto & neighbor : neighbors) {

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1187,7 +1187,7 @@ void SpatialPooler::inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
       }
     }
 
-    if (numBigger < numActive) {
+    if (overlaps[column] > 0 && numBigger < numActive) {
       activeColumns.push_back(column);
       overlaps[column] += arbitration;
     }

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1179,19 +1179,20 @@ void SpatialPooler::inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
   for (UInt column = 0; column < numColumns_; column++) {
     getNeighborsND_(column, columnDimensions_, inhibitionRadius_, false,
                     neighbors);
-    UInt numActive = (UInt) (0.5 + (density * (neighbors.size() + 1)));
-    UInt numBigger = 0;
-    for (auto & neighbor : neighbors) {
-      if (overlaps[neighbor] > overlaps[column]) {
-        numBigger++;
+    if (overlaps[column] > 0) {
+      UInt numActive = (UInt) (0.5 + (density * (neighbors.size() + 1)));
+      UInt numBigger = 0;
+      for (auto & neighbor : neighbors) {
+        if (overlaps[neighbor] > overlaps[column]) {
+          numBigger++;
+        }
+      }
+
+      if (numBigger < numActive) {
+        activeColumns.push_back(column);
+        overlaps[column] += arbitration;
       }
     }
-
-    if (overlaps[column] > 0 && numBigger < numActive) {
-      activeColumns.push_back(column);
-      overlaps[column] += arbitration;
-    }
-
   }
 }
 

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1363,6 +1363,22 @@ namespace {
     ASSERT_TRUE(!check_vector_eq(activeColumns, activeColumnsGlobal));
     ASSERT_TRUE(check_vector_eq(activeColumns, activeColumnsLocal));
 
+  }
+
+TEST(SpatialPoolerTest, testInhibitColumnsActivatesOnlyColumnsWithOverlap)
+  {
+    SpatialPooler sp;
+    setup(sp, 10,10);
+
+    vector<Real> overlapsReal;
+    vector<Real> overlaps;
+    vector<UInt> activeColumns;
+    vector<UInt> activeColumnsGlobal;
+    vector<UInt> activeColumnsLocal;
+    Real density;
+    UInt inhibitionRadius;
+    UInt numColumns;
+
     // Assert that only columns with overlap are activated
     numColumns = 16;
     density = 0.5;
@@ -1380,7 +1396,6 @@ namespace {
     }
 
   }
-
   TEST(SpatialPoolerTest, testInhibitColumnsGlobal)
   {
     SpatialPooler sp;

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1376,10 +1376,6 @@ namespace {
     sp.inhibitColumnsLocal_(overlapsReal, density, activeColumnsLocal);
 
     for (auto & activeColumn : activeColumnsLocal) {
-      cout << "\n================================================";
-      cout << "\n" + std::to_string(activeColumn);
-      cout << "\n" + std::to_string(overlaps[activeColumn]);
-      cout << "\n================================================";
       ASSERT_TRUE(overlapsArray2[activeColumn] > 0);
     }
 

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1383,10 +1383,6 @@ namespace {
       ASSERT_TRUE(overlapsArray2[activeColumn] > 0);
     }
 
-
-    // ASSERT_TRUE(!check_vector_eq(activeColumns, activeColumnsGlobal));
-    // ASSERT_TRUE(check_vector_eq(activeColumns, activeColumnsLocal));
-
   }
 
   TEST(SpatialPoolerTest, testInhibitColumnsGlobal)

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1362,6 +1362,31 @@ namespace {
 
     ASSERT_TRUE(!check_vector_eq(activeColumns, activeColumnsGlobal));
     ASSERT_TRUE(check_vector_eq(activeColumns, activeColumnsLocal));
+
+    // Assert that only columns with overlap are activated
+    numColumns = 16;
+    density = 0.5;
+    inhibitionRadius = 2;
+    Real overlapsArray2[16] = {1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0};
+
+    sp.setGlobalInhibition(false);
+    sp.setInhibitionRadius(inhibitionRadius);
+
+    overlapsReal.assign(&overlapsArray2[0], &overlapsArray2[numColumns]);
+    sp.inhibitColumnsLocal_(overlapsReal, density, activeColumnsLocal);
+
+    for (auto & activeColumn : activeColumnsLocal) {
+      cout << "\n================================================";
+      cout << "\n" + std::to_string(activeColumn);
+      cout << "\n" + std::to_string(overlaps[activeColumn]);
+      cout << "\n================================================";
+      ASSERT_TRUE(overlapsArray2[activeColumn] > 0);
+    }
+
+
+    // ASSERT_TRUE(!check_vector_eq(activeColumns, activeColumnsGlobal));
+    // ASSERT_TRUE(check_vector_eq(activeColumns, activeColumnsLocal));
+
   }
 
   TEST(SpatialPoolerTest, testInhibitColumnsGlobal)


### PR DESCRIPTION
Fixes #1053

Added additional condition to winner column selection that ensures the
column overlaps with input vector.