### PR TITLE
Grow synapses in predicted columns, not just bursting columns

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -729,6 +729,7 @@ SegmentExcitationTally::SegmentExcitationTally(
    numActiveSynapsesForSegment_(connections.nextFlatIdx_, 0),
    numMatchingSynapsesForSegment_(connections.nextFlatIdx_, 0)
 {
+  NTA_ASSERT(matchingPermanenceThreshold <= activePermanenceThreshold);
 }
 
 void SegmentExcitationTally::addActivePresynapticCell(CellIdx cell)

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -67,6 +67,7 @@ namespace nupic
         CellIdx cell;
 
         Segment(SegmentIdx idx, CellIdx cell) : idx(idx), cell(cell) {}
+        Segment(const Segment& s) : idx(s.idx), cell(s.cell) {}
         Segment() {}
 
         bool operator==(const Segment &other) const;

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -67,7 +67,6 @@ namespace nupic
         CellIdx cell;
 
         Segment(SegmentIdx idx, CellIdx cell) : idx(idx), cell(cell) {}
-        Segment(const Segment& s) : idx(s.idx), cell(s.cell) {}
         Segment() {}
 
         bool operator==(const Segment &other) const;

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -470,17 +470,14 @@ static void punishPredictedColumn(
   }
 }
 
-void TemporalMemory::compute(
-  UInt activeColumnsSize,
-  const UInt activeColumnsUnsorted[],
+void TemporalMemory::activateCells(
+  const vector<UInt>& activeColumns,
   bool learn)
 {
+  NTA_ASSERT(std::is_sorted(activeColumns.begin(), activeColumns.end()));
+
   const vector<CellIdx> prevActiveCells = std::move(activeCells_);
   const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
-
-  vector<UInt> activeColumns(activeColumnsUnsorted,
-                             activeColumnsUnsorted + activeColumnsSize);
-  std::sort(activeColumns.begin(), activeColumns.end());
 
   const auto columnForSegment =
     [&](const SegmentOverlap& s) { return s.segment.cell / cellsPerColumn_; };
@@ -537,7 +534,10 @@ void TemporalMemory::compute(
       }
     }
   }
+}
 
