### PR TITLE
TM: Abolish the SegmentOverlap

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -33,20 +33,23 @@
 
 #include <nupic/algorithms/Connections.hpp>
 
-using namespace std;
+
+using std::vector;
+using std::string;
+using std::endl;
 using namespace nupic;
 using namespace nupic::algorithms::connections;
 
 static const Permanence EPSILON = 0.00001;
 
-Connections::Connections(UInt32 numCells,
+Connections::Connections(CellIdx numCells,
                          SegmentIdx maxSegmentsPerCell,
                          SynapseIdx maxSynapsesPerSegment)
 {
   initialize(numCells, maxSegmentsPerCell, maxSynapsesPerSegment);
 }
 
-void Connections::initialize(UInt32 numCells,
+void Connections::initialize(CellIdx numCells,
                              SegmentIdx maxSegmentsPerCell,
                              SynapseIdx maxSynapsesPerSegment)
 {
@@ -73,7 +76,7 @@ void Connections::unsubscribe(UInt32 token)
   eventHandlers_.erase(token);
 }
 
-Segment Connections::createSegment(UInt32 cell)
+Segment Connections::createSegment(CellIdx cell)
 {
   NTA_CHECK(maxSegmentsPerCell_ > 0);
   while (numSegments(cell) >= maxSegmentsPerCell_)
@@ -82,7 +85,7 @@ Segment Connections::createSegment(UInt32 cell)
   }
 
   CellData& cellData = cells_[cell];
-  Segment segment = {(SegmentIdx)-1, cell};
+  Segment segment = {cell, (SegmentIdx)-1, (UInt32)-1};
   if (cellData.numDestroyedSegments > 0)
   {
     bool found = false;
@@ -102,10 +105,13 @@ Segment Connections::createSegment(UInt32 cell)
   }
   else
   {
+    const UInt32 flatIdx = nextFlatIdx_++;
     segment.idx = cellData.segments.size();
-    cellData.segments.push_back(SegmentData());
-    cellData.segments[segment.idx].flatIdx = nextFlatIdx_++;
+    segment.flatIdx = flatIdx;
     segmentForFlatIdx_.push_back(segment);
+
+    cellData.segments.push_back(SegmentData());
+    cellData.segments[segment.idx].flatIdx = flatIdx;
   }
 
   cellData.segments[segment.idx].lastUsedIteration = iteration_;
@@ -120,7 +126,7 @@ Segment Connections::createSegment(UInt32 cell)
 }
 
 Synapse Connections::createSynapse(const Segment& segment,
-                                   UInt32 presynapticCell,
+                                   CellIdx presynapticCell,
                                    Permanence permanence)
 {
   NTA_CHECK(maxSynapsesPerSegment_ > 0);
@@ -253,7 +259,7 @@ void Connections::updateSynapsePermanence(const Synapse& synapse,
   dataForSynapse_(synapse).permanence = permanence;
 }
 
-vector<Segment> Connections::segmentsForCell(UInt32 cell) const
+vector<Segment> Connections::segmentsForCell(CellIdx cell) const
 {
   vector<Segment> segments;
   segments.reserve(numSegments(cell));
@@ -264,14 +270,20 @@ vector<Segment> Connections::segmentsForCell(UInt32 cell) const
   {
     if (!allSegments[i].destroyed)
     {
-      segments.push_back({i, cell});
+      segments.push_back({cell, i, allSegments[i].flatIdx});
     }
   }
 
   return segments;
 }
 
-vector<Synapse> Connections::synapsesForSegment(const Segment& segment)
+Segment Connections::getSegment(CellIdx cell, SegmentIdx idx) const
+{
+  const UInt32 flatIdx = cells_[cell].segments[idx].flatIdx;
+  return {cell, idx, flatIdx};
+}
+
+vector<Synapse> Connections::synapsesForSegment(const Segment& segment) const
 {
   vector<Synapse> synapses;
   synapses.reserve(numSynapses(segment));
@@ -332,7 +344,13 @@ Segment Connections::segmentForFlatIdx(UInt32 flatIdx) const
   return segmentForFlatIdx_[flatIdx];
 }
 
-std::vector<Synapse> Connections::synapsesForPresynapticCell(UInt32 presynapticCell) const
+UInt32 Connections::segmentFlatListLength() const
+{
+  return nextFlatIdx_;
+}
+
+vector<Synapse> Connections::synapsesForPresynapticCell(
+  CellIdx presynapticCell) const
 {
   if (synapsesForPresynapticCell_.find(presynapticCell) ==
       synapsesForPresynapticCell_.end())
@@ -341,7 +359,7 @@ std::vector<Synapse> Connections::synapsesForPresynapticCell(UInt32 presynapticC
   return synapsesForPresynapticCell_.at(presynapticCell);
 }
 
-Segment Connections::leastRecentlyUsedSegment_(UInt32 cell) const
+Segment Connections::leastRecentlyUsedSegment_(CellIdx cell) const
 {
   const vector<SegmentData>& segments = cells_[cell].segments;
   bool found = false;
@@ -360,7 +378,7 @@ Segment Connections::leastRecentlyUsedSegment_(UInt32 cell) const
 
   NTA_CHECK(found);
 
-  return Segment(minIdx, cell);
+  return Segment(cell, minIdx, segments[minIdx].flatIdx);
 }
 
 Synapse Connections::minPermanenceSynapse_(const Segment& segment) const
@@ -386,30 +404,58 @@ Synapse Connections::minPermanenceSynapse_(const Segment& segment) const
   return Synapse(minIdx, segment);
 }
 
-bool segmentIncreasingOrder(const SegmentOverlap& a, const SegmentOverlap& b)
+void Connections::computeActivity(
+  vector<UInt32>& numActiveConnectedSynapsesForSegment,
+  vector<UInt32>& numActivePotentialSynapsesForSegment,
+  CellIdx activePresynapticCell,
+  Permanence connectedPermanence) const
 {
-  return a.segment < b.segment;
+  NTA_ASSERT(numActiveConnectedSynapsesForSegment.size() == nextFlatIdx_);
+  NTA_ASSERT(numActivePotentialSynapsesForSegment.size() == nextFlatIdx_);
+
+  if (synapsesForPresynapticCell_.count(activePresynapticCell))
+  {
+    for (const Synapse& synapse :
+           synapsesForPresynapticCell_.at(activePresynapticCell))
+    {
+      ++numActivePotentialSynapsesForSegment[synapse.segment.flatIdx];
+
+      const SynapseData& synapseData = dataForSynapse_(synapse);
+      NTA_ASSERT(synapseData.permanence > 0);
+      if (synapseData.permanence >= connectedPermanence - EPSILON)
+      {
+        ++numActiveConnectedSynapsesForSegment[synapse.segment.flatIdx];
+      }
+    }
+  }
 }
 
-void Connections::computeActivity(const vector<CellIdx>& input,
-                                  Permanence activePermanenceThreshold,
-                                  SynapseIdx activeSynapseThreshold,
-                                  Permanence matchingPermanenceThreshold,
-                                  SynapseIdx matchingSynapseThreshold,
-                                  vector<SegmentOverlap>& activeSegmentsOut,
-                                  vector<SegmentOverlap>& matchingSegmentsOut)
-  const
+void Connections::computeActivity(
+  vector<UInt32>& numActiveConnectedSynapsesForSegment,
+  vector<UInt32>& numActivePotentialSynapsesForSegment,
+  const vector<CellIdx>& activePresynapticCells,
+  Permanence connectedPermanence) const
 {
-  SegmentExcitationTally excitations(*this, activePermanenceThreshold,
-                                     matchingPermanenceThreshold);
+  NTA_ASSERT(numActiveConnectedSynapsesForSegment.size() == nextFlatIdx_);
+  NTA_ASSERT(numActivePotentialSynapsesForSegment.size() == nextFlatIdx_);
 
-  for (CellIdx cell : input)
+  for (CellIdx cell : activePresynapticCells)
   {
-    excitations.addActivePresynapticCell(cell);
-  }
+    if (synapsesForPresynapticCell_.count(cell))
+    {
+      for (const Synapse& synapse : synapsesForPresynapticCell_.at(cell))
+      {
+        ++numActivePotentialSynapsesForSegment[synapse.segment.flatIdx];
 
-  excitations.getResults(activeSynapseThreshold, matchingSynapseThreshold,
-                         activeSegmentsOut, matchingSegmentsOut);
+        const SynapseData& synapseData = dataForSynapse_(synapse);
+        NTA_ASSERT(synapseData.permanence > 0);
+        if (synapseData.permanence >= connectedPermanence - EPSILON)
+        {
+          ++numActiveConnectedSynapsesForSegment[synapse.segment.flatIdx];
+        }
+      }
+    }
+  }
 }
 
 void Connections::recordSegmentActivity(Segment segment)
@@ -422,7 +468,7 @@ void Connections::startNewIteration()
   iteration_++;
 }
 
