### PR TITLE
Use C arrays as (Extended)TemporalMemory inputs

### DIFF
--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -58,6 +58,28 @@ static const UInt TM_VERSION = 2;
 
 
 
+template<typename Iterator>
+bool isSortedWithoutDuplicates(Iterator begin, Iterator end)
+{
+  if (std::distance(begin, end) >= 2)
+  {
+    Iterator now = begin;
+    Iterator next = begin + 1;
+    while (next != end)
+    {
+      if (*now >= *next)
+      {
+        return false;
+      }
+
+      now = next++;
+    }
+  }
+
+  return true;
+}
+
+
 TemporalMemory::TemporalMemory()
 {
 }
@@ -448,8 +470,9 @@ void TemporalMemory::activateCells(
   const UInt activeColumns[],
   bool learn)
 {
-  NTA_ASSERT(std::is_sorted(activeColumns,
-                            activeColumns + activeColumnsSize));
+  NTA_CHECK(isSortedWithoutDuplicates(activeColumns,
+                                      activeColumns + activeColumnsSize))
+    << "The activeColumns must be a sorted list of indices without duplicates.";
 
   const vector<CellIdx> prevActiveCells = std::move(activeCells_);
   const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -274,7 +274,8 @@ static void adaptSegment(
   Connections& connections,
   Segment segment,
   const vector<CellIdx>& prevActiveCells,
-  const vector<CellIdx>& prevActiveExternalCells,
+  size_t prevActiveExternalCellsSize,
+  const CellIdx prevActiveExternalCells[],
   Permanence permanenceIncrement,
   Permanence permanenceDecrement)
 {
@@ -295,8 +296,8 @@ static void adaptSegment(
     else
     {
       isActive = std::binary_search(
-        prevActiveExternalCells.begin(),
-        prevActiveExternalCells.end(),
+        prevActiveExternalCells,
+        prevActiveExternalCells + prevActiveExternalCellsSize,
         synapseData.presynapticCell - connections.numCells());
     }
 
@@ -336,15 +337,17 @@ static void growSynapses(
   Segment segment,
   UInt32 nDesiredNewSynapses,
   const vector<CellIdx>& internalCandidates,
-  const vector<CellIdx>& externalCandidates,
+  size_t externalCandidatesSize,
+  const CellIdx externalCandidates[],
   Permanence initialPermanence)
 {
   vector<CellIdx> candidates;
-  candidates.reserve(internalCandidates.size() + externalCandidates.size());
+  candidates.reserve(internalCandidates.size() + externalCandidatesSize);
   candidates.insert(candidates.begin(), internalCandidates.begin(),
                     internalCandidates.end());
-  for (CellIdx cell : externalCandidates)
+  for (size_t i = 0; i < externalCandidatesSize; i++)
   {
+    const CellIdx cell = externalCandidates[i];
     candidates.push_back(cell + connections.numCells());
   }
 
@@ -389,7 +392,8 @@ static void learnOnCell(
   vector<Segment>::const_iterator cellMatchingSegmentsEnd,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& internalCandidates,
-  const vector<CellIdx>& externalCandidates,
+  size_t externalCandidatesSize,
+  const CellIdx externalCandidates[],
   const vector<UInt32>& numActivePotentialSynapsesForSegment,
   UInt maxNewSynapseCount,
   Permanence initialPermanence,
@@ -405,7 +409,8 @@ static void learnOnCell(
     {
       adaptSegment(connections,
                    *activeSegment,
-                   prevActiveCells, externalCandidates,
+                   prevActiveCells,
+                   externalCandidatesSize, externalCandidates,
                    permanenceIncrement, permanenceDecrement);
 
       const Int32 nGrowDesired = maxNewSynapseCount -
@@ -414,7 +419,8 @@ static void learnOnCell(
         {
           growSynapses(connections, rng,
                        *activeSegment, nGrowDesired,
-                       internalCandidates, externalCandidates,
+                       internalCandidates,
+                       externalCandidatesSize, externalCandidates,
                        initialPermanence);
         }
     } while (++activeSegment != cellActiveSegmentsEnd);
@@ -434,7 +440,8 @@ static void learnOnCell(
 
     adaptSegment(connections,
                  bestMatchingSegment,
-                 prevActiveCells, externalCandidates,
+                 prevActiveCells,
+                 externalCandidatesSize, externalCandidates,
                  permanenceIncrement, permanenceDecrement);
 
     const Int32 nGrowDesired = maxNewSynapseCount -
@@ -443,7 +450,8 @@ static void learnOnCell(
     {
       growSynapses(connections, rng,
                    bestMatchingSegment, nGrowDesired,
-                   internalCandidates, externalCandidates,
+                   internalCandidates,
+                   externalCandidatesSize, externalCandidates,
                    initialPermanence);
     }
   }
@@ -455,13 +463,14 @@ static void learnOnCell(
     // Don't grow a segment that will never match.
     const UInt32 nGrowExact = std::min(maxNewSynapseCount,
                                        (UInt)(internalCandidates.size() +
-                                              externalCandidates.size()));
+                                              externalCandidatesSize));
     if (nGrowExact > 0)
     {
       const Segment segment = connections.createSegment(cell);
       growSynapses(connections, rng,
                    segment, nGrowExact,
-                   internalCandidates, externalCandidates,
+                   internalCandidates,
+                   externalCandidatesSize, externalCandidates,
                    initialPermanence);
       NTA_ASSERT(connections.numSynapses(segment) == nGrowExact);
     }
@@ -485,8 +494,10 @@ static void activatePredictedColumn(
   UInt32 predictiveThreshold,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& prevWinnerCells,
-  const vector<CellIdx>& prevActiveExternalCellsBasal,
-  const vector<CellIdx>& prevActiveExternalCellsApical,
+  size_t prevActiveExternalCellsBasalSize,
+  const CellIdx prevActiveExternalCellsBasal[],
+  size_t prevActiveExternalCellsApicalSize,
+  const CellIdx prevActiveExternalCellsApical[],
   const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
   const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
   UInt maxNewSynapseCount,
@@ -530,6 +541,7 @@ static void activatePredictedColumn(
                     prevActiveCells,
                     (formInternalBasalConnections
                      ? prevWinnerCells : CELLS_NONE),
+                    prevActiveExternalCellsBasalSize,
                     prevActiveExternalCellsBasal,
                     numActivePotentialSynapsesForBasalSegment,
                     maxNewSynapseCount, initialPermanence,
@@ -540,7 +552,9 @@ static void activatePredictedColumn(
                     cellActiveApicalBegin, cellActiveApicalEnd,
                     cellMatchingApicalBegin, cellMatchingApicalEnd,
                     prevActiveCells,
-                    CELLS_NONE, prevActiveExternalCellsApical,
+                    CELLS_NONE,
+                    prevActiveExternalCellsApicalSize,
+                    prevActiveExternalCellsApical,
                     numActivePotentialSynapsesForApicalSegment,
                     maxNewSynapseCount, initialPermanence,
                     permanenceIncrement, permanenceDecrement);
@@ -567,8 +581,10 @@ static void burstColumn(
   vector<Segment>::const_iterator columnMatchingApicalEnd,
   const vector<CellIdx>& prevActiveCells,
   const vector<CellIdx>& prevWinnerCells,
-  const vector<CellIdx>& prevActiveExternalCellsBasal,
-  const vector<CellIdx>& prevActiveExternalCellsApical,
+  size_t prevActiveExternalCellsBasalSize,
+  const CellIdx prevActiveExternalCellsBasal[],
+  size_t prevActiveExternalCellsApicalSize,
+  const CellIdx prevActiveExternalCellsApical[],
   const vector<UInt32>& numActivePotentialSynapsesForBasalSegment,
   const vector<UInt32>& numActivePotentialSynapsesForApicalSegment,
   UInt cellsPerColumn,
@@ -655,6 +671,7 @@ static void burstColumn(
                 prevActiveCells,
                 (formInternalBasalConnections
                  ? prevWinnerCells : CELLS_NONE),
+                prevActiveExternalCellsBasalSize,
                 prevActiveExternalCellsBasal,
                 numActivePotentialSynapsesForBasalSegment,
                 maxNewSynapseCount, initialPermanence,
@@ -665,7 +682,9 @@ static void burstColumn(
                 cellActiveApicalBegin, cellActiveApicalEnd,
                 cellMatchingApicalBegin, cellMatchingApicalEnd,
                 prevActiveCells,
-                CELLS_NONE, prevActiveExternalCellsApical,
+                CELLS_NONE,
+                prevActiveExternalCellsApicalSize,
+                prevActiveExternalCellsApical,
                 numActivePotentialSynapsesForApicalSegment,
                 maxNewSynapseCount, initialPermanence,
                 permanenceIncrement, permanenceDecrement);
@@ -677,7 +696,8 @@ static void punishPredictedColumn(
   vector<Segment>::const_iterator matchingSegmentsBegin,
   vector<Segment>::const_iterator matchingSegmentsEnd,
   const vector<CellIdx>& prevActiveCells,
-  const vector<CellIdx>& prevActiveExternalCells,
+  size_t prevActiveExternalCellsSize,
+  const CellIdx prevActiveExternalCells[],
   Permanence predictedSegmentDecrement)
 {
   if (predictedSegmentDecrement > 0.0)
@@ -686,23 +706,33 @@ static void punishPredictedColumn(
          matchingSegment != matchingSegmentsEnd; matchingSegment++)
     {
       adaptSegment(connections, *matchingSegment,
-                   prevActiveCells, prevActiveExternalCells,
+                   prevActiveCells,
+                   prevActiveExternalCellsSize, prevActiveExternalCells,
                    -predictedSegmentDecrement, 0.0);
     }
   }
 }
 
 void ExtendedTemporalMemory::activateCells(
-  const vector<UInt>& activeColumns,
-  const vector<CellIdx>& prevActiveExternalCellsBasal,
-  const vector<CellIdx>& prevActiveExternalCellsApical,
+  size_t activeColumnsSize,
+  const UInt activeColumns[],
+
+  size_t prevActiveExternalCellsBasalSize,
+  const CellIdx prevActiveExternalCellsBasal[],
+
+  size_t prevActiveExternalCellsApicalSize,
+  const CellIdx prevActiveExternalCellsApical[],
+
   bool learn)
 {
-  NTA_ASSERT(std::is_sorted(activeColumns.begin(), activeColumns.end()));
-  NTA_ASSERT(std::is_sorted(prevActiveExternalCellsBasal.begin(),
-                            prevActiveExternalCellsBasal.end()));
-  NTA_ASSERT(std::is_sorted(prevActiveExternalCellsApical.begin(),
-                            prevActiveExternalCellsApical.end()));
+  NTA_ASSERT(std::is_sorted(activeColumns,
+                            activeColumns + activeColumnsSize));
+  NTA_ASSERT(std::is_sorted(prevActiveExternalCellsBasal,
+                            prevActiveExternalCellsBasal +
+                            prevActiveExternalCellsBasalSize));
+  NTA_ASSERT(std::is_sorted(prevActiveExternalCellsApical,
+                            prevActiveExternalCellsApical +
+                            prevActiveExternalCellsApicalSize));
 
   const vector<CellIdx> prevActiveCells = std::move(activeCells_);
   const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
@@ -710,15 +740,21 @@ void ExtendedTemporalMemory::activateCells(
   const auto columnForSegment =
     [&](Segment segment) { return segment.cell / cellsPerColumn_; };
 
-  for (auto& columnData : groupBy(activeColumns, identity<UInt>,
-                                  activeBasalSegments_, columnForSegment,
-                                  matchingBasalSegments_, columnForSegment,
-                                  activeApicalSegments_, columnForSegment,
-                                  matchingApicalSegments_, columnForSegment))
+  for (auto& columnData : iterGroupBy(
+         activeColumns,
+         activeColumns + activeColumnsSize, identity<UInt>,
+         activeBasalSegments_.begin(),
+         activeBasalSegments_.end(), columnForSegment,
+         matchingBasalSegments_.begin(),
+         matchingBasalSegments_.end(), columnForSegment,
+         activeApicalSegments_.begin(),
+         activeApicalSegments_.end(), columnForSegment,
+         matchingApicalSegments_.begin(),
+         matchingApicalSegments_.end(), columnForSegment))
   {
     UInt column;
-    vector<UInt>::const_iterator
-      activeColumnsBegin, activeColumnsEnd;
+    const UInt* activeColumnsBegin;
+    const UInt* activeColumnsEnd;
     vector<Segment>::const_iterator
       columnActiveBasalBegin, columnActiveBasalEnd,
       columnMatchingBasalBegin, columnMatchingBasalEnd,
@@ -765,7 +801,8 @@ void ExtendedTemporalMemory::activateCells(
           columnMatchingApicalBegin, columnMatchingApicalEnd,
           maxPredictiveScore,
           prevActiveCells, prevWinnerCells,
-          prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
+          prevActiveExternalCellsBasalSize, prevActiveExternalCellsBasal,
+          prevActiveExternalCellsApicalSize, prevActiveExternalCellsApical,
           numActivePotentialSynapsesForBasalSegment_,
           numActivePotentialSynapsesForApicalSegment_,
           maxNewSynapseCount_,
@@ -784,7 +821,8 @@ void ExtendedTemporalMemory::activateCells(
           columnActiveApicalBegin, columnActiveApicalEnd,
           columnMatchingApicalBegin, columnMatchingApicalEnd,
           prevActiveCells, prevWinnerCells,
-          prevActiveExternalCellsBasal, prevActiveExternalCellsApical,
+          prevActiveExternalCellsBasalSize, prevActiveExternalCellsBasal,
+          prevActiveExternalCellsApicalSize, prevActiveExternalCellsApical,
           numActivePotentialSynapsesForBasalSegment_,
           numActivePotentialSynapsesForApicalSegment_,
           cellsPerColumn_, maxNewSynapseCount_,
@@ -799,7 +837,8 @@ void ExtendedTemporalMemory::activateCells(
         punishPredictedColumn(
           basalConnections,
           columnMatchingBasalBegin, columnMatchingBasalEnd,
-          prevActiveCells, prevActiveExternalCellsBasal,
+          prevActiveCells,
+          prevActiveExternalCellsBasalSize, prevActiveExternalCellsBasal,
           predictedSegmentDecrement_);
 
         // Don't punish apical segments.
@@ -815,7 +854,8 @@ static void calculateExcitation(
   vector<Segment>& matchingSegments,
   Connections& connections,
   const vector<CellIdx>& activeCells,
-  const vector<CellIdx>& activeExternalCells,
+  size_t activeExternalCellsSize,
+  const CellIdx activeExternalCells[],
   Permanence connectedPermanence,
   UInt activationThreshold,
   UInt minThreshold,
@@ -830,8 +870,9 @@ static void calculateExcitation(
                               activeCells,
                               connectedPermanence);
 
-  for (CellIdx cell : activeExternalCells)
+  for (size_t i = 0; i < activeExternalCellsSize; i++)
   {
+    const CellIdx cell = activeExternalCells[i];
     connections.computeActivity(numActiveConnectedSynapsesForSegment,
                                 numActivePotentialSynapsesForSegment,
                                 cell + connections.numCells(),
@@ -871,68 +912,63 @@ static void calculateExcitation(
   }
 }
 
-void ExtendedTemporalMemory::activateBasalDendrites(
-  const vector<CellIdx>& activeExternalCells,
+void ExtendedTemporalMemory::activateDendrites(
+  size_t activeExternalCellsBasalSize,
+  const CellIdx activeExternalCellsBasal[],
+
+  size_t activeExternalCellsApicalSize,
+  const CellIdx activeExternalCellsApical[],
+
   bool learn)
 {
   calculateExcitation(
     numActiveConnectedSynapsesForBasalSegment_, activeBasalSegments_,
     numActivePotentialSynapsesForBasalSegment_, matchingBasalSegments_,
     basalConnections,
-    activeCells_, activeExternalCells,
+    activeCells_, activeExternalCellsBasalSize, activeExternalCellsBasal,
     connectedPermanence_, activationThreshold_, minThreshold_,
     learn);
-}
 
-void ExtendedTemporalMemory::activateApicalDendrites(
-  const vector<CellIdx>& activeExternalCells,
-  bool learn)
-{
   calculateExcitation(
     numActiveConnectedSynapsesForApicalSegment_, activeApicalSegments_,
     numActivePotentialSynapsesForApicalSegment_, matchingApicalSegments_,
     apicalConnections,
-    activeCells_, activeExternalCells,
+    activeCells_, activeExternalCellsApicalSize, activeExternalCellsApical,
     connectedPermanence_, activationThreshold_, minThreshold_,
     learn);
 }
 
-void ExtendedTemporalMemory::activateDendrites(
-  const vector<CellIdx>& activeExternalCellsBasal,
-  const vector<CellIdx>& activeExternalCellsApical,
+void ExtendedTemporalMemory::compute(
+  size_t activeColumnsSize,
+  const UInt activeColumns[],
+
+  size_t prevActiveExternalCellsBasalSize,
+  const CellIdx prevActiveExternalCellsBasal[],
+
+  size_t activeExternalCellsBasalSize,
+  const CellIdx activeExternalCellsBasal[],
+
+  size_t prevActiveExternalCellsApicalSize,
+  const CellIdx prevActiveExternalCellsApical[],
+
+  size_t activeExternalCellsApicalSize,
+  const CellIdx activeExternalCellsApical[],
+
   bool learn)
 {
-  activateBasalDendrites(activeExternalCellsBasal, learn);
-  activateApicalDendrites(activeExternalCellsApical, learn);
-}
-
-void ExtendedTemporalMemory::compute(
-  UInt activeColumnsSize, const UInt activeColumnsUnsorted[], bool learn)
-{
-  const vector<UInt> activeColumns(activeColumnsUnsorted,
-                                   activeColumnsUnsorted + activeColumnsSize);
-  compute(activeColumns, {}, {}, {}, {}, learn);
-}
-
-void ExtendedTemporalMemory::compute(
-  const vector<UInt>& activeColumnsUnsorted,
-  const vector<CellIdx>& prevActiveExternalCellsBasal,
-  const vector<CellIdx>& activeExternalCellsBasal,
-  const vector<CellIdx>& prevActiveExternalCellsApical,
-  const vector<CellIdx>& activeExternalCellsApical,
-  bool learn)
-{
-  vector<UInt> activeColumns(activeColumnsUnsorted.begin(),
-                             activeColumnsUnsorted.end());
-  std::sort(activeColumns.begin(), activeColumns.end());
-
-  activateCells(activeColumns,
+  activateCells(activeColumnsSize,
+                activeColumns,
+                prevActiveExternalCellsBasalSize,
                 prevActiveExternalCellsBasal,
+                prevActiveExternalCellsApicalSize,
                 prevActiveExternalCellsApical,
                 learn);
 
-  activateBasalDendrites(activeExternalCellsBasal, learn);
-  activateApicalDendrites(activeExternalCellsApical, learn);
+  activateDendrites(activeExternalCellsBasalSize,
+                    activeExternalCellsBasal,
+                    activeExternalCellsApicalSize,
+                    activeExternalCellsApical,
+                    learn);
 }
 
 void ExtendedTemporalMemory::reset(void)

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -1344,13 +1344,13 @@ namespace {
       SequenceMachine sequenceMachine = SequenceMachine(self.patternMachine);
       Sequence sequence = self.sequenceMachine.generateFromNumbers(range(5));
     */
-    vector<vector<UInt>> sequence = 
-      { 
-        { 83, 53, 70, 45 },
-        { 8, 65, 67, 59 },
-        { 25, 98, 99, 39 },
-        { 66, 11, 78, 14 },
-        { 96, 87, 69, 95 } };
+    vector<vector<UInt>> sequence =
+      {
+        { 45, 53, 70, 83 },
+        { 8, 59, 65, 67 },
+        { 25, 39, 98, 99 },
+        { 11, 14, 66, 78 },
+        { 69, 87, 95, 96 } };
 
     for (UInt i = 0; i < 3; i++)
     {

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -66,6 +66,56 @@ namespace {
   }
 
   /**
+   * If you call compute with unsorted input, it should throw an exception.
+   */
+  TEST(TemporalMemoryTest, testCheckInputs_UnsortedColumns)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42
+      );
+
+    const UInt activeColumns[4] = {1, 3, 2, 4};
+
+    EXPECT_THROW(tm.compute(4, activeColumns), exception);
+  }
+
+  /**
+   * If you call compute with a binary vector rather than a list of indices, it
+   * should throw an exception.
+   */
+  TEST(TemporalMemoryTest, testCheckInputs_BinaryArray)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.21,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.10,
+      /*permanenceDecrement*/ 0.10,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42
+      );
+
+    // Use an input that will pass an `is_sorted` check.
+    const UInt activeColumns[5] = {0, 0, 0, 1, 1};
+
+    EXPECT_THROW(tm.compute(5, activeColumns), exception);
+  }
+
+  /**
    * When a predicted column is activated, only the predicted cells in the
    * columns should be activated.
    */

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -101,9 +101,9 @@ namespace {
     tm.basalConnections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
     tm.basalConnections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
     ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_EQ(expectedActiveCells, tm.getActiveCells());
   }
@@ -133,7 +133,7 @@ namespace {
     const UInt activeColumns[1] = {0};
     const vector<CellIdx> burstingCells = {0, 1, 2, 3};
 
-    tm.compute(1, activeColumns, true);
+    tm.compute(1, activeColumns);
 
     EXPECT_EQ(burstingCells, tm.getActiveCells());
   }
@@ -172,13 +172,13 @@ namespace {
     tm.basalConnections.createSynapse(segment, previousActiveCells[2], 0.5);
     tm.basalConnections.createSynapse(segment, previousActiveCells[3], 0.5);
 
-    tm.compute(1, previousActiveColumns, true);
+    tm.compute(1, previousActiveColumns);
     ASSERT_FALSE(tm.getActiveCells().empty());
     ASSERT_FALSE(tm.getWinnerCells().empty());
     ASSERT_FALSE(tm.getPredictiveCells().empty());
 
     const UInt zeroColumns[0] = {};
-    tm.compute(0, zeroColumns, true);
+    tm.compute(0, zeroColumns);
 
     EXPECT_TRUE(tm.getActiveCells().empty());
     EXPECT_TRUE(tm.getWinnerCells().empty());
@@ -225,8 +225,12 @@ namespace {
     tm.basalConnections.createSynapse(activeSegment2, previousActiveCells[1], 0.5);
     tm.basalConnections.createSynapse(activeSegment2, previousActiveCells[2], 0.5);
 
-    tm.compute(numActiveColumns, previousActiveColumns, false);
-    tm.compute(numActiveColumns, activeColumns, false);
+    tm.compute(numActiveColumns, previousActiveColumns,
+               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               false);
+    tm.compute(numActiveColumns, activeColumns,
+               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               false);
 
     EXPECT_EQ(expectedWinnerCells, tm.getWinnerCells());
   }
@@ -256,7 +260,9 @@ namespace {
     const UInt activeColumns[1] = {0};
     const set<CellIdx> burstingCells = {0, 1, 2, 3};
 
-    tm.compute(1, activeColumns, false);
+    tm.compute(1, activeColumns,
+               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               false);
 
     vector<CellIdx> winnerCells = tm.getWinnerCells();
     ASSERT_EQ(1, winnerCells.size());
@@ -302,8 +308,8 @@ namespace {
     Synapse inactiveSynapse =
       tm.basalConnections.createSynapse(activeSegment, 81, 0.5);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_NEAR(0.6, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
                 EPSILON);
@@ -368,8 +374,8 @@ namespace {
     tm.basalConnections.createSynapse(otherMatchingSegment,
                                       81, 0.3);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_NEAR(0.4, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
                 EPSILON);
@@ -431,8 +437,8 @@ namespace {
       tm.basalConnections.createSynapse(otherMatchingSegment,
                                         81, 0.3);
 
-    tm.compute(1, previousActiveColumns, true);
-    tm.compute(1, activeColumns, true);
+    tm.compute(1, previousActiveColumns);
+    tm.compute(1, activeColumns);
 
     EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
                 EPSILON);
@@ -495,9 +501,9 @@ namespace {
       tm.basalConnections.createSynapse(matchingSegmentOnOtherCell,
                                         previousActiveCells[1], 0.3);
 
-    tm.compute(1, previousActiveColumns, true);
+    tm.compute(1, previousActiveColumns);
     ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells());
-    tm.compute(1, activeColumns, true);
+    tm.compute(1, activeColumns);
 
     EXPECT_NEAR(0.3, tm.basalConnections.dataForSynapse(synapse1).permanence,
                 EPSILON);
@@ -818,8 +824,8 @@ namespace {
     Synapse weakActiveSynapse =
       tm.basalConnections.createSynapse(activeSegment, previousActiveCells[3], 0.015);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_TRUE(tm.basalConnections.dataForSynapse(weakActiveSynapse).destroyed);
   }
@@ -859,8 +865,8 @@ namespace {
     Synapse weakInactiveSynapse =
       tm.basalConnections.createSynapse(activeSegment, 81, 0.09);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_TRUE(tm.basalConnections.dataForSynapse(weakInactiveSynapse).destroyed);
   }
@@ -1008,8 +1014,8 @@ namespace {
     tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[2], 0.015);
     tm.basalConnections.createSynapse(matchingSegment, previousActiveCells[3], 0.015);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_TRUE(tm.basalConnections.dataForSegment(matchingSegment).destroyed);
     EXPECT_EQ(0, tm.basalConnections.numSegments(expectedActiveCell));
@@ -1066,8 +1072,8 @@ namespace {
     Synapse inactiveSynapse2 =
       tm.basalConnections.createSynapse(matchingSegment, previousInactiveCell, 0.5);
 
-    tm.compute(numActiveColumns, previousActiveColumns, true);
-    tm.compute(numActiveColumns, activeColumns, true);
+    tm.compute(numActiveColumns, previousActiveColumns);
+    tm.compute(numActiveColumns, activeColumns);
 
     EXPECT_NEAR(0.48, tm.basalConnections.dataForSynapse(activeSynapse1).permanence,
                 EPSILON);
@@ -1124,8 +1130,8 @@ namespace {
       Segment segment2 = tm.basalConnections.createSegment(nonmatchingCells[1]);
       tm.basalConnections.createSynapse(segment2, previousActiveCells[1], 0.5);
 
-      tm.compute(4, previousActiveColumns, true);
-      tm.compute(1, activeColumns, true);
+      tm.compute(4, previousActiveColumns);
+      tm.compute(1, activeColumns);
 
       ASSERT_EQ(activeCells, tm.getActiveCells());
 
@@ -1271,8 +1277,12 @@ namespace {
 
     Connections before = tm.basalConnections;
 
-    tm.compute(1, previousActiveColumns, false);
-    tm.compute(2, activeColumns, false);
+    tm.compute(1, previousActiveColumns,
+               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               false);
+    tm.compute(2, activeColumns,
+               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               false);
 
     EXPECT_EQ(before, tm.basalConnections);
   }
@@ -1363,7 +1373,7 @@ namespace {
     tm1.basalConnections.createSynapse(activeSegment, previousActiveCells[3],
                                        0.5);
 
-    tm1.compute(numActiveColumns, previousActiveColumns, true);
+    tm1.compute(numActiveColumns, previousActiveColumns);
     ASSERT_EQ(expectedActiveCells, tm1.getPredictiveCells());
 
     {
@@ -1401,11 +1411,11 @@ namespace {
     */
     vector<vector<UInt>> sequence =
       {
-        { 83, 53, 70, 45 },
-        { 8, 65, 67, 59 },
-        { 25, 98, 99, 39 },
-        { 66, 11, 78, 14 },
-        { 96, 87, 69, 95 } };
+        { 45, 53, 70, 83 },
+        { 8, 59, 65, 67 },
+        { 25, 39, 98, 99 },
+        { 11, 14, 66, 78 },
+        { 69, 87, 95, 96 } };
 
     for (UInt i = 0; i < 3; i++)
     {


### PR DESCRIPTION
Fixes #1073

Building a `const vector<UInt>&` from a numpy array is expensive. At the very least, it requires copying the array, because there's (sadly) no way to construct a `const vector<UInt>&` from a `UInt[]`. On top of that, when you convert a numpy array to a vector, SWIG calls `PyLong_AsUnsignedLong` on every entry in the array. This is very slow. (Also, it shouldn't be necessary since the numpy `uint32` is already formatted correctly for C.)

Fundamentally, using vectors as inputs in a public API is a limiting move. It forces your callers to use vectors, or to pay the cost of copying their input into a vector. It's better to build APIs that use C arrays, because then anyone who stores their data in contiguous blocks of memory is free to call your API on their data.

With this change, the TM and ETM take C arrays as inputs, and we consume the arrays in-place, never copying them into a vector (except when building a candidates list in `growSynapses`). Now the arrays must already be sorted, but the SWIG code handles this, so this won't break Python callers.

## Perf results

**Before**

Running [this research script](https://github.com/numenta/nupic.research/blob/d6374a213172dbdfc671727b5d288fef1ef99786/projects/l2_pooling/multi_column_convergence.py) (which takes about 13 seconds), here's what the Python profiler has to say about the ETM:

~~~
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4900    2.262    0.000    2.262    0.000 {_experimental.ExtendedTemporalMemory_compute}
     4900    0.401    0.000    0.401    0.000 {_experimental.ExtendedTemporalMemory_activateDendrites}
     4900    0.346    0.000    0.346    0.000 {_experimental.ExtendedTemporalMemory_activateCells}
~~~

See issue #1073 for the C profiler numbers of a different run.

**After**

Python profiler:

~~~
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4900    0.390    0.000    0.390    0.000 {_experimental.ExtendedTemporalMemory_convertedCompute}
     4900    0.353    0.000    0.353    0.000 {_experimental.ExtendedTemporalMemory_convertedActivateDendrites}
     4900    0.308    0.000    0.308    0.000 {_experimental.ExtendedTemporalMemory_convertedActivateCells}
~~~

So the ETM now only takes 1.05 seconds where it previously took 3.01 seconds.

Here's an updated C profile:

![image](https://cloud.githubusercontent.com/assets/364113/18407158/1950cbb2-76be-11e6-8030-7297aa7a2db3.png)

11.0% of the time is spent calling the ETM, and 10.7% of the time is spent inside the ETM. That's much less SWIG overhead than before.