+void TemporalMemory::activateDendrites(bool learn)
+{
   activeSegments_.clear();
   matchingSegments_.clear();
   connections.computeActivity(activeCells_,
@@ -554,6 +554,20 @@ void TemporalMemory::compute(
 
     connections.startNewIteration();
   }
+}
+
+void TemporalMemory::compute(
+  UInt activeColumnsSize,
+  const UInt activeColumnsUnsorted[],
+  bool learn)
+{
+  vector<UInt> activeColumns(activeColumnsUnsorted,
+                             activeColumnsUnsorted + activeColumnsSize);
+  std::sort(activeColumns.begin(), activeColumns.end());
+
+  activateCells(activeColumns, learn);
+
+  activateDendrites(learn);
 }
 
 void TemporalMemory::reset(void)

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -320,6 +320,7 @@ static void activatePredictedColumn(
 
     if (activeOverlapsBegin != activeOverlapsEnd)
     {
+      // Active segments are a superset of matching segments.
       NTA_ASSERT(std::distance(activeOverlapsBegin, activeOverlapsEnd) == 1);
       NTA_ASSERT(std::distance(matchingOverlapsBegin, matchingOverlapsEnd) == 1);
 

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -182,6 +182,28 @@ namespace nupic {
         virtual void reset();
 
         /**
+         * Calculate the active cells, using the current active columns and
+         * dendrite segments. Grow and reinforce synapses.
+         *
+         * @param activeColumns
+         * A sorted list of active column indices.
+         *
+         * @param learn
+         * If true, reinforce / punish / grow synapses.
+         */
+        void activateCells(
+          const vector<UInt>& activeColumns, bool learn = true);
+
+        /**
+         * Calculate dendrite segment activity, using the current active cells.
+         *
+         * @param learn
+         * If true, segment activations will be recorded. This information is
+         * used during segment cleanup.
+         */
+        void activateDendrites(bool learn = true);
+
+        /**
          * Feeds input record through TM, performing inference and learning.
          *
          * @param activeColumnsSize Number of active columns

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -303,7 +303,8 @@ namespace nupic {
         void setMinThreshold(UInt);
 
         /**
-         * Returns the maximum new synapse count.
+         * Returns the maximum number of synapses that can be added to a segment
+         * in a single time step.
          *
          * @returns Integer number of maximum new synapse count
          */

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -127,6 +127,7 @@ void ExtendedTemporalMemory::initialize(
   NTA_CHECK(connectedPermanence >= 0.0 && connectedPermanence <= 1.0);
   NTA_CHECK(permanenceIncrement >= 0.0 && permanenceIncrement <= 1.0);
   NTA_CHECK(permanenceDecrement >= 0.0 && permanenceDecrement <= 1.0);
+  NTA_CHECK(minThreshold <= activationThreshold);
 
   // Save member variables
 

--- a/src/nupic/utils/GroupBy.hpp
+++ b/src/nupic/utils/GroupBy.hpp
@@ -71,9 +71,10 @@ namespace nupic
 
   template<typename Iterator0, typename KeyFn0,
            typename Element0 = decltype(*std::declval<Iterator0>()),
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   class GroupBy1
   {
   public:
@@ -189,9 +190,10 @@ namespace nupic
   // ==========================================================================
 
   template<typename Iterator0, typename KeyFn0,
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   static KeyType minFrontKey(KeyType frontrunner,
                              Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0)
   {
@@ -209,9 +211,10 @@ namespace nupic
            typename Iterator1, typename KeyFn1,
            typename Element0 = decltype(*std::declval<Iterator0>()),
            typename Element1 = decltype(*std::declval<Iterator1>()),
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   class GroupBy2
   {
   public:
@@ -376,9 +379,10 @@ namespace nupic
 
   template<typename Iterator0, typename KeyFn0,
            typename Iterator1, typename KeyFn1,
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   static KeyType minFrontKey(KeyType frontrunner,
                              Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
                              Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1)
@@ -404,9 +408,10 @@ namespace nupic
            typename Element0 = decltype(*std::declval<Iterator0>()),
            typename Element1 = decltype(*std::declval<Iterator1>()),
            typename Element2 = decltype(*std::declval<Iterator2>()),
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   class GroupBy3
   {
   public:
@@ -617,9 +622,10 @@ namespace nupic
   template<typename Iterator0, typename KeyFn0,
            typename Iterator1, typename KeyFn1,
            typename Iterator2, typename KeyFn2,
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   static KeyType minFrontKey(KeyType frontrunner,
                              Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
                              Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
@@ -653,9 +659,10 @@ namespace nupic
            typename Element1 = decltype(*std::declval<Iterator1>()),
            typename Element2 = decltype(*std::declval<Iterator2>()),
            typename Element3 = decltype(*std::declval<Iterator3>()),
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   class GroupBy4
   {
   public:
@@ -912,9 +919,10 @@ namespace nupic
            typename Iterator1, typename KeyFn1,
            typename Iterator2, typename KeyFn2,
            typename Iterator3, typename KeyFn3,
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   static KeyType minFrontKey(KeyType frontrunner,
                              Iterator0 begin0, Iterator0 end0, KeyFn0 keyFn0,
                              Iterator1 begin1, Iterator1 end1, KeyFn1 keyFn1,
@@ -956,9 +964,10 @@ namespace nupic
            typename Element2 = decltype(*std::declval<Iterator2>()),
            typename Element3 = decltype(*std::declval<Iterator3>()),
            typename Element4 = decltype(*std::declval<Iterator4>()),
-           typename KeyType = typename std::result_of<
-             KeyFn0(decltype(*std::declval<Iterator0>()))
-               >::type>
+           typename KeyType = typename std::remove_const<
+             typename std::result_of<
+               KeyFn0(decltype(*std::declval<Iterator0>()))
+                 >::type >::type>
   class GroupBy5
   {
   public:

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -773,6 +773,56 @@ namespace {
   }
 
   /**
+   * When a segment becomes active, grow synapses to previous winner cells.
+   *
+   * The number of grown synapses is calculated from the "matching segment"
+   * overlap, not the "active segment" overlap.
+   */
+  TEST(TemporalMemoryTest, ActiveSegmentGrowSynapsesAccordingToPotentialOverlap)
+  {
+    ExtendedTemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 2,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 1,
+      /*maxNewSynapseCount*/ 4,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*learnOnOneCell*/ false,
+      /*seed*/ 42
+      );
+
+    // Use 1 cell per column so that we have easy control over the winner cells.
+    const UInt previousActiveColumns[5] = {0, 1, 2, 3, 4};
+    const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3, 4};
+    const UInt activeColumns[1] = {5};
+
+    Segment activeSegment = tm.basalConnections.createSegment(5);
+    tm.basalConnections.createSynapse(activeSegment, 0, 0.5);
+    tm.basalConnections.createSynapse(activeSegment, 1, 0.5);
+    tm.basalConnections.createSynapse(activeSegment, 2, 0.2);
+
+    tm.compute(5, previousActiveColumns);
+
+    ASSERT_EQ(prevWinnerCells, tm.getWinnerCells());
+
+    tm.compute(1, activeColumns);
+
+    vector<Synapse> synapses = tm.basalConnections.synapsesForSegment(activeSegment);
+
+    ASSERT_EQ(4, synapses.size());
+
+    SynapseData synapseData = tm.basalConnections.dataForSynapse(synapses[3]);
+    EXPECT_NEAR(0.21, synapseData.permanence, EPSILON);
+    EXPECT_TRUE(synapseData.presynapticCell == prevWinnerCells[3] ||
+                synapseData.presynapticCell == prevWinnerCells[4]);
+  }
+
+  /**
    * When a synapse is punished for contributing to a wrong prediction, if its
    * permanence falls to 0 it should be destroyed.
    */

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -778,7 +778,7 @@ namespace {
    * The number of grown synapses is calculated from the "matching segment"
    * overlap, not the "active segment" overlap.
    */
-  TEST(TemporalMemoryTest, ActiveSegmentGrowSynapsesAccordingToPotentialOverlap)
+  TEST(ExtendedTemporalMemoryTest, ActiveSegmentGrowSynapsesAccordingToPotentialOverlap)
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},


### PR DESCRIPTION
Fixes #1058

This PR does a few things:

- Makes the TM and ETM learn on predicted segments. To keep this clean, I reworked some code, especially in the ETM.
- Makes the TM more similar to the ETM. Specifically, the implementations of `activatePredictedColumn`, and having the `activateCells` and `activateDendrites` phases.
- Does some last-minute ETM cleanup before we code the Python version. Specifically, stop making `learnOnCell` search the segments lists for the cell's segments -- calculate these before calling learnOnCell.