### PR TITLE
NUP-2300 Fix parallel build failure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -795,7 +795,7 @@ if (NUPIC_BUILD_PYEXT_MODULES)
     endif()
 
 
-    set(SWIG_MODULE_${MODULE_NAME}_EXTRA_DEPS ${extra_deps})
+    add_dependencies(${real_target} ${extra_deps})
     set_target_properties(${real_target} PROPERTIES
                           LINK_FLAGS "${link_flags}")
 


### PR DESCRIPTION
Fixes #1056

NUP-2300 use add_dependencies to set swig module dependencies instead of setting SWIG_MODULE_${MODULE_NAME}_EXTRA_DEPS, which doesn't work.

It looks like cmake's `set` function doesn't allow the destination variable name to be composed from other variables.