-void Connections::save(ostream& outStream) const
+void Connections::save(std::ostream& outStream) const
 {
   // Write a starting marker.
   outStream << "Connections" << endl;
@@ -433,18 +479,21 @@ void Connections::save(ostream& outStream) const
             << maxSynapsesPerSegment_ << " "
             << endl;
 
-  for (CellData cellData : cells_) {
+  for (CellData cellData : cells_)
+  {
     auto segments = cellData.segments;
     outStream << segments.size() << " ";
-    
-    for (SegmentData segment : segments) {
+
+    for (SegmentData segment : segments)
+    {
       outStream << segment.destroyed << " ";
       outStream << segment.lastUsedIteration << " ";
 
       auto synapses = segment.synapses;
       outStream << synapses.size() << " ";
 
-      for (SynapseData synapse : synapses) {
+      for (SynapseData synapse : synapses)
+      {
         outStream << synapse.presynapticCell << " ";
         outStream << synapse.permanence << " ";
         outStream << synapse.destroyed << " ";
@@ -466,17 +515,20 @@ void Connections::write(ConnectionsProto::Builder& proto) const
 
   auto protoCells = proto.initCells(cells_.size());
 
-  for (UInt32 i = 0; i < cells_.size(); ++i) {
+  for (UInt32 i = 0; i < cells_.size(); ++i)
+  {
     auto segments = cells_[i].segments;
     auto protoSegments = protoCells[i].initSegments(segments.size());
 
-    for (SegmentIdx j = 0; j < (SegmentIdx)segments.size(); ++j) {
+    for (SegmentIdx j = 0; j < (SegmentIdx)segments.size(); ++j)
+    {
       auto synapses = segments[j].synapses;
       auto protoSynapses = protoSegments[j].initSynapses(synapses.size());
       protoSegments[j].setDestroyed(segments[j].destroyed);
       protoSegments[j].setLastUsedIteration(segments[j].lastUsedIteration);
 
-      for (SynapseIdx k = 0; k < synapses.size(); ++k) {
+      for (SynapseIdx k = 0; k < synapses.size(); ++k)
+      {
         protoSynapses[k].setPresynapticCell(synapses[k].presynapticCell);
         protoSynapses[k].setPermanence(synapses[k].permanence);
         protoSynapses[k].setDestroyed(synapses[k].destroyed);
@@ -489,7 +541,7 @@ void Connections::write(ConnectionsProto::Builder& proto) const
   proto.setIteration(iteration_);
 }
 
-void Connections::load(istream& inStream)
+void Connections::load(std::istream& inStream)
 {
   // Check the marker
   string marker;
@@ -518,19 +570,22 @@ void Connections::load(istream& inStream)
     inStream >> numSegments;
 
     cellData.segments.resize(numSegments);
-    for (UInt j = 0; j < numSegments; j++)
+    for (SegmentIdx j = 0; j < numSegments; j++)
     {
       inStream >> cellData.segments[j].destroyed;
       inStream >> cellData.segments[j].lastUsedIteration;
-      cellData.segments[j].flatIdx = nextFlatIdx_++;
-      segmentForFlatIdx_.push_back(Segment(j, cell));
+      const UInt32 flatIdx = nextFlatIdx_++;
+      cellData.segments[j].flatIdx = flatIdx;
+      const Segment segment = {cell, j, flatIdx};
+      segmentForFlatIdx_.push_back(segment);
 
       UInt numSynapses;
       inStream >> numSynapses;
 
       auto& synapses = cellData.segments[j].synapses;
       synapses.resize(numSynapses);
-      for (UInt k = 0; k < numSynapses; k++) {
+      for (UInt k = 0; k < numSynapses; k++)
+      {
         inStream >> synapses[k].presynapticCell;
         inStream >> synapses[k].permanence;
         inStream >> synapses[k].destroyed;
@@ -543,7 +598,7 @@ void Connections::load(istream& inStream)
         {
           numSynapses_++;
 
-          Synapse synapse = Synapse(k, Segment(j, cell));
+          Synapse synapse = Synapse(k, segment);
           synapsesForPresynapticCell_[synapses[k].presynapticCell].push_back(synapse);
         }
       }
@@ -577,26 +632,28 @@ void Connections::read(ConnectionsProto::Reader& proto)
              proto.getMaxSegmentsPerCell(),
              proto.getMaxSynapsesPerSegment());
 
-  for (UInt32 cell = 0; cell < protoCells.size(); ++cell)
+  for (CellIdx cell = 0; cell < protoCells.size(); ++cell)
   {
     auto protoSegments = protoCells[cell].getSegments();
     vector<SegmentData>& segments = cells_[cell].segments;
 
     for (SegmentIdx j = 0; j < (SegmentIdx)protoSegments.size(); ++j)
     {
-      SegmentData segmentData = {vector<SynapseData>(),
-                                 0,
-                                 protoSegments[j].getDestroyed(),
-                                 protoSegments[j].getLastUsedIteration(),
-                                 nextFlatIdx_++};
+      const SegmentData segmentData = {vector<SynapseData>(),
+                                       0,
+                                       protoSegments[j].getDestroyed(),
+                                       protoSegments[j].getLastUsedIteration(),
+                                       nextFlatIdx_++};
       segments.push_back(segmentData);
-      segmentForFlatIdx_.push_back(Segment(j, cell));
+      const Segment segment = {cell, j, segmentData.flatIdx};
+      segmentForFlatIdx_.push_back(segment);
 
       auto protoSynapses = protoSegments[j].getSynapses();
       vector<SynapseData>& synapses = segments[j].synapses;
 
-      for (SynapseIdx k = 0; k < protoSynapses.size(); ++k) {
-        UInt32 presynapticCell = protoSynapses[k].getPresynapticCell();
+      for (SynapseIdx k = 0; k < protoSynapses.size(); ++k)
+      {
+        CellIdx presynapticCell = protoSynapses[k].getPresynapticCell();
         SynapseData synapseData = {presynapticCell,
                                    protoSynapses[k].getPermanence(),
                                    protoSynapses[k].getDestroyed()};
@@ -610,7 +667,7 @@ void Connections::read(ConnectionsProto::Reader& proto)
         {
           numSynapses_++;
 
-          Synapse synapse = Synapse(k, Segment(j, cell));
+          Synapse synapse = Synapse(k, segment);
           synapsesForPresynapticCell_[presynapticCell].push_back(synapse);
         }
       }
@@ -639,7 +696,7 @@ UInt Connections::numSegments() const
   return numSegments_;
 }
 
-UInt Connections::numSegments(UInt32 cell) const
+UInt Connections::numSegments(CellIdx cell) const
 {
   const CellData& cellData = cells_[cell];
   return cellData.segments.size() - cellData.numDestroyedSegments;
@@ -663,13 +720,15 @@ bool Connections::operator==(const Connections &other) const
 
   if (cells_.size() != other.cells_.size()) return false;
 
-  for (UInt32 i = 0; i < cells_.size(); ++i) {
+  for (CellIdx i = 0; i < cells_.size(); ++i)
+  {
     auto segments = cells_[i].segments;
     auto otherSegments = other.cells_[i].segments;
 
     if (segments.size() != otherSegments.size()) return false;
 
-    for (SegmentIdx j = 0; j < (SegmentIdx)segments.size(); ++j) {
+    for (SegmentIdx j = 0; j < (SegmentIdx)segments.size(); ++j)
+    {
       auto segment = segments[j];
       auto otherSegment = otherSegments[j];
       auto synapses = segment.synapses;
@@ -679,7 +738,8 @@ bool Connections::operator==(const Connections &other) const
       if (segment.lastUsedIteration != otherSegment.lastUsedIteration) return false;
       if (synapses.size() != otherSynapses.size()) return false;
 
-      for (SynapseIdx k = 0; k < synapses.size(); ++k) {
+      for (SynapseIdx k = 0; k < synapses.size(); ++k)
+      {
         auto synapse = synapses[k];
         auto otherSynapse = synapses[k];
 
@@ -692,13 +752,15 @@ bool Connections::operator==(const Connections &other) const
 
   if (synapsesForPresynapticCell_.size() != other.synapsesForPresynapticCell_.size()) return false;
 
-  for (auto i = synapsesForPresynapticCell_.begin(); i != synapsesForPresynapticCell_.end(); ++i) {
+  for (auto i = synapsesForPresynapticCell_.begin(); i != synapsesForPresynapticCell_.end(); ++i)
+  {
     auto synapses = i->second;
     auto otherSynapses = other.synapsesForPresynapticCell_.at(i->first);
 
     if (synapses.size() != otherSynapses.size()) return false;
 
-    for (SynapseIdx j = 0; j < synapses.size(); ++j) {
+    for (SynapseIdx j = 0; j < synapses.size(); ++j)
+    {
       auto synapse = synapses[j];
       auto otherSynapse = otherSynapses[j];
       auto segment = synapse.segment;
@@ -719,77 +781,12 @@ bool Connections::operator==(const Connections &other) const
   return true;
 }
 
-SegmentExcitationTally::SegmentExcitationTally(
-  const Connections& connections,
-  Permanence activePermanenceThreshold,
-  Permanence matchingPermanenceThreshold)
-  :connections_(connections),
-   activePermanenceThreshold_(activePermanenceThreshold),
-   matchingPermanenceThreshold_(matchingPermanenceThreshold),
-   numActiveSynapsesForSegment_(connections.nextFlatIdx_, 0),
-   numMatchingSynapsesForSegment_(connections.nextFlatIdx_, 0)
-{
-  NTA_ASSERT(matchingPermanenceThreshold <= activePermanenceThreshold);
-}
+Segment::Segment()
+{}
 
-void SegmentExcitationTally::addActivePresynapticCell(CellIdx cell)
-{
-  if (connections_.synapsesForPresynapticCell_.count(cell))
-  {
-    for (const Synapse& synapse :
-           connections_.synapsesForPresynapticCell_.at(cell))
-    {
-      const SynapseData& synapseData = connections_.dataForSynapse_(synapse);
-
-      NTA_ASSERT(synapseData.permanence > 0);
-
-      if (synapseData.permanence >= matchingPermanenceThreshold_ - EPSILON)
-      {
-        const SegmentData& segmentData =
-          connections_.dataForSegment_(synapse.segment);
-
-        ++numMatchingSynapsesForSegment_[segmentData.flatIdx];
-
-        if (synapseData.permanence >= activePermanenceThreshold_ - EPSILON)
-        {
-          ++numActiveSynapsesForSegment_[segmentData.flatIdx];
-        }
-      }
-    }
-  }
-}
-
-void SegmentExcitationTally::getResults(
-  SynapseIdx activeSynapseThreshold,
-  SynapseIdx matchingSynapseThreshold,
-  vector<SegmentOverlap>& activeSegmentsOut,
-  vector<SegmentOverlap>& matchingSegmentsOut) const
-{
-  for (size_t i = 0; i < numActiveSynapsesForSegment_.size(); i++)
-  {
-    if (numActiveSynapsesForSegment_[i] >= activeSynapseThreshold)
-    {
-      const SegmentOverlap segmentOverlap =
-        {connections_.segmentForFlatIdx_[i], numActiveSynapsesForSegment_[i]};
-      activeSegmentsOut.push_back(segmentOverlap);
-    }
-  }
-
-  for (size_t i = 0; i < numMatchingSynapsesForSegment_.size(); i++)
-  {
-    if (numMatchingSynapsesForSegment_[i] >= matchingSynapseThreshold)
-    {
-      const SegmentOverlap segmentOverlap =
-        {connections_.segmentForFlatIdx_[i], numMatchingSynapsesForSegment_[i]};
-      matchingSegmentsOut.push_back(segmentOverlap);
-    }
-  }
-
-  std::sort(activeSegmentsOut.begin(), activeSegmentsOut.end(),
-            segmentIncreasingOrder);
-  std::sort(matchingSegmentsOut.begin(), matchingSegmentsOut.end(),
-            segmentIncreasingOrder);
-}
+Segment::Segment(CellIdx cell, SegmentIdx idx, UInt32 flatIdx)
+  : cell(cell), idx(idx), flatIdx(flatIdx)
+{}
 
 bool Segment::operator==(const Segment &other) const
 {

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -515,7 +515,7 @@ void Connections::write(ConnectionsProto::Builder& proto) const
 
   auto protoCells = proto.initCells(cells_.size());
 
-  for (UInt32 i = 0; i < cells_.size(); ++i)
+  for (CellIdx i = 0; i < cells_.size(); ++i)
   {
     auto segments = cells_[i].segments;
     auto protoSegments = protoCells[i].initSegments(segments.size());

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -209,7 +209,7 @@ namespace nupic
        * that all HTM learning algorithms can use. It is flexible enough to
        * support any learning algorithm that operates on a collection of cells.
        *
-       * Each type of connection (proximal, distal, apical) should be
+       * Each type of connection (proximal, distal basal, apical) should be
        * represented by a different instantiation of this class. This class
        * will help compute the activity along those connections due to active
        * input cells. The responsibility for what effect that activity has on
@@ -217,6 +217,12 @@ namespace nupic
        *
        * This class is optimized to store connections between cells, and
        * compute the activity of cells due to input over the connections.
+       *
+       * This class assigns each segment a unique "flatIdx" so that it's
+       * possible to use a simple vector to associate segments with values.
+       * Create a vector of length `connections.segmentFlatListLength()`,
+       * iterate over segments and update the vector at index `segment.flatIdx`,
+       * and then recover the segments using `connections.segmentForFlatIdx(i)`.
        *
        */
       class Connections : public Serializable<ConnectionsProto>

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -59,15 +59,17 @@ namespace nupic
        *
        * @param idx     Index of segment.
        * @param cellIdx Index of cell.
+       * @param flatIdx This segment's index in flattened lists of all segments.
        *
        */
       struct Segment
       {
-        SegmentIdx idx;
         CellIdx cell;
+        SegmentIdx idx;
+        UInt32 flatIdx;
 
-        Segment(SegmentIdx idx, CellIdx cell) : idx(idx), cell(cell) {}
-        Segment() {}
+        Segment(CellIdx cell, SegmentIdx idx, UInt32 flatIdx);
+        Segment();
 
         bool operator==(const Segment &other) const;
         bool operator<=(const Segment &other) const;
@@ -128,7 +130,7 @@ namespace nupic
        * @param synapses          Data for synapses that this segment contains.
        * @param destroyed         Whether this segment has been destroyed.
        * @param lastUsedIteration The iteration that this segment was last used at.
-       * @param flatIdx           This segment's index in flattened lists of all segments
+       * @param flatIdx           This segment's index in flattened lists of all segments.
        *
        */
       struct SegmentData
@@ -154,20 +156,6 @@ namespace nupic
       {
         std::vector<SegmentData> segments;
         UInt32 numDestroyedSegments;
-      };
-
-      /**
-       * A segment + overlap pair.
-       *
-       * @b Description
-       * The "overlap" describes the number of active synapses on the segment.
-       * Depending on the use case, these synapses may have a permanence below
-       * the connected threshold.
-       */
-      struct SegmentOverlap
-      {
-        Segment segment;
-        UInt32 overlap;
       };
 
       /**
@@ -233,8 +221,6 @@ namespace nupic
        */
       class Connections : public Serializable<ConnectionsProto>
       {
-        friend class SegmentExcitationTally;
-
       public:
         static const UInt16 VERSION = 1;
 
@@ -329,7 +315,7 @@ namespace nupic
          *
          * @retval Synapses on segment.
          */
-        std::vector<Synapse> synapsesForSegment(const Segment& segment);
+        std::vector<Synapse> synapsesForSegment(const Segment& segment) const;
 
         /**
          * Gets the data for a segment.
@@ -350,6 +336,16 @@ namespace nupic
         SynapseData dataForSynapse(const Synapse& synapse) const;
 
         /**
+         * Get the segment at the specified cell and offset.
+         *
+         * @param cell The cell that the segment is on.
+         * @param idx The index of the segment on the cell.
+         *
+         * @retval Segment
+         */
+        Segment getSegment(CellIdx cell, SegmentIdx idx) const;
+
+        /**
          * Do a reverse-lookup of a segment from its flatIdx.
          *
          * @param flatIdx the flatIdx of the segment
@@ -357,6 +353,14 @@ namespace nupic
          * @retval Segment
          */
         Segment segmentForFlatIdx(UInt32 flatIdx) const;
+
+        /**
+         * Get the vector length needed to use the segments' flatIdx for
+         * indexing.
+         *
+         * @retval A vector length
+         */
+        UInt32 segmentFlatListLength() const;
 
         /**
          * Returns the synapses for the source cell that they synapse on.
@@ -369,39 +373,55 @@ namespace nupic
           const;
 
         /**
-         * Compute the segment excitations for a vector of cells.
+         * Compute the segment excitations for a vector of active presynaptic
+         * cells.
          *
-         * @param input
+         * The output vectors aren't grown or cleared. They must be
+         * preinitialized with the length returned by
+         * getSegmentFlatVectorLength().
+         *
+         * @param numActiveConnectedSynapsesForSegment
+         * An output vector for active connected synapse counts per segment.
+         *
+         * @param numActivePotentialSynapsesForSegment
+         * An output vector for active potential synapse counts per segment.
+         *
+         * @param activePresynapticCells
          * Active cells in the input.
          *
-         * @param activePermanenceThreshold
-         * Minimum permanence for a synapse to contribute to an active segment
-         *
-         * @param activeSynapseThreshold
-         * Minimum number of synapses to mark a segment as "active"
-         *
-         * @param matchingPermanenceThreshold
-         * Minimum permanence for a synapse to contribute to an matching segment
-         *
-         * @param matchingSynapseThreshold
-         * Minimum number of synapses to mark a segment as "matching"
-         *
-         * @param outActiveSegments
-         * An output vector.
-         * On return, filled with active segments and overlaps.
-         *
-         * @param outActiveSegments
-         * An output vector.
-         * On return, filled with matching segments and overlaps.
+         * @param connectedPermanence
+         * Minimum permanence for a synapse to be "connected".
          */
-        void computeActivity(const std::vector<CellIdx>& input,
-                             Permanence activePermanenceThreshold,
-                             SynapseIdx activeSynapseThreshold,
-                             Permanence matchingPermanenceThreshold,
-                             SynapseIdx matchingSynapseThreshold,
-                             std::vector<SegmentOverlap>& activeSegmentsOut,
-                             std::vector<SegmentOverlap>& matchingSegmentsOut)
-          const;
+        void computeActivity(
+          std::vector<UInt32>& numActiveConnectedSynapsesForSegment,
+          std::vector<UInt32>& numActivePotentialSynapsesForSegment,
+          const std::vector<CellIdx>& activePresynapticCells,
+          Permanence connectedPermanence) const;
+
+        /**
+         * Compute the segment excitations for a single active presynaptic cell.
+         *
+         * The output vectors aren't grown or cleared. They must be
+         * preinitialized with the length returned by
+         * getSegmentFlatVectorLength().
+         *
+         * @param numActiveConnectedSynapsesForSegment
+         * An output vector for active connected synapse counts per segment.
+         *
+         * @param numActivePotentialSynapsesForSegment
+         * An output vector for active potential synapse counts per segment.
+         *
+         * @param activePresynapticCells
+         * Active cells in the input.
+         *
+         * @param connectedPermanence
+         * Minimum permanence for a synapse to be "connected".
+         */
+        void computeActivity(
+          std::vector<UInt32>& numActiveConnectedSynapsesForSegment,
+          std::vector<UInt32>& numActivePotentialSynapsesForSegment,
+          CellIdx activePresynapticCell,
+          Permanence connectedPermanence) const;
 
         /**
          * Record the fact that a segment had some activity. This information is
@@ -587,40 +607,6 @@ namespace nupic
         UInt32 nextEventToken_;
         std::map<UInt32, ConnectionsEventHandler*> eventHandlers_;
       }; // end class Connections
-
-      /**
-       * Takes a Connections instance and a set of active cells, and calculates
-       * the excited columns.
-       *
-       * This is essentially part of the Connections class. It accesses
-       * Connections internals to perform this calculation quickly.
-       *
-       * This is implemented as a class rather than a Connections method because
-       * this allows callers to provide the "active presynaptic cells" without
-       * imposing requirements on how these cells are stored. The cells might be
-       * stored in a vector, in multiple vectors, as a list of indices, as a
-       * list of zeros and ones, etc., so we expose a "Tally" class and require
-       * the caller to do the iteration.
-       */
-      class SegmentExcitationTally
-      {
-      public:
-        SegmentExcitationTally(const Connections& connections,
-                               Permanence activePermanenceThreshold,
-                               Permanence matchingPermanenceThreshold);
-        void addActivePresynapticCell(CellIdx cellIdx);
-        void getResults(SynapseIdx activeSynapseThreshold,
-                        SynapseIdx matchingSynapseThreshold,
-                        std::vector<SegmentOverlap>& activeSegmentsOut,
-                        std::vector<SegmentOverlap>& matchingSegmentsOut)
-          const;
-      private:
-        const Connections& connections_;
-        const Permanence activePermanenceThreshold_;
-        const Permanence matchingPermanenceThreshold_;
-        std::vector<UInt32> numActiveSynapsesForSegment_;
-        std::vector<UInt32> numMatchingSynapsesForSegment_;
-      };
 
     } // end namespace connections
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -328,8 +328,8 @@ static void activatePredictedColumn(
                      prevActiveCells,
                      permanenceIncrement, permanenceDecrement);
 
-        const Int32 nGrowDesired =
-          maxNewSynapseCount - numActivePotentialSynapsesForSegment[activeSegment->flatIdx];
+        const Int32 nGrowDesired = maxNewSynapseCount -
+          numActivePotentialSynapsesForSegment[activeSegment->flatIdx];
         if (nGrowDesired > 0)
         {
           growSynapses(connections, rng,

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -90,9 +90,9 @@ namespace nupic {
          * is said to be connected.
          *
          * @param minThreshold
-         * If the number of synapses active on a segment is at least this
-         * threshold, it is selected as the best matching cell in a bursting
-         * column.
+         * If the number of potential synapses active on a segment is at least
+         * this threshold, it is said to be "matching" and is eligible for
+         * learning.
          *
          * @param maxNewSynapseCount
          * The maximum number of synapses added to a segment during learning.
@@ -106,8 +106,7 @@ namespace nupic {
          * learning.
          *
          * @param predictedSegmentDecrement
-         * Amount by which active permanences of synapses of previously
-         * predicted but inactive segments are decremented.
+         * Amount by which segments are punished for incorrect predictions.
          *
          * @param seed
          * Seed for the random number generator.
@@ -438,8 +437,10 @@ namespace nupic {
 
         vector<CellIdx> activeCells_;
         vector<CellIdx> winnerCells_;
-        vector<SegmentOverlap> activeSegments_;
-        vector<SegmentOverlap> matchingSegments_;
+        vector<Segment> activeSegments_;
+        vector<Segment> matchingSegments_;
+        vector<UInt32> numActiveConnectedSynapsesForSegment_;
+        vector<UInt32> numActivePotentialSynapsesForSegment_;
 
         Random rng_;
 

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -22,6 +22,15 @@
 
 /** @file
  * Implementation of ExtendedTemporalMemory
+ *
+ * The functions in this file use the following parameter ordering
+ * convention:
+ *
+ * 1. Output / mutated params
+ * 2. Traditional parameters to the function, i.e. the ones that would still
+ *    exist if this function were a method on a class
+ * 3. Model state (marked const)
+ * 4. Model parameters (including "learn")
  */
 
 #include <cstring>
@@ -171,10 +180,10 @@ void ExtendedTemporalMemory::initialize(
 }
 
 static UInt32 predictiveScore(
-  vector<SegmentOverlap>::const_iterator cellActiveBasalBegin,
-  vector<SegmentOverlap>::const_iterator cellActiveBasalEnd,
-  vector<SegmentOverlap>::const_iterator cellActiveApicalBegin,
-  vector<SegmentOverlap>::const_iterator cellActiveApicalEnd)
+  vector<Segment>::const_iterator cellActiveBasalBegin,
+  vector<Segment>::const_iterator cellActiveBasalEnd,
+  vector<Segment>::const_iterator cellActiveApicalBegin,
+  vector<Segment>::const_iterator cellActiveApicalEnd)
 {
   UInt32 score = 0;
 
@@ -191,35 +200,34 @@ static UInt32 predictiveScore(
   return score;
 }
 
-static CellIdx cellForSegment(const SegmentOverlap& s)
+static CellIdx cellForSegment(Segment segment)
 {
-  return s.segment.cell;
+  return segment.cell;
 }
 
-static tuple<vector<SegmentOverlap>::const_iterator,
-             vector<SegmentOverlap>::const_iterator>
-segmentsForCell(vector<SegmentOverlap>::const_iterator segmentsStart,
-                vector<SegmentOverlap>::const_iterator segmentsEnd,
+static tuple<vector<Segment>::const_iterator,
+             vector<Segment>::const_iterator>
+segmentsForCell(vector<Segment>::const_iterator segmentsStart,
+                vector<Segment>::const_iterator segmentsEnd,
                 CellIdx cell)
 {
   const auto cellBegin = std::find_if(segmentsStart, segmentsEnd,
-                                      [&](const SegmentOverlap& x)
+                                      [&](Segment segment)
                                       {
-                                        return x.segment.cell == cell;
+                                        return segment.cell == cell;
                                       });
   const auto cellEnd = std::find_if(cellBegin, segmentsEnd,
-                                    [&](const SegmentOverlap& x)
+                                    [&](Segment segment)
                                     {
-                                      return x.segment.cell != cell;
+                                      return segment.cell != cell;
                                     });
-  return tuple<vector<SegmentOverlap>::const_iterator,
-               vector<SegmentOverlap>::const_iterator>(cellBegin, cellEnd);
+  return std::make_tuple(cellBegin, cellEnd);
 }
 
 static CellIdx getLeastUsedCell(
-  Connections& connections,
   Random& rng,
   UInt column,
+  const Connections& connections,
   UInt cellsPerColumn)
 {
   const CellIdx start = column * cellsPerColumn;
@@ -375,13 +383,14 @@ static void learnOnCell(
   Connections& connections,
   Random& rng,
   CellIdx cell,
+  vector<Segment>::const_iterator cellActiveSegmentsBegin,
+  vector<Segment>::const_iterator cellActiveSegmentsEnd,
+  vector<Segment>::const_iterator cellMatchingSegmentsBegin,
+  vector<Segment>::const_iterator cellMatchingSegmentsEnd,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& internalCandidates,
   const vector<CellIdx>& externalCandidates,
-  vector<SegmentOverlap>::const_iterator cellActiveSegmentsBegin,
-  vector<SegmentOverlap>::const_iterator cellActiveSegmentsEnd,
-  vector<SegmentOverlap>::const_iterator cellMatchingSegmentsBegin,
-  vector<SegmentOverlap>::const_iterator cellMatchingSegmentsEnd,
+  const vector<UInt32>& numActivePotentialSynapsesForSegment,
   UInt maxNewSynapseCount,
   Permanence initialPermanence,
   Permanence permanenceIncrement,
@@ -391,65 +400,49 @@ static void learnOnCell(
   {
     // Learn on every active segment.
 
-    auto bySegment = [](const SegmentOverlap& x) { return x.segment; };
-    for (auto segmentData : iterGroupBy(
-           cellActiveSegmentsBegin, cellActiveSegmentsEnd, bySegment,
-           cellMatchingSegmentsBegin, cellMatchingSegmentsEnd, bySegment))
+    auto activeSegment = cellActiveSegmentsBegin;
+    do
     {
-      // Find the active segment's corresponding "matching" overlap.
-      Segment segment;
-      vector<SegmentOverlap>::const_iterator
-        activeOverlapsBegin, activeOverlapsEnd,
-        matchingOverlapsBegin, matchingOverlapsEnd;
-      tie(segment,
-          activeOverlapsBegin, activeOverlapsEnd,
-          matchingOverlapsBegin, matchingOverlapsEnd) = segmentData;
-      if (activeOverlapsBegin != activeOverlapsEnd)
-      {
-        // Active segments are a superset of matching segments.
-        NTA_ASSERT(std::distance(activeOverlapsBegin, activeOverlapsEnd) == 1);
-        NTA_ASSERT(std::distance(matchingOverlapsBegin, matchingOverlapsEnd) == 1);
+      adaptSegment(connections,
+                   *activeSegment,
+                   prevActiveCells, externalCandidates,
+                   permanenceIncrement, permanenceDecrement);
 
-        adaptSegment(connections,
-                     segment,
-                     prevActiveCells, externalCandidates,
-                     permanenceIncrement, permanenceDecrement);
-
-        const Int32 nActivePotentialSynapses = matchingOverlapsBegin->overlap;
-        const Int32 nGrowDesired = (maxNewSynapseCount -
-                                    nActivePotentialSynapses);
+      const Int32 nGrowDesired = maxNewSynapseCount -
+        numActivePotentialSynapsesForSegment[activeSegment->flatIdx];
         if (nGrowDesired > 0)
         {
           growSynapses(connections, rng,
-                       segment, nGrowDesired,
+                       *activeSegment, nGrowDesired,
                        internalCandidates, externalCandidates,
                        initialPermanence);
         }
-      }
-    }
+    } while (++activeSegment != cellActiveSegmentsEnd);
   }
   else if (cellMatchingSegmentsBegin != cellMatchingSegmentsEnd)
   {
     // No active segments.
     // Learn on the best matching segment.
 
-    const SegmentOverlap& bestMatching = *std::max_element(
+    const Segment bestMatchingSegment = *std::max_element(
       cellMatchingSegmentsBegin, cellMatchingSegmentsEnd,
-      [](const SegmentOverlap& a, const SegmentOverlap& b)
+      [&](Segment a, Segment b)
       {
-        return a.overlap < b.overlap;
+        return (numActivePotentialSynapsesForSegment[a.flatIdx] <
+                numActivePotentialSynapsesForSegment[b.flatIdx]);
       });
 
     adaptSegment(connections,
-                 bestMatching.segment,
+                 bestMatchingSegment,
                  prevActiveCells, externalCandidates,
                  permanenceIncrement, permanenceDecrement);
 
-    const Int32 nGrowDesired = maxNewSynapseCount - bestMatching.overlap;
+    const Int32 nGrowDesired = maxNewSynapseCount -
+      numActivePotentialSynapsesForSegment[bestMatchingSegment.flatIdx];
     if (nGrowDesired > 0)
     {
       growSynapses(connections, rng,
-                   bestMatching.segment, nGrowDesired,
+                   bestMatchingSegment, nGrowDesired,
                    internalCandidates, externalCandidates,
                    initialPermanence);
     }
@@ -481,19 +474,21 @@ static void activatePredictedColumn(
   Connections& basalConnections,
   Connections& apicalConnections,
   Random& rng,
-  vector<SegmentOverlap>::const_iterator columnActiveBasalBegin,
-  vector<SegmentOverlap>::const_iterator columnActiveBasalEnd,
-  vector<SegmentOverlap>::const_iterator columnMatchingBasalBegin,
-  vector<SegmentOverlap>::const_iterator columnMatchingBasalEnd,
-  vector<SegmentOverlap>::const_iterator columnActiveApicalBegin,
-  vector<SegmentOverlap>::const_iterator columnActiveApicalEnd,
-  vector<SegmentOverlap>::const_iterator columnMatchingApicalBegin,
-  vector<SegmentOverlap>::const_iterator columnMatchingApicalEnd,
+  vector<Segment>::const_iterator columnActiveBasalBegin,
+  vector<Segment>::const_iterator columnActiveBasalEnd,
+  vector<Segment>::const_iterator columnMatchingBasalBegin,
+  vector<Segment>::const_iterator columnMatchingBasalEnd,
+  vector<Segment>::const_iterator columnActiveApicalBegin,
+  vector<Segment>::const_iterator columnActiveApicalEnd,
+  vector<Segment>::const_iterator columnMatchingApicalBegin,
+  vector<Segment>::const_iterator columnMatchingApicalEnd,
   UInt32 predictiveThreshold,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& prevWinnerCells,
   const vector<CellIdx>& prevActiveExternalCellsBasal,
   const vector<CellIdx>& prevActiveExternalCellsApical,
+  const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
+  const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
   Permanence initialPermanence,
   UInt maxNewSynapseCount,
   Permanence permanenceIncrement,
@@ -508,7 +503,7 @@ static void activatePredictedColumn(
          columnMatchingApicalBegin, columnMatchingApicalEnd, cellForSegment))
   {
     CellIdx cell;
-    vector<SegmentOverlap>::const_iterator
+    vector<Segment>::const_iterator
       cellActiveBasalBegin, cellActiveBasalEnd,
       cellMatchingBasalBegin, cellMatchingBasalEnd,
       cellActiveApicalBegin, cellActiveApicalEnd,
@@ -529,20 +524,24 @@ static void activatePredictedColumn(
       if (learn)
       {
         learnOnCell(basalConnections, rng,
-                    cell, prevActiveCells,
+                    cell,
+                    cellActiveBasalBegin, cellActiveBasalEnd,
+                    cellMatchingBasalBegin, cellMatchingBasalEnd,
+                    prevActiveCells,
                     (formInternalBasalConnections
                      ? prevWinnerCells : CELLS_NONE),
                     prevActiveExternalCellsBasal,
-                    cellActiveBasalBegin, cellActiveBasalEnd,
-                    cellMatchingBasalBegin, cellMatchingBasalEnd,
+                    numActivePotentialSynapsesForBasalSegment,
                     maxNewSynapseCount, initialPermanence,
                     permanenceIncrement, permanenceDecrement);
 
         learnOnCell(apicalConnections, rng,
-                    cell, prevActiveCells,
-                    CELLS_NONE, prevActiveExternalCellsApical,
+                    cell,
                     cellActiveApicalBegin, cellActiveApicalEnd,
                     cellMatchingApicalBegin, cellMatchingApicalEnd,
+                    prevActiveCells,
+                    CELLS_NONE, prevActiveExternalCellsApical,
+                    numActivePotentialSynapsesForApicalSegment,
                     maxNewSynapseCount, initialPermanence,
                     permanenceIncrement, permanenceDecrement);
       }
@@ -558,18 +557,20 @@ static void burstColumn(
   Random& rng,
   map<UInt, CellIdx>& chosenCellForColumn,
   UInt column,
-  vector<SegmentOverlap>::const_iterator columnActiveBasalBegin,
-  vector<SegmentOverlap>::const_iterator columnActiveBasalEnd,
-  vector<SegmentOverlap>::const_iterator columnMatchingBasalBegin,
-  vector<SegmentOverlap>::const_iterator columnMatchingBasalEnd,
-  vector<SegmentOverlap>::const_iterator columnActiveApicalBegin,
-  vector<SegmentOverlap>::const_iterator columnActiveApicalEnd,
-  vector<SegmentOverlap>::const_iterator columnMatchingApicalBegin,
-  vector<SegmentOverlap>::const_iterator columnMatchingApicalEnd,
+  vector<Segment>::const_iterator columnActiveBasalBegin,
+  vector<Segment>::const_iterator columnActiveBasalEnd,
+  vector<Segment>::const_iterator columnMatchingBasalBegin,
+  vector<Segment>::const_iterator columnMatchingBasalEnd,
+  vector<Segment>::const_iterator columnActiveApicalBegin,
+  vector<Segment>::const_iterator columnActiveApicalEnd,
+  vector<Segment>::const_iterator columnMatchingApicalBegin,
+  vector<Segment>::const_iterator columnMatchingApicalEnd,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& prevWinnerCells,
   const vector<CellIdx>& prevActiveExternalCellsBasal,
   const vector<CellIdx>& prevActiveExternalCellsApical,
+  const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
+  const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
   UInt cellsPerColumn,
   Permanence initialPermanence,
   UInt maxNewSynapseCount,
@@ -601,21 +602,22 @@ static void burstColumn(
   {
     if (columnMatchingBasalBegin != columnMatchingBasalEnd)
     {
-      auto bestBasal = std::max_element(
+      auto bestBasalSegment = std::max_element(
         columnMatchingBasalBegin, columnMatchingBasalEnd,
-        [](const SegmentOverlap& a, const SegmentOverlap& b)
+        [&](Segment a, Segment b)
         {
-          return a.overlap < b.overlap;
+          return (numActivePotentialSynapsesForBasalSegment[a.flatIdx] <
+                  numActivePotentialSynapsesForBasalSegment[b.flatIdx]);
         });
 
-      basalCandidatesBegin = bestBasal;
-      basalCandidatesEnd = bestBasal + 1;
+      basalCandidatesBegin = bestBasalSegment;
+      basalCandidatesEnd = bestBasalSegment + 1;
 
-      winnerCell = bestBasal->segment.cell;
+      winnerCell = bestBasalSegment->cell;
     }
     else
     {
-      winnerCell = getLeastUsedCell(basalConnections, rng, column,
+      winnerCell = getLeastUsedCell(rng, column, basalConnections,
                                     cellsPerColumn);
     }
 
@@ -629,7 +631,7 @@ static void burstColumn(
   // Learn.
   if (learn)
   {
-    vector<SegmentOverlap>::const_iterator
+    vector<Segment>::const_iterator
       cellActiveApicalBegin, cellActiveApicalEnd,
       cellMatchingApicalBegin, cellMatchingApicalEnd,
       cellActiveBasalBegin, cellActiveBasalEnd;
@@ -647,20 +649,24 @@ static void burstColumn(
                                               winnerCell);
 
     learnOnCell(basalConnections, rng,
-                winnerCell, prevActiveCells,
+                winnerCell,
+                cellActiveBasalBegin, cellActiveBasalEnd,
+                basalCandidatesBegin, basalCandidatesEnd,
+                prevActiveCells,
                 (formInternalBasalConnections
                  ? prevWinnerCells : CELLS_NONE),
                 prevActiveExternalCellsBasal,
-                cellActiveBasalBegin, cellActiveBasalEnd,
-                basalCandidatesBegin, basalCandidatesEnd,
+                numActivePotentialSynapsesForBasalSegment,
                 maxNewSynapseCount, initialPermanence,
                 permanenceIncrement, permanenceDecrement);
 
     learnOnCell(apicalConnections, rng,
-                winnerCell, prevActiveCells,
-                CELLS_NONE, prevActiveExternalCellsApical,
+                winnerCell,
                 cellActiveApicalBegin, cellActiveApicalEnd,
                 cellMatchingApicalBegin, cellMatchingApicalEnd,
+                prevActiveCells,
+                CELLS_NONE, prevActiveExternalCellsApical,
+                numActivePotentialSynapsesForApicalSegment,
                 maxNewSynapseCount, initialPermanence,
                 permanenceIncrement, permanenceDecrement);
   }
@@ -668,18 +674,18 @@ static void burstColumn(
 
 static void punishPredictedColumn(
   Connections& connections,
-  vector<SegmentOverlap>::const_iterator matchingSegmentsBegin,
-  vector<SegmentOverlap>::const_iterator matchingSegmentsEnd,
+  vector<Segment>::const_iterator matchingSegmentsBegin,
+  vector<Segment>::const_iterator matchingSegmentsEnd,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& prevActiveExternalCells,
   Permanence predictedSegmentDecrement)
 {
   if (predictedSegmentDecrement > 0.0)
   {
-    for (auto matching = matchingSegmentsBegin;
-         matching != matchingSegmentsEnd; matching++)
+    for (auto matchingSegment = matchingSegmentsBegin;
+         matchingSegment != matchingSegmentsEnd; matchingSegment++)
     {
-      adaptSegment(connections, matching->segment,
+      adaptSegment(connections, *matchingSegment,
                    prevActiveCells, prevActiveExternalCells,
                    -predictedSegmentDecrement, 0.0);
     }
@@ -702,7 +708,7 @@ void ExtendedTemporalMemory::activateCells(
   const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
 
   const auto columnForSegment =
-    [&](const SegmentOverlap& s) { return s.segment.cell / cellsPerColumn_; };
+    [&](Segment segment) { return segment.cell / cellsPerColumn_; };
 
   for (auto& columnData : groupBy(activeColumns, identity<UInt>,
                                   activeBasalSegments_, columnForSegment,
@@ -713,7 +719,7 @@ void ExtendedTemporalMemory::activateCells(
     UInt column;
     vector<UInt>::const_iterator
       activeColumnsBegin, activeColumnsEnd;
-    vector<SegmentOverlap>::const_iterator
+    vector<Segment>::const_iterator
       columnActiveBasalBegin, columnActiveBasalEnd,
       columnMatchingBasalBegin, columnMatchingBasalEnd,
       columnActiveApicalBegin, columnActiveApicalEnd,
@@ -735,7 +741,7 @@ void ExtendedTemporalMemory::activateCells(
              columnActiveApicalBegin, columnActiveApicalEnd, cellForSegment))
       {
         CellIdx cell;
-        vector<SegmentOverlap>::const_iterator
+        vector<Segment>::const_iterator
           cellActiveBasalBegin, cellActiveBasalEnd,
           cellActiveApicalBegin, cellActiveApicalEnd;
         tie(cell,
@@ -760,6 +766,8 @@ void ExtendedTemporalMemory::activateCells(
           maxPredictiveScore,
           prevActiveCells, prevWinnerCells,
           prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
+          numActivePotentialSynapsesForBasalSegment_,
+          numActivePotentialSynapsesForApicalSegment_,
           initialPermanence_, maxNewSynapseCount_,
           permanenceIncrement_, permanenceDecrement_,
           formInternalBasalConnections_, learn);
@@ -777,6 +785,8 @@ void ExtendedTemporalMemory::activateCells(
           columnMatchingApicalBegin, columnMatchingApicalEnd,
           prevActiveCells, prevWinnerCells,
           prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
+          numActivePotentialSynapsesForBasalSegment_,
+          numActivePotentialSynapsesForApicalSegment_,
           cellsPerColumn_, initialPermanence_, maxNewSynapseCount_,
           permanenceIncrement_, permanenceDecrement_,
           formInternalBasalConnections_, learnOnOneCell_, learn);
@@ -798,9 +808,11 @@ void ExtendedTemporalMemory::activateCells(
   }
 }
 
-static void activateDendrites(
-  vector<SegmentOverlap>& activeSegments,
-  vector<SegmentOverlap>& matchingSegments,
+static void calculateExcitation(
+  vector<UInt32>& numActiveConnectedSynapsesForSegment,
+  vector<Segment>& activeSegments,
+  vector<UInt32>& numActivePotentialSynapsesForSegment,
+  vector<Segment>& matchingSegments,
   Connections& connections,
   const vector<CellIdx>& activeCells,
   const vector<CellIdx>& activeExternalCells,
@@ -809,24 +821,50 @@ static void activateDendrites(
   UInt minThreshold,
   bool learn)
 {
-  SegmentExcitationTally excitations(connections, connectedPermanence, 0.0);
-  for (CellIdx cell : activeCells)
-  {
-    excitations.addActivePresynapticCell(cell);
-  }
+  const UInt32 length = connections.segmentFlatListLength();
+  numActiveConnectedSynapsesForSegment.assign(length, 0);
+  numActivePotentialSynapsesForSegment.assign(length, 0);
+
+  connections.computeActivity(numActiveConnectedSynapsesForSegment,
+                              numActivePotentialSynapsesForSegment,
+                              activeCells,
+                              connectedPermanence);
+
   for (CellIdx cell : activeExternalCells)
   {
-    excitations.addActivePresynapticCell(cell + connections.numCells());
+    connections.computeActivity(numActiveConnectedSynapsesForSegment,
+                                numActivePotentialSynapsesForSegment,
+                                cell + connections.numCells(),
+                                connectedPermanence);
   }
 
-  excitations.getResults(activationThreshold, minThreshold,
-                         activeSegments, matchingSegments);
+  // Active segments, connected synapses.
+  activeSegments.clear();
+  for (size_t i = 0; i < numActiveConnectedSynapsesForSegment.size(); i++)
+  {
+    if (numActiveConnectedSynapsesForSegment[i] >= activationThreshold)
+    {
+      activeSegments.push_back(connections.segmentForFlatIdx(i));
+    }
+  }
+  std::sort(activeSegments.begin(), activeSegments.end());
+
+  // Matching segments, potential synapses.
+  matchingSegments.clear();
+  for (size_t i = 0; i < numActivePotentialSynapsesForSegment.size(); i++)
+  {
+    if (numActivePotentialSynapsesForSegment[i] >= minThreshold)
+    {
+      matchingSegments.push_back(connections.segmentForFlatIdx(i));
+    }
+  }
+  std::sort(matchingSegments.begin(), matchingSegments.end());
 
   if (learn)
   {
-    for (const SegmentOverlap& segmentOverlap : activeSegments)
+    for (Segment segment : activeSegments)
     {
-      connections.recordSegmentActivity(segmentOverlap.segment);
+      connections.recordSegmentActivity(segment);
     }
 
     connections.startNewIteration();
@@ -837,26 +875,35 @@ void ExtendedTemporalMemory::activateBasalDendrites(
   const vector<CellIdx>& activeExternalCells,
   bool learn)
 {
-  activeBasalSegments_.clear();
-  matchingBasalSegments_.clear();
-  activateDendrites(activeBasalSegments_, matchingBasalSegments_,
-                    basalConnections,
-                    activeCells_, activeExternalCells,
-                    connectedPermanence_, activationThreshold_, minThreshold_,
-                    learn);
+  calculateExcitation(
+    numActiveConnectedSynapsesForBasalSegment_, activeBasalSegments_,
+    numActivePotentialSynapsesForBasalSegment_, matchingBasalSegments_,
+    basalConnections,
+    activeCells_, activeExternalCells,
+    connectedPermanence_, activationThreshold_, minThreshold_,
+    learn);
 }
 
 void ExtendedTemporalMemory::activateApicalDendrites(
   const vector<CellIdx>& activeExternalCells,
   bool learn)
 {
-  activeApicalSegments_.clear();
-  matchingApicalSegments_.clear();
-  activateDendrites(activeApicalSegments_, matchingApicalSegments_,
-                    apicalConnections,
-                    activeCells_, activeExternalCells,
-                    connectedPermanence_, activationThreshold_, minThreshold_,
-                    learn);
+  calculateExcitation(
+    numActiveConnectedSynapsesForApicalSegment_, activeApicalSegments_,
+    numActivePotentialSynapsesForApicalSegment_, matchingApicalSegments_,
+    apicalConnections,
+    activeCells_, activeExternalCells,
+    connectedPermanence_, activationThreshold_, minThreshold_,
+    learn);
+}
+
+void ExtendedTemporalMemory::activateDendrites(
+  const vector<CellIdx>& activeExternalCellsBasal,
+  const vector<CellIdx>& activeExternalCellsApical,
+  bool learn)
+{
+  activateBasalDendrites(activeExternalCellsBasal, learn);
+  activateApicalDendrites(activeExternalCellsApical, learn);
 }
 
 void ExtendedTemporalMemory::compute(
@@ -939,13 +986,13 @@ vector<CellIdx> ExtendedTemporalMemory::getPredictiveCells() const
   vector<CellIdx> predictiveCells;
 
   const auto columnForSegment =
-    [&](const SegmentOverlap& s) { return s.segment.cell / cellsPerColumn_; };
+    [&](Segment segment) { return segment.cell / cellsPerColumn_; };
 
   for (auto& columnData : groupBy(activeBasalSegments_, columnForSegment,
                                   activeApicalSegments_, columnForSegment))
   {
     UInt column;
-    vector<SegmentOverlap>::const_iterator
+    vector<Segment>::const_iterator
       columnActiveBasalBegin, columnActiveBasalEnd,
       columnActiveApicalBegin, columnActiveApicalEnd;
     tie(column,
@@ -959,7 +1006,7 @@ vector<CellIdx> ExtendedTemporalMemory::getPredictiveCells() const
     UInt32 maxDepolarization = 0;
     for (auto& cellData : groupedByCell)
     {
-      vector<SegmentOverlap>::const_iterator
+      vector<Segment>::const_iterator
         cellActiveBasalBegin, cellActiveBasalEnd,
         cellActiveApicalBegin, cellActiveApicalEnd;
       tie(std::ignore,
@@ -978,7 +1025,7 @@ vector<CellIdx> ExtendedTemporalMemory::getPredictiveCells() const
       for (auto& cellData : groupedByCell)
       {
         CellIdx cell;
-        vector<SegmentOverlap>::const_iterator
+        vector<Segment>::const_iterator
           cellActiveBasalBegin, cellActiveBasalEnd,
           cellActiveApicalBegin, cellActiveApicalEnd;
         tie(cell,
@@ -1005,46 +1052,22 @@ vector<CellIdx> ExtendedTemporalMemory::getWinnerCells() const
 
 vector<Segment> ExtendedTemporalMemory::getActiveBasalSegments() const
 {
-  vector<Segment> ret;
-  ret.reserve(activeBasalSegments_.size());
-  for (const SegmentOverlap& segmentOverlap : activeBasalSegments_)
-  {
-    ret.push_back(segmentOverlap.segment);
-  }
-  return ret;
+  return activeBasalSegments_;
 }
 
 vector<Segment> ExtendedTemporalMemory::getMatchingBasalSegments() const
 {
-  vector<Segment> ret;
-  ret.reserve(matchingBasalSegments_.size());
-  for (const SegmentOverlap& segmentOverlap : matchingBasalSegments_)
-  {
-    ret.push_back(segmentOverlap.segment);
-  }
-  return ret;
+  return matchingBasalSegments_;
 }
 
 vector<Segment> ExtendedTemporalMemory::getActiveApicalSegments() const
 {
-  vector<Segment> ret;
-  ret.reserve(activeApicalSegments_.size());
-  for (const SegmentOverlap& segmentOverlap : activeApicalSegments_)
-  {
-    ret.push_back(segmentOverlap.segment);
-  }
-  return ret;
+  return activeApicalSegments_;
 }
 
 vector<Segment> ExtendedTemporalMemory::getMatchingApicalSegments() const
 {
-  vector<Segment> ret;
-  ret.reserve(matchingApicalSegments_.size());
-  for (const SegmentOverlap& segmentOverlap : matchingApicalSegments_)
-  {
-    ret.push_back(segmentOverlap.segment);
-  }
-  return ret;
+  return matchingApicalSegments_;
 }
 
 UInt ExtendedTemporalMemory::numberOfColumns() const
@@ -1248,38 +1271,42 @@ void ExtendedTemporalMemory::save(ostream& outStream) const
   outStream << endl;
 
   outStream << activeBasalSegments_.size() << " ";
-  for (SegmentOverlap elem : activeBasalSegments_)
+  for (Segment segment : activeBasalSegments_)
   {
-    outStream << elem.segment.idx << " ";
-    outStream << elem.segment.cell << " ";
-    outStream << elem.overlap << " ";
+    outStream << segment.idx << " ";
+    outStream << segment.cell << " ";
+    outStream << numActiveConnectedSynapsesForBasalSegment_[segment.flatIdx]
+              << " ";
   }
   outStream << endl;
 
   outStream << matchingBasalSegments_.size() << " ";
-  for (SegmentOverlap elem : matchingBasalSegments_)
+  for (Segment segment : matchingBasalSegments_)
   {
-    outStream << elem.segment.idx << " ";
-    outStream << elem.segment.cell << " ";
-    outStream << elem.overlap << " ";
+    outStream << segment.idx << " ";
+    outStream << segment.cell << " ";
+    outStream << numActivePotentialSynapsesForBasalSegment_[segment.flatIdx]
+              << " ";
   }
   outStream << endl;
 
   outStream << activeApicalSegments_.size() << " ";
-  for (SegmentOverlap elem : activeApicalSegments_)
+  for (Segment segment : activeApicalSegments_)
   {
-    outStream << elem.segment.idx << " ";
-    outStream << elem.segment.cell << " ";
-    outStream << elem.overlap << " ";
+    outStream << segment.idx << " ";
+    outStream << segment.cell << " ";
+    outStream << numActiveConnectedSynapsesForApicalSegment_[segment.flatIdx]
+              << " ";
   }
   outStream << endl;
 
   outStream << matchingApicalSegments_.size() << " ";
-  for (SegmentOverlap elem : matchingApicalSegments_)
+  for (Segment segment : matchingApicalSegments_)
   {
-    outStream << elem.segment.idx << " ";
-    outStream << elem.segment.cell << " ";
-    outStream << elem.overlap << " ";
+    outStream << segment.idx << " ";
+    outStream << segment.cell << " ";
+    outStream << numActivePotentialSynapsesForApicalSegment_[segment.flatIdx]
+              << " ";
   }
   outStream << endl;
 
@@ -1337,44 +1364,44 @@ void ExtendedTemporalMemory::write(ExtendedTemporalMemoryProto::Builder& proto) 
     proto.initActiveBasalSegmentOverlaps(activeBasalSegments_.size());
   for (UInt i = 0; i < activeBasalSegments_.size(); ++i)
   {
-    Segment segment = activeBasalSegments_[i].segment;
+    Segment segment = activeBasalSegments_[i];
     activeBasalSegmentOverlaps[i].setCell(segment.cell);
     activeBasalSegmentOverlaps[i].setSegment(segment.idx);
     activeBasalSegmentOverlaps[i].setOverlap(
-      activeBasalSegments_[i].overlap);
+      numActiveConnectedSynapsesForBasalSegment_[segment.flatIdx]);
   }
 
   auto matchingBasalSegmentOverlaps =
     proto.initMatchingBasalSegmentOverlaps(matchingBasalSegments_.size());
   for (UInt i = 0; i < matchingBasalSegments_.size(); ++i)
   {
-    Segment segment = matchingBasalSegments_[i].segment;
+    Segment segment = matchingBasalSegments_[i];
     matchingBasalSegmentOverlaps[i].setCell(segment.cell);
     matchingBasalSegmentOverlaps[i].setSegment(segment.idx);
     matchingBasalSegmentOverlaps[i].setOverlap(
-      matchingBasalSegments_[i].overlap);
+      numActivePotentialSynapsesForBasalSegment_[segment.flatIdx]);
   }
 
   auto activeApicalSegmentOverlaps =
     proto.initActiveApicalSegmentOverlaps(activeApicalSegments_.size());
   for (UInt i = 0; i < activeApicalSegments_.size(); ++i)
   {
-    Segment segment = activeApicalSegments_[i].segment;
+    Segment segment = activeApicalSegments_[i];
     activeApicalSegmentOverlaps[i].setCell(segment.cell);
     activeApicalSegmentOverlaps[i].setSegment(segment.idx);
     activeApicalSegmentOverlaps[i].setOverlap(
-      activeApicalSegments_[i].overlap);
+      numActiveConnectedSynapsesForApicalSegment_[segment.flatIdx]);
   }
 
   auto matchingApicalSegmentOverlaps =
     proto.initMatchingApicalSegmentOverlaps(matchingApicalSegments_.size());
   for (UInt i = 0; i < matchingApicalSegments_.size(); ++i)
   {
-    Segment segment = matchingApicalSegments_[i].segment;
+    Segment segment = matchingApicalSegments_[i];
     matchingApicalSegmentOverlaps[i].setCell(segment.cell);
     matchingApicalSegmentOverlaps[i].setSegment(segment.idx);
     matchingApicalSegmentOverlaps[i].setOverlap(
-      matchingApicalSegments_[i].overlap);
+      numActivePotentialSynapsesForApicalSegment_[segment.flatIdx]);
   }
 
   NTA_CHECK(learnOnOneCell_ == false) <<
@@ -1413,6 +1440,16 @@ void ExtendedTemporalMemory::read(ExtendedTemporalMemoryProto::Reader& proto)
   auto _apicalConnections = proto.getApicalConnections();
   apicalConnections.read(_apicalConnections);
 
+  numActiveConnectedSynapsesForBasalSegment_.assign(
+    basalConnections.segmentFlatListLength(), 0);
+  numActivePotentialSynapsesForBasalSegment_.assign(
+    basalConnections.segmentFlatListLength(), 0);
+
+  numActiveConnectedSynapsesForApicalSegment_.assign(
+    apicalConnections.segmentFlatListLength(), 0);
+  numActivePotentialSynapsesForApicalSegment_.assign(
+    apicalConnections.segmentFlatListLength(), 0);
+
   auto random = proto.getRandom();
   rng_.read(random);
 
@@ -1431,29 +1468,45 @@ void ExtendedTemporalMemory::read(ExtendedTemporalMemoryProto::Reader& proto)
   activeBasalSegments_.clear();
   for (auto value : proto.getActiveBasalSegmentOverlaps())
   {
-    Segment segment = {(SegmentIdx)value.getSegment(), value.getCell()};
-    activeBasalSegments_.push_back({segment, value.getOverlap()});
+    Segment segment = basalConnections.getSegment(value.getCell(),
+                                                  value.getSegment());
+
+    activeBasalSegments_.push_back(segment);
+    numActiveConnectedSynapsesForBasalSegment_[segment.flatIdx] =
+      value.getOverlap();
   }
 
   matchingBasalSegments_.clear();
   for (auto value : proto.getMatchingBasalSegmentOverlaps())
   {
-    Segment segment = {(SegmentIdx)value.getSegment(), value.getCell()};
-    matchingBasalSegments_.push_back({segment, value.getOverlap()});
+    Segment segment = basalConnections.getSegment(value.getCell(),
+                                                  value.getSegment());
+
+    matchingBasalSegments_.push_back(segment);
+    numActivePotentialSynapsesForBasalSegment_[segment.flatIdx] =
+      value.getOverlap();
   }
 
   activeApicalSegments_.clear();
   for (auto value : proto.getActiveApicalSegmentOverlaps())
   {
-    Segment segment = {(SegmentIdx)value.getSegment(), value.getCell()};
-    activeApicalSegments_.push_back({segment, value.getOverlap()});
+    Segment segment = apicalConnections.getSegment(value.getCell(),
+                                                   value.getSegment());
+
+    activeApicalSegments_.push_back(segment);
+    numActiveConnectedSynapsesForApicalSegment_[segment.flatIdx] =
+      value.getOverlap();
   }
 
   matchingApicalSegments_.clear();
   for (auto value : proto.getMatchingApicalSegmentOverlaps())
   {
-    Segment segment = {(SegmentIdx)value.getSegment(), value.getCell()};
-    matchingApicalSegments_.push_back({segment, value.getOverlap()});
+    Segment segment = apicalConnections.getSegment(value.getCell(),
+                                                   value.getSegment());
+
+    matchingApicalSegments_.push_back(segment);
+    numActivePotentialSynapsesForApicalSegment_[segment.flatIdx] =
+      value.getOverlap();
   }
 
   learnOnOneCell_ = false;
@@ -1487,6 +1540,16 @@ void ExtendedTemporalMemory::load(istream& inStream)
 
   basalConnections.load(inStream);
   apicalConnections.load(inStream);
+
+  numActiveConnectedSynapsesForBasalSegment_.assign(
+    basalConnections.segmentFlatListLength(), 0);
+  numActivePotentialSynapsesForBasalSegment_.assign(
+    basalConnections.segmentFlatListLength(), 0);
+
+  numActiveConnectedSynapsesForApicalSegment_.assign(
+    apicalConnections.segmentFlatListLength(), 0);
+  numActivePotentialSynapsesForApicalSegment_.assign(
+    apicalConnections.segmentFlatListLength(), 0);
 
   inStream >> rng_;
 
@@ -1522,9 +1585,16 @@ void ExtendedTemporalMemory::load(istream& inStream)
   activeBasalSegments_.resize(numActiveBasalSegments);
   for (UInt i = 0; i < numActiveBasalSegments; i++)
   {
-    inStream >> activeBasalSegments_[i].segment.idx;
-    inStream >> activeBasalSegments_[i].segment.cell;
-    inStream >> activeBasalSegments_[i].overlap;
+    SegmentIdx idx;
+    inStream >> idx;
+
+    CellIdx cellIdx;
+    inStream >> cellIdx;
+
+    Segment segment = basalConnections.getSegment(cellIdx, idx);
+    activeBasalSegments_[i] = segment;
+
+    inStream >> numActiveConnectedSynapsesForBasalSegment_[segment.flatIdx];
   }
 
   UInt numMatchingBasalSegments;
@@ -1532,9 +1602,16 @@ void ExtendedTemporalMemory::load(istream& inStream)
   matchingBasalSegments_.resize(numMatchingBasalSegments);
   for (UInt i = 0; i < numMatchingBasalSegments; i++)
   {
-    inStream >> matchingBasalSegments_[i].segment.idx;
-    inStream >> matchingBasalSegments_[i].segment.cell;
-    inStream >> matchingBasalSegments_[i].overlap;
+    SegmentIdx idx;
+    inStream >> idx;
+
+    CellIdx cellIdx;
+    inStream >> cellIdx;
+
+    Segment segment = basalConnections.getSegment(cellIdx, idx);
+    matchingBasalSegments_[i] = segment;
+
+    inStream >> numActivePotentialSynapsesForBasalSegment_[segment.flatIdx];
   }
 
   UInt numActiveApicalSegments;
@@ -1542,9 +1619,16 @@ void ExtendedTemporalMemory::load(istream& inStream)
   activeApicalSegments_.resize(numActiveApicalSegments);
   for (UInt i = 0; i < numActiveApicalSegments; i++)
   {
-    inStream >> activeApicalSegments_[i].segment.idx;
-    inStream >> activeApicalSegments_[i].segment.cell;
-    inStream >> activeApicalSegments_[i].overlap;
+    SegmentIdx idx;
+    inStream >> idx;
+
+    CellIdx cellIdx;
+    inStream >> cellIdx;
+
+    Segment segment = apicalConnections.getSegment(cellIdx, idx);
+    activeApicalSegments_[i] = segment;
+
+    inStream >> numActiveConnectedSynapsesForApicalSegment_[segment.flatIdx];
   }
 
   UInt numMatchingApicalSegments;
@@ -1552,9 +1636,16 @@ void ExtendedTemporalMemory::load(istream& inStream)
   matchingApicalSegments_.resize(numMatchingApicalSegments);
   for (UInt i = 0; i < numMatchingApicalSegments; i++)
   {
-    inStream >> matchingApicalSegments_[i].segment.idx;
-    inStream >> matchingApicalSegments_[i].segment.cell;
-    inStream >> matchingApicalSegments_[i].overlap;
+    SegmentIdx idx;
+    inStream >> idx;
+
+    CellIdx cellIdx;
+    inStream >> cellIdx;
+
+    Segment segment = apicalConnections.getSegment(cellIdx, idx);
+    matchingApicalSegments_[i] = segment;
+
+    inStream >> numActivePotentialSynapsesForApicalSegment_[segment.flatIdx];
   }
 
   learnOnOneCell_ = false;

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -489,8 +489,8 @@ static void activatePredictedColumn(
   const vector<CellIdx>& prevActiveExternalCellsApical,
   const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
   const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
-  Permanence initialPermanence,
   UInt maxNewSynapseCount,
+  Permanence initialPermanence,
   Permanence permanenceIncrement,
   Permanence permanenceDecrement,
   bool formInternalBasalConnections,
@@ -572,8 +572,8 @@ static void burstColumn(
   const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
   const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
   UInt cellsPerColumn,
-  Permanence initialPermanence,
   UInt maxNewSynapseCount,
+  Permanence initialPermanence,
   Permanence permanenceIncrement,
   Permanence permanenceDecrement,
   bool formInternalBasalConnections,
@@ -768,8 +768,8 @@ void ExtendedTemporalMemory::activateCells(
           prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
           numActivePotentialSynapsesForBasalSegment_,
           numActivePotentialSynapsesForApicalSegment_,
-          initialPermanence_, maxNewSynapseCount_,
-          permanenceIncrement_, permanenceDecrement_,
+          maxNewSynapseCount_,
+          initialPermanence_, permanenceIncrement_, permanenceDecrement_,
           formInternalBasalConnections_, learn);
       }
       else
@@ -787,8 +787,8 @@ void ExtendedTemporalMemory::activateCells(
           prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
           numActivePotentialSynapsesForBasalSegment_,
           numActivePotentialSynapsesForApicalSegment_,
-          cellsPerColumn_, initialPermanence_, maxNewSynapseCount_,
-          permanenceIncrement_, permanenceDecrement_,
+          cellsPerColumn_, maxNewSynapseCount_,
+          initialPermanence_, permanenceIncrement_, permanenceDecrement_,
           formInternalBasalConnections_, learnOnOneCell_, learn);
       }
     }

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -175,11 +175,17 @@ namespace nupic {
          * @param activeColumns
          * A sorted list of active column indices.
          *
-         * @param prevActiveExternalCells
-         * The external cells that were used to calculate the current segment
-         * excitation. This class doesn't save a copy of these cells because the
-         * caller is more flexible to find ways of keeping this list available
-         * without extra copying.
+         * @param prevActiveExternalCellsBasal
+         * A sorted list of the external cells that were used to calculate the
+         * current basal segment excitation. This class doesn't save a copy of
+         * these cells because the caller is more flexible to find ways of
+         * keeping this list available without extra copying.
+         *
+         * @param prevActiveExternalCellsApical
+         * A sorted list of the external cells that were used to calculate the
+         * current apical segment excitation. This class doesn't save a copy of
+         * these cells because the caller is more flexible to find ways of
+         * keeping this list available without extra copying.
          *
          * @param learn
          * If true, reinforce / punish / grow synapses.
@@ -226,12 +232,10 @@ namespace nupic {
          * Calculate dendrite segment activity, using the current active cells.
          *
          * @param activeExternalCellsBasal
-         * Active external cells that should be used for activating basal
-         * dendrites in this timestep.
+         * Sorted list of active external cells for activating basal dendrites.
          *
          * @param activeExternalCellsApical
-         * Active external cells that should be used for activating apical
-         * dendrites in this timestep.
+         * Sorted list of active external cells for activating apical dendrites.
          *
          * @param learn
          * If true, segment activations will be recorded. This information is
@@ -267,8 +271,8 @@ namespace nupic {
          * available without extra copying.
          *
          * @param activeExternalCellsBasal
-         * Active external cells that should be used for activating basal
-         * dendrites in this timestep.
+         * Sorted list of active external cells that should be used for
+         * activating basal dendrites in this timestep.
          *
          * @param prevActiveExternalCellsApical
          * The external cells that were used to calculate the current apical
@@ -277,8 +281,8 @@ namespace nupic {
          * available without extra copying.
          *
          * @param activeExternalCellsApical
-         * Active external cells that should be used for activating apical
-         * dendrites in this timestep.
+         * Sorted list of active external cells that should be used for
+         * activating apical dendrites in this timestep.
          *
          * @param learn
          * Whether or not learning is enabled

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -223,6 +223,26 @@ namespace nupic {
           bool learn = true);
 
         /**
+         * Calculate dendrite segment activity, using the current active cells.
+         *
+         * @param activeExternalCellsBasal
+         * Active external cells that should be used for activating basal
+         * dendrites in this timestep.
+         *
+         * @param activeExternalCellsApical
+         * Active external cells that should be used for activating apical
+         * dendrites in this timestep.
+         *
+         * @param learn
+         * If true, segment activations will be recorded. This information is
+         * used during segment cleanup.
+         */
+        void activateDendrites(
+          const vector<CellIdx>& activeExternalCellsBasal,
+          const vector<CellIdx>& activeExternalCellsApical,
+          bool learn = true);
+
+        /**
          * For backward-compatibility with TemporalMemory unit tests.
          *
          * Feeds input record through TM, performing inference and learning.
@@ -502,10 +522,16 @@ namespace nupic {
 
         vector<CellIdx> activeCells_;
         vector<CellIdx> winnerCells_;
-        vector<SegmentOverlap> activeBasalSegments_;
-        vector<SegmentOverlap> matchingBasalSegments_;
-        vector<SegmentOverlap> activeApicalSegments_;
-        vector<SegmentOverlap> matchingApicalSegments_;
+
+        vector<Segment> activeBasalSegments_;
+        vector<Segment> matchingBasalSegments_;
+        vector<UInt32> numActiveConnectedSynapsesForBasalSegment_;
+        vector<UInt32> numActivePotentialSynapsesForBasalSegment_;
+
+        vector<Segment> activeApicalSegments_;
+        vector<Segment> matchingApicalSegments_;
+        vector<UInt32> numActiveConnectedSynapsesForApicalSegment_;
+        vector<UInt32> numActivePotentialSynapsesForApicalSegment_;
 
         bool learnOnOneCell_;
         map<UInt, CellIdx> chosenCellForColumn_;

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -45,7 +45,7 @@ namespace nupic
 
     namespace connections
     {
-      struct SegmentOverlap;
+      struct Segment;
     }
   }
 
@@ -83,7 +83,7 @@ namespace nupic
     std::vector<CellIdx> computeSPWinnerCells(
       Connections& connections,
       UInt numCells,
-      vector<algorithms::connections::SegmentOverlap> activeSegments);
+      const vector<UInt>& numActiveSynapsesForSegment);
 
   }; // end class ConnectionsPerformanceTest
 

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -303,43 +303,6 @@ namespace {
   }
 
   /**
-   * Active segments on predicted active cells should not grow new synapses.
-   */
-  TEST(TemporalMemoryTest, NoGrowthOnCorrectlyActiveSegments)
-  {
-    TemporalMemory tm(
-      /*columnDimensions*/ {32},
-      /*cellsPerColumn*/ 4,
-      /*activationThreshold*/ 3,
-      /*initialPermanence*/ 0.2,
-      /*connectedPermanence*/ 0.50,
-      /*minThreshold*/ 2,
-      /*maxNewSynapseCount*/ 4,
-      /*permanenceIncrement*/ 0.10,
-      /*permanenceDecrement*/ 0.10,
-      /*predictedSegmentDecrement*/ 0.02,
-      /*seed*/ 42
-      );
-
-    const UInt numActiveColumns = 1;
-    const UInt previousActiveColumns[1] = {0};
-    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
-    const UInt activeColumns[1] = {1};
-    const vector<CellIdx> activeCells = {5};
-    const CellIdx activeCell = 5;
-
-    Segment activeSegment = tm.connections.createSegment(activeCell);
-    tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
-    tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
-    tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
-
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
-
-    EXPECT_EQ(3, tm.connections.numSynapses(activeSegment));
-  }
-
-  /**
    * The best matching segment in a bursting column should be reinforced. Active
    * synapses should be strengthened, and inactive synapses should be weakened.
    */

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -316,45 +316,6 @@ namespace {
   }
 
   /**
-   * Active segments on predicted active cells should not grow new synapses.
-   */
-  TEST(ExtendedTemporalMemoryTest, NoGrowthOnCorrectlyActiveSegments)
-  {
-    ExtendedTemporalMemory tm(
-      /*columnDimensions*/ {32},
-      /*cellsPerColumn*/ 4,
-      /*activationThreshold*/ 3,
-      /*initialPermanence*/ 0.2,
-      /*connectedPermanence*/ 0.50,
-      /*minThreshold*/ 2,
-      /*maxNewSynapseCount*/ 4,
-      /*permanenceIncrement*/ 0.10,
-      /*permanenceDecrement*/ 0.10,
-      /*predictedSegmentDecrement*/ 0.02,
-      /*formInternalBasalConnections*/ true,
-      /*learnOnOneCell*/ false,
-      /*seed*/ 42
-      );
-
-    const UInt numActiveColumns = 1;
-    const UInt previousActiveColumns[1] = {0};
-    const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
-    const UInt activeColumns[1] = {1};
-    const vector<CellIdx> activeCells = {5};
-    const CellIdx activeCell = 5;
-
-    Segment activeSegment = tm.basalConnections.createSegment(activeCell);
-    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
-    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
-    tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
-
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
-
-    EXPECT_EQ(3, tm.basalConnections.numSynapses(activeSegment));
-  }
-
-  /**
    * The best matching segment in a bursting column should be reinforced. Active
    * synapses should be strengthened, and inactive synapses should be weakened.
    */


### PR DESCRIPTION
Fixes #1062

Here's the matching Python change, with additional changes: https://github.com/numenta/nupic/pull/3307

This change stops passing around Segment + Overlap pairs. Instead, `activeSegments` and `matchingSegments` are simply lists of segments, and we keep the internals of `computeActivity` available so that we can look up the "overlap" of any segment. We don't call it the "overlap" any more, we refer specifically to the `numActivePotentialSynapsesForSegment` and `numActiveConnectedSynapsesForSegment`.

This simplifies the code, especially `activatePredictedColumn`, and it's just cleaner in principle. Also it's a little faster.

Before:

~~~
> python scripts/temporal_memory_performance_benchmark.py -i tm_cpp -t hotgym
Test: hotgym

tm_cpp: 0.776342s
~~~

After:

~~~
> python scripts/temporal_memory_performance_benchmark.py -i tm_cpp -t hotgym
Test: hotgym

tm_cpp: 0.709386s
~~~

So it's about 9% faster.