### PR TITLE
Remove const from segmentsForCell signature

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -253,7 +253,7 @@ void Connections::updateSynapsePermanence(const Synapse& synapse,
   dataForSynapse_(synapse).permanence = permanence;
 }
 
-vector<Segment> Connections::segmentsForCell(UInt32 cell) const
+vector<Segment> Connections::segmentsForCell(CellIdx cell)
 {
   vector<Segment> segments;
   segments.reserve(numSegments(cell));

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -320,7 +320,7 @@ namespace nupic
          *
          * @retval Segments on cell.
          */
-        std::vector<Segment> segmentsForCell(CellIdx cell) const;
+        std::vector<Segment> segmentsForCell(CellIdx cell);
 
         /**
          * Gets the synapses for a segment.


### PR DESCRIPTION
Needed in order for segmentsForCell() to work in python bindings.