### PR TITLE
Faster local inhibition: Stop creating lists of neighbors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -351,6 +351,7 @@ set(src_nupiccore_srcs
     nupic/experimental/ExtendedTemporalMemory.cpp
     nupic/math/SparseMatrixAlgorithms.cpp
     nupic/math/StlIo.cpp
+    nupic/math/Topology.cpp
     nupic/ntypes/ArrayBase.cpp
     nupic/ntypes/Buffer.cpp
     nupic/ntypes/BundleIO.cpp
@@ -578,6 +579,7 @@ add_executable(${src_executable_gtests}
                test/unit/math/SparseMatrixTest.cpp
                test/unit/math/SparseMatrixUnitTest.cpp
                test/unit/math/SparseTensorUnitTest.cpp
+               test/unit/math/TopologyTest.cpp
                test/unit/ntypes/ArrayTest.cpp
                test/unit/ntypes/BufferTest.cpp
                test/unit/ntypes/CollectionTest.cpp

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1259,7 +1259,6 @@ void SpatialPooler::inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
     arbitration = 0.001;
   }
 
-  vector<UInt> neighbors;
   for (UInt column = 0; column < numColumns_; column++)
   {
     if (overlaps[column] >= stimulusThreshold_)

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -42,7 +42,8 @@ using namespace nupic::math::topology;
 // MSVC doesn't provide round() which only became standard in C99 or C++11
 #if defined(NTA_COMPILER_MSVC)
   template<typename T>
-  T round(T num) {
+  T round(T num)
+  {
       return (num > 0.0) ? floor(num + 0.5) : ceil(num - 0.5);
   }
 #endif
@@ -82,7 +83,8 @@ class CoordinateConverterND
     {
       dimensions_ = dimensions;
       UInt b = 1;
-      for (Int i = (Int) dimensions.size()-1; i >= 0; i--) {
+      for (Int i = (Int) dimensions.size()-1; i >= 0; i--)
+      {
         bounds_.insert(bounds_.begin(), b);
         b *= dimensions[i];
       }
@@ -91,7 +93,8 @@ class CoordinateConverterND
     void toCoord(UInt index, vector<UInt>& coord)
     {
       coord.clear();
-      for (UInt i = 0; i < bounds_.size(); i++)  {
+      for (UInt i = 0; i < bounds_.size(); i++)
+      {
         coord.push_back((index / bounds_[i]) % dimensions_[i]);
       }
     };
@@ -99,7 +102,8 @@ class CoordinateConverterND
     UInt toIndex(vector<UInt>& coord)
     {
       UInt index = 0;
-      for (UInt i = 0; i < coord.size(); i++) {
+      for (UInt i = 0; i < coord.size(); i++)
+      {
         index += coord[i] * bounds_[i];
       }
       return index;
@@ -579,7 +583,8 @@ void SpatialPooler::initialize(vector<UInt> inputDimensions,
   iterationLearnNum_ = 0;
 
   tieBreaker_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     tieBreaker_[i] = 0.01 * rng_.getReal64();
   }
 
@@ -609,7 +614,8 @@ void SpatialPooler::initialize(vector<UInt> inputDimensions,
 
   updateInhibitionRadius_();
 
-  if (spVerbosity_ > 0) {
+  if (spVerbosity_ > 0)
+  {
     printParameters();
     std::cout << "CPP SP seed                 = " << seed << std::endl;
   }
@@ -622,21 +628,26 @@ void SpatialPooler::compute(UInt inputArray[], bool learn,
   calculateOverlap_(inputArray, overlaps_);
   calculateOverlapPct_(overlaps_, overlapsPct_);
 
-  if (learn) {
+  if (learn)
+  {
     boostOverlaps_(overlaps_, boostedOverlaps_);
-  } else {
+  }
+  else
+  {
     boostedOverlaps_.assign(overlaps_.begin(), overlaps_.end());
   }
 
   inhibitColumns_(boostedOverlaps_, activeColumns_);
   toDense_(activeColumns_, activeArray, numColumns_);
 
-  if (learn) {
+  if (learn)
+  {
     adaptSynapses_(inputArray, activeColumns_);
     updateDutyCycles_(overlaps_, activeArray);
     bumpUpWeakColumns_();
     updateBoostFactors_();
-    if (isUpdateRound_()) {
+    if (isUpdateRound_())
+    {
       updateInhibitionRadius_();
       updateMinDutyCycles_();
     }
@@ -645,8 +656,10 @@ void SpatialPooler::compute(UInt inputArray[], bool learn,
 
 void SpatialPooler::stripUnlearnedColumns(UInt activeArray[]) const
 {
-  for (UInt i = 0; i < numColumns_; i++) {
-    if (activeDutyCycles_[i] == 0) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
+    if (activeDutyCycles_[i] == 0)
+    {
       activeArray[i] = 0;
     }
   }
@@ -658,7 +671,8 @@ void SpatialPooler::toDense_(vector<UInt>& sparse,
                             UInt n)
 {
   std::fill(dense,dense+n, 0);
-  for (auto & elem : sparse) {
+  for (auto & elem : sparse)
+  {
     UInt index = elem;
     dense[index] = 1;
   }
@@ -667,7 +681,8 @@ void SpatialPooler::toDense_(vector<UInt>& sparse,
 void SpatialPooler::boostOverlaps_(vector<UInt>& overlaps,
                                    vector<Real>& boosted)
 {
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     boosted[i] = overlaps[i] * boostFactors_[i];
   }
 }
@@ -748,14 +763,19 @@ vector<Real> SpatialPooler::initPermanence_(vector<UInt>& potential,
                                             Real connectedPct)
 {
   vector<Real> perm(numInputs_, 0);
-  for (UInt i = 0; i < numInputs_; i++) {
-    if (potential[i] < 1) {
+  for (UInt i = 0; i < numInputs_; i++)
+  {
+    if (potential[i] < 1)
+    {
       continue;
     }
 
-    if (rng_.getReal64() <= connectedPct) {
+    if (rng_.getReal64() <= connectedPct)
+    {
       perm[i] = initPermConnected_();
-    } else {
+    }
+    else
+    {
       perm[i] = initPermNonConnected_();
     }
     perm[i] = perm[i] < synPermTrimThreshold_ ? 0 : perm[i];
@@ -782,7 +802,8 @@ void SpatialPooler::updatePermanencesForColumn_(vector<Real>& perm,
   vector<UInt> connectedSparse;
 
   UInt numConnected;
-  if (raisePerm) {
+  if (raisePerm)
+  {
     vector<UInt> potential;
     potential.resize(numInputs_);
     potential = potentialPools_.getSparseRow(column);
@@ -792,7 +813,8 @@ void SpatialPooler::updatePermanencesForColumn_(vector<Real>& perm,
   numConnected = 0;
   for (UInt i = 0; i < perm.size(); ++i)
   {
-    if (perm[i] >= synPermConnected_) {
+    if (perm[i] >= synPermConnected_)
+    {
       connectedSparse.push_back(i);
       ++numConnected;
     }
@@ -808,8 +830,10 @@ void SpatialPooler::updatePermanencesForColumn_(vector<Real>& perm,
 UInt SpatialPooler::countConnected_(vector<Real>& perm)
 {
   UInt numConnected = 0;
-  for (auto & elem : perm) {
-     if (elem > synPermConnected_) {
+  for (auto & elem : perm)
+  {
+     if (elem > synPermConnected_)
+     {
        ++numConnected;
      }
    }
@@ -827,7 +851,8 @@ UInt SpatialPooler::raisePermanencesToThreshold_(vector<Real>& perm,
     if (numConnected >= stimulusThreshold_)
       break;
 
-    for (auto & elem : potential) {
+    for (auto & elem : potential)
+    {
       UInt index = elem;
       perm[index] += synPermBelowStimulusInc_;
     }
@@ -837,14 +862,16 @@ UInt SpatialPooler::raisePermanencesToThreshold_(vector<Real>& perm,
 
 void SpatialPooler::updateInhibitionRadius_()
 {
-  if (globalInhibition_) {
+  if (globalInhibition_)
+  {
     inhibitionRadius_ = *max_element(columnDimensions_.begin(),
                                      columnDimensions_.end());
     return;
   }
 
   Real connectedSpan = 0;
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     connectedSpan += avgConnectedSpanForColumnND_(i);
   }
   connectedSpan /= numColumns_;
@@ -858,9 +885,12 @@ void SpatialPooler::updateInhibitionRadius_()
 void SpatialPooler::updateMinDutyCycles_()
 {
   if (globalInhibition_ || inhibitionRadius_ >
-    *max_element(columnDimensions_.begin(), columnDimensions_.end())) {
+    *max_element(columnDimensions_.begin(), columnDimensions_.end()))
+  {
     updateMinDutyCyclesGlobal_();
-  } else {
+  }
+  else
+  {
     updateMinDutyCyclesLocal_();
   }
 
@@ -882,7 +912,8 @@ void SpatialPooler::updateMinDutyCyclesGlobal_()
 
 void SpatialPooler::updateMinDutyCyclesLocal_()
 {
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     Real maxActiveDuty = 0;
     Real maxOverlapDuty = 0;
     for (UInt column : Neighborhood(i, inhibitionRadius_, columnDimensions_))
@@ -902,7 +933,8 @@ void SpatialPooler::updateDutyCycles_(vector<UInt>& overlaps,
   vector<UInt> newOverlapVal(numColumns_, 0);
   vector<UInt> newActiveVal(numColumns_, 0);
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     newOverlapVal[i] = overlaps[i] > 0 ? 1 : 0;
     newActiveVal[i] = activeArray[i] > 0 ? 1 : 0;
   }
@@ -918,7 +950,8 @@ Real SpatialPooler::avgColumnsPerInput_()
 {
   UInt numDim = max(columnDimensions_.size(), inputDimensions_.size());
   Real columnsPerInput = 0;
-  for (UInt i = 0; i < numDim; i++) {
+  for (UInt i = 0; i < numDim; i++)
+  {
     Real col = (i < columnDimensions_.size()) ? columnDimensions_[i] : 1;
     Real input = (i < inputDimensions_.size()) ? inputDimensions_[i] : 1;
     columnsPerInput += col / input;
@@ -952,13 +985,15 @@ Real SpatialPooler::avgConnectedSpanForColumn2D_(UInt column)
 
   vector<UInt> connectedSparse = connectedSynapses_.getSparseRow(column);
   vector<UInt> rows, cols;
-  for (auto & elem : connectedSparse) {
+  for (auto & elem : connectedSparse)
+  {
     UInt index = elem;
     rows.push_back(conv.toRow(index));
     cols.push_back(conv.toCol(index));
   }
 
-  if (rows.empty() && cols.empty()) {
+  if (rows.empty() && cols.empty())
+  {
     return 0;
   }
 
@@ -982,21 +1017,25 @@ Real SpatialPooler::avgConnectedSpanForColumnND_(UInt column)
 
   CoordinateConverterND conv(inputDimensions_);
 
-  if (connectedSparse.empty() ) {
+  if (connectedSparse.empty() )
+  {
     return 0;
   }
 
   vector<UInt> columnCoord;
-  for (auto & elem : connectedSparse) {
+  for (auto & elem : connectedSparse)
+  {
     conv.toCoord(elem,columnCoord);
-    for (UInt j = 0; j < columnCoord.size(); j++) {
+    for (UInt j = 0; j < columnCoord.size(); j++)
+    {
       maxCoord[j] = max(maxCoord[j], columnCoord[j]);
       minCoord[j] = min(minCoord[j], columnCoord[j]);
     }
   }
 
   UInt totalSpan = 0;
-  for (UInt j = 0; j < inputDimensions_.size(); j++) {
+  for (UInt j = 0; j < inputDimensions_.size(); j++)
+  {
     totalSpan += maxCoord[j] - minCoord[j] + 1;
   }
 
@@ -1008,20 +1047,24 @@ void SpatialPooler::adaptSynapses_(UInt inputVector[],
                     vector<UInt>& activeColumns)
 {
   vector<Real> permChanges(numInputs_, -1 * synPermInactiveDec_);
-  for (UInt i = 0; i < numInputs_; i++) {
-    if (inputVector[i] > 0) {
+  for (UInt i = 0; i < numInputs_; i++)
+  {
+    if (inputVector[i] > 0)
+    {
       permChanges[i] = synPermActiveInc_;
     }
   }
 
-  for (UInt i = 0; i < activeColumns.size(); i++) {
+  for (UInt i = 0; i < activeColumns.size(); i++)
+  {
     UInt column = activeColumns[i];
     vector<UInt> potential;
     vector <Real> perm(numInputs_, 0);
     potential.resize(potentialPools_.nNonZerosOnRow(i));
     potential = potentialPools_.getSparseRow(column);
     permanences_.getRowToDense(column, perm);
-    for (auto & elem : potential) {
+    for (auto & elem : potential)
+    {
         UInt index = elem;
         perm[index] += permChanges[index];
     }
@@ -1031,8 +1074,10 @@ void SpatialPooler::adaptSynapses_(UInt inputVector[],
 
 void SpatialPooler::bumpUpWeakColumns_()
 {
-  for (UInt i = 0; i < numColumns_; i++) {
-    if (overlapDutyCycles_[i] >= minOverlapDutyCycles_[i]) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
+    if (overlapDutyCycles_[i] >= minOverlapDutyCycles_[i])
+    {
       continue;
     }
     vector<Real> perm(numInputs_, 0);
@@ -1040,7 +1085,8 @@ void SpatialPooler::bumpUpWeakColumns_()
     potential.resize(potentialPools_.nNonZerosOnRow(i));
     potential = potentialPools_.getSparseRow(i);
     permanences_.getRowToDense(i, perm);
-    for (auto & elem : potential) {
+    for (auto & elem : potential)
+    {
       UInt index = elem;
       perm[index] += synPermBelowStimulusInc_;
     }
@@ -1054,18 +1100,22 @@ void SpatialPooler::updateDutyCyclesHelper_(vector<Real>& dutyCycles,
 {
   NTA_ASSERT(period >= 1);
   NTA_ASSERT(dutyCycles.size() == newValues.size());
-  for (UInt i = 0; i < dutyCycles.size(); i++) {
+  for (UInt i = 0; i < dutyCycles.size(); i++)
+  {
     dutyCycles[i] = (dutyCycles[i] * (period - 1) + newValues[i]) / period;
   }
 }
 
 void SpatialPooler::updateBoostFactors_()
 {
-  for (UInt i = 0; i < numColumns_; i++) {
-    if (minActiveDutyCycles_[i] <= 0) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
+    if (minActiveDutyCycles_[i] <= 0)
+    {
       continue;
     }
-    if (activeDutyCycles_[i] > minActiveDutyCycles_[i]) {
+    if (activeDutyCycles_[i] > minActiveDutyCycles_[i])
+    {
       boostFactors_[i] = 1.0;
       continue;
     }
@@ -1077,7 +1127,8 @@ void SpatialPooler::updateBoostFactors_()
 void SpatialPooler::updateBookeepingVars_(bool learn)
 {
   iterationNum_++;
-  if (learn) {
+  if (learn)
+  {
     iterationLearnNum_++;
   }
 }
@@ -1094,10 +1145,14 @@ void SpatialPooler::calculateOverlapPct_(vector<UInt>& overlaps,
                                          vector<Real>& overlapPct)
 {
   overlapPct.assign(numColumns_,0);
-  for (UInt i = 0; i < numColumns_; i++) {
-    if (connectedCounts_[i] != 0) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
+    if (connectedCounts_[i] != 0)
+    {
       overlapPct[i] = ((Real) overlaps[i]) / connectedCounts_[i];
-    } else {
+    }
+    else
+    {
       // The intent here is to see if a cell matches its input well.
       // Therefore if nothing is connected the overlapPct is set to 0.
       overlapPct[i] = 0;
@@ -1110,7 +1165,8 @@ void SpatialPooler::inhibitColumns_(vector<Real>& overlaps,
                                     vector<UInt>& activeColumns)
 {
   Real density = localAreaDensity_;
-  if (numActiveColumnsPerInhArea_ > 0) {
+  if (numActiveColumnsPerInhArea_ > 0)
+  {
     UInt inhibitionArea = pow((Real) (2 * inhibitionRadius_ + 1),
                               (Real) columnDimensions_.size());
     inhibitionArea = min(inhibitionArea, numColumns_);
@@ -1120,9 +1176,12 @@ void SpatialPooler::inhibitColumns_(vector<Real>& overlaps,
 
   if (globalInhibition_ ||
       inhibitionRadius_ > *max_element(columnDimensions_.begin(),
-                                       columnDimensions_.end())) {
+                                       columnDimensions_.end()))
+  {
     inhibitColumnsGlobal_(overlaps, density, activeColumns);
-  } else {
+  }
+  else
+  {
     inhibitColumnsLocal_(overlaps, density, activeColumns);
   }
 }
@@ -1130,15 +1189,18 @@ void SpatialPooler::inhibitColumns_(vector<Real>& overlaps,
 bool SpatialPooler::isWinner_(Real score, vector<pair<UInt, Real> >& winners,
                               UInt numWinners)
 {
-  if (score < stimulusThreshold_) {
+  if (score < stimulusThreshold_)
+  {
     return false;
   }
 
-  if (winners.size() < numWinners) {
+  if (winners.size() < numWinners)
+  {
     return true;
   }
 
-  if (score >= winners[numWinners-1].second) {
+  if (score >= winners[numWinners-1].second)
+  {
     return true;
   }
 
@@ -1150,8 +1212,10 @@ void SpatialPooler::addToWinners_(UInt index, Real score,
 {
   pair<UInt, Real> val = make_pair(index, score);
   for (auto it = winners.begin();
-       it != winners.end(); it++) {
-    if (score >= it->second) {
+       it != winners.end(); it++)
+  {
+    if (score >= it->second)
+    {
       winners.insert(it, val);
       return;
     }
@@ -1165,14 +1229,17 @@ void SpatialPooler::inhibitColumnsGlobal_(vector<Real>& overlaps, Real density,
   activeColumns.clear();
   const UInt numDesired = (UInt) (density * numColumns_);
   vector<pair<UInt, Real> > winners;
-  for (UInt i = 0; i < numColumns_; i++) {
-    if (isWinner_(overlaps[i], winners, numDesired)) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
+    if (isWinner_(overlaps[i], winners, numDesired))
+    {
       addToWinners_(i,overlaps[i], winners);
     }
   }
 
   const UInt numActual = min(numDesired, (UInt)winners.size());
-  for (UInt i = 0; i < numActual; i++) {
+  for (UInt i = 0; i < numActual; i++)
+  {
     activeColumns.push_back(winners[i].first);
   }
 
@@ -1195,7 +1262,8 @@ void SpatialPooler::inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
   vector<UInt> neighbors;
   for (UInt column = 0; column < numColumns_; column++)
   {
-    if (overlaps[column] >= stimulusThreshold_) {
+    if (overlaps[column] >= stimulusThreshold_)
+    {
       UInt numNeighbors = 0;
       UInt numBigger = 0;
       for (UInt neighbor : Neighborhood(column, inhibitionRadius_,
@@ -1280,67 +1348,79 @@ void SpatialPooler::save(ostream& outStream) const
 
   // Store vectors.
   outStream << inputDimensions_.size() << " ";
-  for (auto & elem : inputDimensions_) {
+  for (auto & elem : inputDimensions_)
+  {
     outStream << elem << " ";
   }
   outStream << endl;
 
   outStream << columnDimensions_.size() << " ";
-  for (auto & elem : columnDimensions_) {
+  for (auto & elem : columnDimensions_)
+  {
     outStream << elem << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << boostFactors_[i] << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << overlapDutyCycles_[i] << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << activeDutyCycles_[i] << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << minOverlapDutyCycles_[i] << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << minActiveDutyCycles_[i] << " ";
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     outStream << tieBreaker_[i] << " ";
   }
   outStream << endl;
 
 
   // Store matrices.
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     vector<UInt> pot;
     pot.resize(potentialPools_.nNonZerosOnRow(i));
     pot = potentialPools_.getSparseRow(i);
     outStream << pot.size() << endl;
-    for (auto & elem : pot) {
+    for (auto & elem : pot)
+    {
       outStream << elem << " ";
     }
     outStream << endl;
   }
   outStream << endl;
 
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     vector<pair<UInt, Real> > perm;
     perm.resize(permanences_.nNonZerosOnRow(i));
     outStream << perm.size() << endl;
     permanences_.getRowToSparse(i, perm.begin());
-    for (auto & elem : perm) {
+    for (auto & elem : perm)
+    {
       outStream << elem.first << " " << elem.second << " ";
     }
     outStream << endl;
@@ -1398,9 +1478,12 @@ void SpatialPooler::load(istream& inStream)
            >> synPermConnected_
            >> minPctOverlapDutyCycles_
            >> minPctActiveDutyCycles_;
-  if (version == 1) {
+  if (version == 1)
+  {
     wrapAround_ = true;
-  } else {
+  }
+  else
+  {
     inStream >> wrapAround_;
   }
 
@@ -1408,55 +1491,65 @@ void SpatialPooler::load(istream& inStream)
   UInt numInputDimensions;
   inStream >> numInputDimensions;
   inputDimensions_.resize(numInputDimensions);
-  for (UInt i = 0; i < numInputDimensions; i++) {
+  for (UInt i = 0; i < numInputDimensions; i++)
+  {
     inStream >> inputDimensions_[i];
   }
 
   UInt numColumnDimensions;
   inStream >> numColumnDimensions;
   columnDimensions_.resize(numColumnDimensions);
-  for (UInt i = 0; i < numColumnDimensions; i++) {
+  for (UInt i = 0; i < numColumnDimensions; i++)
+  {
     inStream >> columnDimensions_[i];
   }
 
   boostFactors_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> boostFactors_[i];
   }
 
   overlapDutyCycles_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> overlapDutyCycles_[i];
   }
 
   activeDutyCycles_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> activeDutyCycles_[i];
   }
 
   minOverlapDutyCycles_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> minOverlapDutyCycles_[i];
   }
 
   minActiveDutyCycles_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> minActiveDutyCycles_[i];
   }
 
   tieBreaker_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     inStream >> tieBreaker_[i];
   }
 
 
   // Retrieve matrices.
   potentialPools_.resize(numColumns_, numInputs_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     UInt nNonZerosOnRow;
     inStream >> nNonZerosOnRow;
     vector<UInt> pot(nNonZerosOnRow, 0);
-    for (UInt j = 0; j < nNonZerosOnRow; j++) {
+    for (UInt j = 0; j < nNonZerosOnRow; j++)
+    {
       inStream >> pot[j];
     }
     potentialPools_.replaceSparseRow(i,pot.begin(), pot.end());
@@ -1465,12 +1558,14 @@ void SpatialPooler::load(istream& inStream)
   permanences_.resize(numColumns_, numInputs_);
   connectedSynapses_.resize(numColumns_, numInputs_);
   connectedCounts_.resize(numColumns_);
-  for (UInt i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++)
+  {
     UInt nNonZerosOnRow;
     inStream >> nNonZerosOnRow;
     vector<Real> perm(numInputs_, 0);
 
-    for (UInt j = 0; j < nNonZerosOnRow; j++) {
+    for (UInt j = 0; j < nNonZerosOnRow; j++)
+    {
       UInt index;
       Real value;
       inStream >> index;
@@ -1741,8 +1836,10 @@ void SpatialPooler::printParameters() const
 void SpatialPooler::printState(vector<UInt> &state)
 {
   std::cout << "[  ";
-  for (UInt i = 0; i != state.size(); ++i) {
-    if (i > 0 && i % 10 == 0) {
+  for (UInt i = 0; i != state.size(); ++i)
+  {
+    if (i > 0 && i % 10 == 0)
+    {
       std::cout << "\n   ";
     }
     std::cout << state[i] << " ";
@@ -1753,8 +1850,10 @@ void SpatialPooler::printState(vector<UInt> &state)
 void SpatialPooler::printState(vector<Real> &state)
 {
   std::cout << "[  ";
-  for (UInt i = 0; i != state.size(); ++i) {
-    if (i > 0 && i % 10 == 0) {
+  for (UInt i = 0; i != state.size(); ++i)
+  {
+    if (i > 0 && i % 10 == 0)
+    {
       std::cout << "\n   ";
     }
     std::printf("%6.3f ", state[i]);

--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -40,9 +40,12 @@
 
 using namespace std;
 
-namespace nupic {
-  namespace algorithms {
-    namespace spatial_pooler {
+namespace nupic
+{
+  namespace algorithms
+  {
+    namespace spatial_pooler
+    {
 
       /**
        * CLA spatial pooler implementation in C++.
@@ -67,7 +70,8 @@ namespace nupic {
        *     }
        *
        */
-      class SpatialPooler : public Serializable<SpatialPoolerProto> {
+      class SpatialPooler : public Serializable<SpatialPoolerProto>
+      {
         public:
           SpatialPooler();
           SpatialPooler(vector<UInt> inputDimensions,
@@ -1340,6 +1344,7 @@ namespace nupic {
           Random rng_;
 
       };
+
     } // end namespace spatial_pooler
   } // end namespace algorithms
 } // end namespace nupic

--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -837,8 +837,6 @@ namespace nupic {
 
           void boostOverlaps_(vector<UInt>& overlaps,
                               vector<Real>& boostedOverlaps);
-          void range_(Int start, Int end, UInt ubound, bool wrapAround,
-                      vector<UInt>& rangeVector);
 
           /**
             Maps a column to its respective input index, keeping to the topology of
@@ -1071,117 +1069,6 @@ namespace nupic {
           */
           void inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
                                     vector<UInt>& activeColumns);
-
-          /**
-              Returns a list of indices corresponding to the neighbors of a given column.
-
-              In this variation of the method, which only supports a one dimensional
-              column toplogy, a column's neighbors are those neighbors who are 'radius'
-              indices away. This information is needed to perform inhibition. This method
-              is a subset of _getNeighborsND and is only included for illustration
-              purposes, and potentially enhanced performance for spatial pooler
-              implementations that only require a one-dimensional topology.
-
-              ----------------------------
-              @param column  An integer number. The index identifying a column in the permanence, potential
-                              and connectivity matrices.
-
-              @param  dimensions     An int array containg a dimensions for the column space. A 2x3
-                              grid will be represented by [2,3].
-
-              @param  radius      An integer number Indicates how far away from a given column are other
-                              columns to be considered its neighbors. In the previous 2x3
-                              example, each column with coordinates:
-                              [2+/-radius, 3+/-radius] is considered a neighbor.
-
-              @param  wrapAround     A boolean value indicating whether to consider columns at
-                              the border of a dimensions to be adjacent to columns at the
-                              other end of the dimension. For example, if the columns are
-                              layed out in one deimnsion, columns 1 and 10 will be
-                              considered adjacent if wrapAround is set to true:
-                              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].
-
-              @param neighbors An int arrayof indices corresponding to the neighbors of a given column.
-          */
-          void getNeighbors1D_(UInt column, vector<UInt>& dimensions,
-                               UInt radius, bool wrapAround,
-                               vector<UInt>& neighbors);
-
-          /**
-              Returns a list of indices corresponding to the neighbors of a given column.
-
-              Since the permanence values are stored in such a way that information about
-              toplogy is lost, this method allows for reconstructing the toplogy of the
-              inputs, which are flattened to one array. Given a column's index, its
-              neighbors are defined as those columns that are 'radius' indices away from
-              it in each dimension. The method returns a list of the flat indices of
-              these columns. This method is a subset of _getNeighborsND and is only
-              included for illustration purposes, and potentially enhanced performance
-              for spatial pooler implementations that only require a two-dimensional
-              topology.
-
-              @param column   An integer number. The index identifying a column in the permanence, potential
-                              and connectivity matrices.
-
-              @param  dimensions     An int array containg a dimensions for the column space. A 2x3
-                              grid will be represented by [2,3].
-
-              @param  radius      An integer number Indicates how far away from a given column are other
-                              columns to be considered its neighbors. In the previous 2x3
-                              example, each column with coordinates:
-                              [2+/-radius, 3+/-radius] is considered a neighbor.
-
-              @param  wrapAround     A boolean value indicating whether to consider columns at
-                              the border of a dimensions to be adjacent to columns at the
-                              other end of the dimension. For example, if the columns are
-                              layed out in one deimnsion, columns 1 and 10 will be
-                              considered adjacent if wrapAround is set to true:
-                              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].
-
-              @param neighbors An int array of indices corresponding to the neighbors of a given column.
-          */
-          void getNeighbors2D_(UInt column, vector<UInt>& dimensions,
-                               UInt radius, bool wrapAround,
-                               vector<UInt>& neighbors);
-          void cartesianProduct_(vector<vector<UInt> >& vecs,
-                                 vector<vector<UInt> >& product);
-
-          /**
-              Similar to _getNeighbors1D and _getNeighbors2D, this function returns a
-              list of indices corresponding to the neighbors of a given column.
-
-              Since the
-              permanence values are stored in such a way that information about toplogy
-              is lost. This method allows for reconstructing the toplogy of the inputs,
-              which are flattened to one array. Given a column's index, its neighbors are
-              defined as those columns that are 'radius' indices away from it in each
-              dimension. The method returns a list of the flat indices of these columns.
-
-              ----------------------------
-              @param column   An integer number. The index identifying a column in the permanence, potential
-                              and connectivity matrices.
-
-              @param  dimensions     An int array containg a dimensions for the column space. A 2x3
-                              grid will be represented by [2,3].
-
-              @param  radius      An integer number Indicates how far away from a given column are other
-                              columns to be considered its neighbors. In the previous 2x3
-                              example, each column with coordinates:
-                              [2+/-radius, 3+/-radius] is considered a neighbor.
-
-              @param  wrapAround     A boolean value indicating whether to consider columns at
-                              the border of a dimensions to be adjacent to columns at the
-                              other end of the dimension. For example, if the columns are
-                              layed out in one deimnsion, columns 1 and 10 will be
-                              considered adjacent if wrapAround is set to true:
-                              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].
-
-              @param neighbors An int arrayof indices corresponding to the neighbors of a given column.
-          */
-          void getNeighborsND_(UInt column, vector<UInt>& dimensions,
-                               UInt radius, bool wrapAround,
-                               vector<UInt>& neighbors);
-
 
           /**
               The primary method in charge of learning.

--- a/src/nupic/math/Topology.cpp
+++ b/src/nupic/math/Topology.cpp
@@ -1,0 +1,280 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Topology helpers
+ */
+
+#include <nupic/math/Topology.hpp>
+#include <nupic/utils/Log.hpp>
+
+using std::vector;
+using namespace nupic;
+using namespace nupic::math::topology;
+
+namespace nupic {
+  namespace math {
+    namespace topology {
+
+      vector<UInt> coordinatesFromIndex(
+        UInt index,
+        const vector<UInt>& dimensions)
+      {
+        vector<UInt> coordinates(dimensions.size(), 0);
+
+        UInt shifted = index;
+        for (size_t i = dimensions.size() - 1; i > 0; i--)
+        {
+          coordinates[i] = shifted % dimensions[i];
+          shifted = shifted / dimensions[i];
+        }
+
+        NTA_ASSERT(shifted < dimensions[0]);
+        coordinates[0] = shifted;
+
+        return coordinates;
+      }
+
+
+      UInt indexFromCoordinates(const vector<UInt>& coordinates,
+                                const vector<UInt>& dimensions)
+      {
+        NTA_ASSERT(coordinates.size() == dimensions.size());
+
+        UInt index = 0;
+        for (size_t i = 0; i < dimensions.size(); i++)
+        {
+          NTA_ASSERT(coordinates[i] < dimensions[i]);
+          index *= dimensions[i];
+          index += coordinates[i];
+        }
+
+        return index;
+      }
+
+    } // end namespace topology
+  } // end namespace algorithms
+} // end namespace nupic
+
+
+// ============================================================================
+// NEIGHBORHOOD
+// ============================================================================
+
+Neighborhood::Neighborhood(UInt centerIndex, UInt radius,
+                           const vector<UInt>& dimensions)
+  : centerPosition_(coordinatesFromIndex(centerIndex, dimensions)),
+    dimensions_(dimensions),
+    radius_(radius)
+{
+}
+
+Neighborhood::Iterator::Iterator(const Neighborhood& neighborhood, bool end)
+  : neighborhood_(neighborhood),
+    offset_(neighborhood.dimensions_.size(), -neighborhood.radius_),
+    finished_(end)
+{
+  // Choose the first offset that has positive resulting coordinates.
+  for (size_t i = 0; i < offset_.size(); i++)
+  {
+    offset_[i] = std::max(offset_[i],
+                          -(Int)neighborhood_.centerPosition_[i]);
+  }
+}
+
+bool Neighborhood::Iterator::operator!=(const Iterator& other) const
+{
+  return finished_ != other.finished_;
+}
+
+UInt Neighborhood::Iterator::operator*() const
+{
+  UInt index = 0;
+  for (size_t i = 0; i < neighborhood_.dimensions_.size(); i++)
+  {
+    const Int coordinate = neighborhood_.centerPosition_[i] + offset_[i];
+
+    NTA_ASSERT(coordinate >= 0);
+    NTA_ASSERT(coordinate < (Int)neighborhood_.dimensions_[i]);
+
+    index *= neighborhood_.dimensions_[i];
+    index += coordinate;
+  }
+
+  return index;
+}
+
+const Neighborhood::Iterator& Neighborhood::Iterator::operator++()
+{
+  advance_();
+  return *this;
+}
+
+void Neighborhood::Iterator::advance_()
+{
+  // When it overflows, we need to "carry the 1" to the next dimension.
+  bool overflowed = true;
+
+  for (Int i = offset_.size() - 1; i >= 0; i--)
+  {
+    offset_[i]++;
+
+    overflowed =
+      offset_[i] > (Int)neighborhood_.radius_ ||
+      (((Int)neighborhood_.centerPosition_[i] + offset_[i]) >=
+       (Int)neighborhood_.dimensions_[i]);
+
+    if (overflowed)
+    {
+      // Choose the first offset that has a positive resulting coordinate.
+      offset_[i] = std::max(-(Int)neighborhood_.radius_,
+                            -(Int)neighborhood_.centerPosition_[i]);
+    }
+    else
+    {
+      // There's no overflow. The remaining coordinates don't need to change.
+      break;
+    }
+  }
+
+  // When the final coordinate overflows, we're done.
+  if (overflowed)
+  {
+    finished_ = true;
+  }
+}
+
+Neighborhood::Iterator Neighborhood::begin() const
+{
+  return {*this, false};
+}
+
+Neighborhood::Iterator Neighborhood::end() const
+{
+  return {*this, true};
+}
+
+
+// ============================================================================
+// WRAPPING NEIGHBORHOOD
+// ============================================================================
+
+WrappingNeighborhood::WrappingNeighborhood(
+  UInt centerIndex,
+  UInt radius,
+  const vector<UInt>& dimensions)
+  : centerPosition_(coordinatesFromIndex(centerIndex, dimensions)),
+    dimensions_(dimensions),
+    radius_(radius)
+{
+}
+
+WrappingNeighborhood::Iterator::Iterator(
+  const WrappingNeighborhood& neighborhood, bool end)
+  : neighborhood_(neighborhood),
+    offset_(neighborhood.dimensions_.size(), -neighborhood.radius_),
+    finished_(end)
+{
+}
+
+bool WrappingNeighborhood::Iterator::operator!=(const Iterator& other) const
+{
+  return finished_ != other.finished_;
+}
+
+UInt WrappingNeighborhood::Iterator::operator*() const
+{
+  UInt index = 0;
+  for (size_t i = 0; i < neighborhood_.dimensions_.size(); i++)
+  {
+    Int coordinate = neighborhood_.centerPosition_[i] + offset_[i];
+
+    // With a large radius, it may have wrapped around multiple times, so use
+    // `while`, not `if`.
+
+    while (coordinate < 0)
+    {
+      coordinate += neighborhood_.dimensions_[i];
+    }
+
+    while (coordinate >= (Int)neighborhood_.dimensions_[i])
+    {
+      coordinate -= neighborhood_.dimensions_[i];
+    }
+
+    index *= neighborhood_.dimensions_[i];
+    index += coordinate;
+  }
+
+  return index;
+}
+
+const WrappingNeighborhood::Iterator& WrappingNeighborhood::Iterator::operator++()
+{
+  advance_();
+  return *this;
+}
+
+void WrappingNeighborhood::Iterator::advance_()
+{
+  // When it overflows, we need to "carry the 1" to the next dimension.
+  bool overflowed = true;
+
+  for (Int i = offset_.size() - 1; i >= 0; i--)
+  {
+    offset_[i]++;
+
+    // If the offset has moved by more than the dimension size, i.e. if
+    // offset_[i] - (-radius) is greater than the dimension size, then we're
+    // about to run into points that we've already seen. This happens when given
+    // small dimensions, a large radius, and wrap-around.
+    overflowed =
+      offset_[i] > (Int)neighborhood_.radius_ ||
+      offset_[i] + (Int)neighborhood_.radius_ >= (Int)neighborhood_.dimensions_[i];
+
+    if (overflowed)
+    {
+      offset_[i] = -neighborhood_.radius_;
+    }
+    else
+    {
+      // There's no overflow. The remaining coordinates don't need to change.
+      break;
+    }
+  }
+
+  // When the final coordinate overflows, we're done.
+  if (overflowed)
+  {
+    finished_ = true;
+  }
+}
+
+WrappingNeighborhood::Iterator WrappingNeighborhood::begin() const
+{
+  return {*this, /*end*/ false};
+}
+
+WrappingNeighborhood::Iterator WrappingNeighborhood::end() const
+{
+  return {*this, /*end*/ true};
+}

--- a/src/nupic/math/Topology.cpp
+++ b/src/nupic/math/Topology.cpp
@@ -31,9 +31,12 @@ using std::vector;
 using namespace nupic;
 using namespace nupic::math::topology;
 
-namespace nupic {
-  namespace math {
-    namespace topology {
+namespace nupic
+{
+  namespace math
+  {
+    namespace topology
+    {
 
       vector<UInt> coordinatesFromIndex(
         UInt index,
@@ -53,7 +56,6 @@ namespace nupic {
 
         return coordinates;
       }
-
 
       UInt indexFromCoordinates(const vector<UInt>& coordinates,
                                 const vector<UInt>& dimensions)

--- a/src/nupic/math/Topology.hpp
+++ b/src/nupic/math/Topology.hpp
@@ -1,0 +1,214 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ----------------------------------------------------------------------
+ */
+
+/** @file
+ * Topology helpers
+ */
+
+#ifndef NTA_TOPOLOGY_HPP
+#define NTA_TOPOLOGY_HPP
+
+#include <vector>
+
+#include <nupic/types/Types.hpp>
+
+namespace nupic {
+  namespace math {
+    namespace topology {
+
+      /**
+       * Translate an index into coordinates, using the given coordinate system.
+       *
+       * @param index
+       * The index of the point. The coordinates are expressed as a single index
+       * by using the dimensions as a mixed radix definition. For example, in
+       * dimensions 42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+       *
+       * @param dimensions
+       * The coordinate system.
+       *
+       * @returns
+       * A vector of coordinates of length dimensions.size().
+       */
+      std::vector<UInt> coordinatesFromIndex(
+        UInt index,
+        const std::vector<UInt>& dimensions);
+
+
+      /**
+       * Translate coordinates into an index, using the given coordinate system.
+       *
+       * @param coordinates
+       * A vector of coordinates of length dimensions.size().
+       *
+       * @param dimensions
+       * The coordinate system.
+       *
+       * @returns
+       * The index of the point. The coordinates are expressed as a single index
+       * by using the dimensions as a mixed radix definition. For example, in
+       * dimensions 42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+       */
+      UInt indexFromCoordinates(
+        const std::vector<UInt>& coordinates,
+        const std::vector<UInt>& dimensions);
+
+
+      /**
+       * A class that lets you iterate over all points within the neighborhood
+       * of a point.
+       *
+       * Usage:
+       *   UInt center = 42;
+       *   for (UInt neighbor : Neighborhood(center, 10, {100, 100}))
+       *   {
+       *     if (neighbor == center)
+       *     {
+       *       // Note that the center is included in the neighborhood!
+       *     }
+       *     else
+       *     {
+       *       // Do something with the neighbor.
+       *     }
+       *   }
+       *
+       * A point's neighborhood is the n-dimensional hypercube with sides
+       * ranging [center - radius, center + radius], inclusive. For example,
+       * if there are two dimensions and the radius is 3, the neighborhood is
+       * 6x6. Neighborhoods are truncated when they are near an edge.
+       *
+       * Dimensions aren't copied -- a reference is saved. Make sure the
+       * dimensions don't get overwritten while this Neighborhood instance
+       * exists.
+       *
+       * This is designed to be fast. It walks the list of points in the
+       * neighborhood without ever creating a list of points.
+       *
+       * This still could be faster. Because it handles an arbitrary number of
+       * dimensions, it has to allocate vectors. It would be faster to have a
+       * Neighborhood1D, Neighborhood2D, etc., so that all computation could
+       * occur on the stack, but this would put a burden on callers to handle
+       * different dimensions counts. Or it would require using polymorphism,
+       * using pointers/references and putting the Neighborhood on the heap,
+       * which defeats the purpose of avoiding the vector allocations.
+       *
+       * @param centerIndex
+       * The center of this neighborhood. The coordinates are expressed as a
+       * single index by using the dimensions as a mixed radix definition. For
+       * example, in dimensions 42x10, the point [1, 4] is index 1*420 + 4*10 =
+       * 460.
+       *
+       * @param radius
+       * The radius of this neighborhood about the centerIndex.
+       *
+       * @param dimensions
+       * The dimensions of the world outside this neighborhood.
+       *
+       * @returns
+       * An object which supports C++ range-based for loops. Each iteration of
+       * the loop returns a point in the neighborhood. Each point is expressed
+       * as a single index.
+       */
+      class Neighborhood {
+      public:
+        Neighborhood(UInt centerIndex, UInt radius,
+                     const std::vector<UInt>& dimensions);
+
+        class Iterator {
+        public:
+          Iterator(const Neighborhood& neighborhood, bool end);
+          bool operator !=(const Iterator& other) const;
+          UInt operator*() const;
+          const Iterator& operator++();
+
+        private:
+          void advance_();
+
+          const Neighborhood& neighborhood_;
+          std::vector<Int> offset_;
+          bool finished_;
+        };
+
+        Iterator begin() const;
+        Iterator end() const;
+
+      private:
+        const std::vector<UInt> centerPosition_;
+        const std::vector<UInt>& dimensions_;
+        const UInt radius_;
+      };
+
+      /**
+       * Like the Neighborhood class, except that the neighborhood isn't
+       * truncated when it's near an edge. It wraps around to the other side.
+       *
+      * @param centerIndex
+       * The center of this neighborhood. The coordinates are expressed as a
+       * single index by using the dimensions as a mixed radix definition. For
+       * example, in dimensions 42x10, the point [1, 4] is index 1*420 + 4*10 =
+       * 460.
+       *
+       * @param radius
+       * The radius of this neighborhood about the centerIndex.
+       *
+       * @param dimensions
+       * The dimensions of the world outside this neighborhood.
+       *
+       * @returns
+       * An object which supports C++ range-based for loops. Each iteration of
+       * the loop returns a point in the neighborhood. Each point is expressed
+       * as a single index.
+       */
+      class WrappingNeighborhood {
+      public:
+        WrappingNeighborhood(UInt centerIndex, UInt radius,
+                             const std::vector<UInt>& dimensions);
+
+        class Iterator {
+        public:
+          Iterator(const WrappingNeighborhood& neighborhood, bool end);
+          bool operator !=(const Iterator& other) const;
+          UInt operator*() const;
+          const Iterator& operator++();
+
+        private:
+          void advance_();
+
+          const WrappingNeighborhood& neighborhood_;
+          std::vector<Int> offset_;
+          bool finished_;
+        };
+
+        Iterator begin() const;
+        Iterator end() const;
+
+      private:
+        const std::vector<UInt> centerPosition_;
+        const std::vector<UInt>& dimensions_;
+        const UInt radius_;
+      };
+
+    } // end namespace topology
+  } // end namespace algorithms
+} // end namespace nupic
+
+#endif // NTA_TOPOLOGY_HPP

--- a/src/nupic/math/Topology.hpp
+++ b/src/nupic/math/Topology.hpp
@@ -31,9 +31,12 @@
 
 #include <nupic/types/Types.hpp>
 
-namespace nupic {
-  namespace math {
-    namespace topology {
+namespace nupic
+{
+  namespace math
+  {
+    namespace topology
+    {
 
       /**
        * Translate an index into coordinates, using the given coordinate system.
@@ -53,7 +56,6 @@ namespace nupic {
         UInt index,
         const std::vector<UInt>& dimensions);
 
-
       /**
        * Translate coordinates into an index, using the given coordinate system.
        *
@@ -71,7 +73,6 @@ namespace nupic {
       UInt indexFromCoordinates(
         const std::vector<UInt>& coordinates,
         const std::vector<UInt>& dimensions);
-
 
       /**
        * A class that lets you iterate over all points within the neighborhood
@@ -128,7 +129,8 @@ namespace nupic {
        * the loop returns a point in the neighborhood. Each point is expressed
        * as a single index.
        */
-      class Neighborhood {
+      class Neighborhood
+      {
       public:
         Neighborhood(UInt centerIndex, UInt radius,
                      const std::vector<UInt>& dimensions);
@@ -178,7 +180,8 @@ namespace nupic {
        * the loop returns a point in the neighborhood. Each point is expressed
        * as a single index.
        */
-      class WrappingNeighborhood {
+      class WrappingNeighborhood
+      {
       public:
         WrappingNeighborhood(UInt centerIndex, UInt radius,
                              const std::vector<UInt>& dimensions);

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -499,7 +499,7 @@ namespace {
     sp.getMinOverlapDutyCycles(resultMinOverlapArr);
 
     ASSERT_TRUE(check_vector_eq(resultMinOverlapArr, trueOverlapArr,
-                              numColumns));
+                                numColumns));
     ASSERT_TRUE(check_vector_eq(resultMinActiveArr, trueActiveArr, numColumns));
   }
 
@@ -1449,7 +1449,7 @@ namespace {
     UInt trueActive[5] = {1, 2, 5, 6, 9};
     sp.setInhibitionRadius(inhibitionRadius);
     sp.inhibitColumnsLocal_(overlaps, density, active);
-    ASSERT_TRUE(active.size() == 5);
+    ASSERT_EQ(5, active.size());
     ASSERT_TRUE(check_vector_eq(trueActive, active));
 
     Real overlapsArray2[10] = {1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7};
@@ -1476,560 +1476,6 @@ namespace {
 
     ASSERT_TRUE(active.size() == 4);
     ASSERT_TRUE(check_vector_eq(trueActive3, active));
-
-  }
-
-  TEST(SpatialPoolerTest, testGetNeighbors1D)
-  {
-
-    SpatialPooler sp;
-    UInt numInputs = 5;
-    UInt numColumns = 8;
-    setup(sp,numInputs,numColumns);
-
-    UInt column;
-    UInt radius;
-    vector<UInt> dimensions;
-    vector<UInt> neighbors;
-    bool wrapAround;
-    vector<UInt> neighborsMap(numColumns, 0);
-
-    column = 3;
-    radius = 1;
-    wrapAround = true;
-    dimensions.push_back(8);
-    UInt trueNeighborsMap1[8] = {0, 0, 1, 0, 1, 0, 0, 0};
-    sp.getNeighbors1D_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap1, neighborsMap));
-
-    column = 3;
-    radius = 2;
-    wrapAround = false;
-    UInt trueNeighborsMap2[8] = {0, 1, 1, 0, 1, 1, 0, 0};
-    sp.getNeighbors1D_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap2, neighborsMap));
-
-    column = 0;
-    radius = 2;
-    wrapAround = true;
-    UInt trueNeighborsMap3[8] = {0, 1, 1, 0, 0, 0, 1, 1};
-    sp.getNeighbors1D_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap3, neighborsMap));
-  }
-
-  TEST(SpatialPoolerTest, testGetNeighbors2D)
-  {
-    UInt numColumns = 30;
-    vector<UInt> dimensions;
-    dimensions.push_back(6);
-    dimensions.push_back(5);
-    SpatialPooler sp;
-    vector<UInt> neighbors;
-    UInt column;
-    UInt radius;
-    bool wrapAround;
-    vector<UInt> neighborsMap;
-
-    UInt trueNeighborsMap1[30] =
-      {0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       0, 1, 1, 1, 0,
-       0, 1, 0, 1, 0,
-       0, 1, 1, 1, 0,
-       0, 0, 0, 0, 0};
-
-    column = 3*5+2;
-    radius = 1;
-    wrapAround = false;
-    sp.getNeighbors2D_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap1, neighborsMap));
-
-    UInt trueNeighborsMap2[30] =
-      {0, 0, 0, 0, 0,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 0, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1};
-
-    column = 3*5+2;
-    radius = 2;
-    wrapAround = false;
-    sp.getNeighbors2D_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap2, neighborsMap));
-
-    UInt trueNeighborsMap3[30] =
-      {1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 0, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1};
-
-    column = 3*5+2;
-    radius = 3;
-    wrapAround = false;
-    sp.getNeighbors2D_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap3, neighborsMap));
-
-    UInt trueNeighborsMap4[30] =
-      {1, 0, 0, 1, 1,
-       0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       1, 0, 0, 1, 1,
-       1, 0, 0, 1, 0};
-
-    column = 29;
-    radius = 1;
-    wrapAround = true;
-    sp.getNeighbors2D_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap4, neighborsMap));
-  }
-
-  bool findVector(UInt needle[], UInt n, vector<vector<UInt> > haystack)
-  {
-    for (auto & elem : haystack) {
-      vector<UInt> hay = elem;
-      if (hay.size() != n) {
-        continue;
-      }
-
-      bool match = true;
-      for (UInt j = 0; j < hay.size(); j++) {
-        if (hay[j] != needle[j]) {
-          match = false;
-          break;
-        }
-      }
-
-      if (match) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  TEST(SpatialPoolerTest, testCartesianProduct)
-  {
-    vector<vector<UInt> > vecs;
-    vector<vector<UInt> > prod;
-    UInt needle[3];
-    vector<UInt> v1, v2, v3;
-    SpatialPooler sp;
-
-    sp.cartesianProduct_(vecs, prod);
-    ASSERT_TRUE(prod.size() == 0);
-
-    v1.push_back(2);
-    v1.push_back(4);
-
-    v2.push_back(1);
-    v2.push_back(3);
-
-    vecs.push_back(v2);
-    vecs.push_back(v1);
-
-    sp.cartesianProduct_(vecs,prod);
-    ASSERT_TRUE(prod.size() == 4);
-    needle[0] = 2; needle[1] = 1;
-    ASSERT_TRUE(findVector(needle, 2, prod));
-    needle[0] = 2; needle[1] = 3;
-    ASSERT_TRUE(findVector(needle, 2, prod));
-    needle[0] = 4; needle[1] = 1;
-    ASSERT_TRUE(findVector(needle, 2, prod));
-    needle[0] = 4; needle[1] = 3;
-    ASSERT_TRUE(findVector(needle, 2, prod));
-
-
-    v1.clear();
-    v2.clear();
-    vecs.clear();
-    prod.clear();
-
-    v1.push_back(1);
-    v1.push_back(2);
-    v1.push_back(3);
-
-    v2.push_back(4);
-    v2.push_back(5);
-    v2.push_back(6);
-
-    v3.push_back(7);
-    v3.push_back(8);
-    v3.push_back(9);
-
-    vecs.push_back(v3);
-    vecs.push_back(v2);
-    vecs.push_back(v1);
-
-    sp.cartesianProduct_(vecs, prod);
-    ASSERT_TRUE(prod.size() == 27);
-    needle[0] = 1; needle[1] = 4; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 4; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 4; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 1; needle[1] = 5; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 5; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 5; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 1; needle[1] = 6; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 6; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 1; needle[1] = 6; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 2; needle[1] = 4; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 4; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 4; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 2; needle[1] = 5; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 5; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 5; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 2; needle[1] = 6; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 6; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 2; needle[1] = 6; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 3; needle[1] = 4; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 4; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 4; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 3; needle[1] = 5; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 5; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 5; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-    needle[0] = 3; needle[1] = 6; needle[2] = 7;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 6; needle[2] = 8;
-    ASSERT_TRUE(findVector(needle,3,prod));
-    needle[0] = 3; needle[1] = 6; needle[2] = 9;
-    ASSERT_TRUE(findVector(needle,3,prod));
-
-  }
-
-  TEST(SpatialPoolerTest, testGetNeighborsND)
-  {
-    SpatialPooler sp;
-    UInt column;
-    vector<UInt> dimensions;
-    vector<UInt> nums;
-    vector<UInt> neighbors;
-    bool wrapAround;
-    UInt numColumns;
-
-    UInt radius;
-    UInt x,y,z,w;
-    dimensions.clear();
-    dimensions.push_back(4);
-    dimensions.push_back(5);
-    dimensions.push_back(7);
-
-    vector<UInt> neighborsMap;
-    UInt trueNeighbors1[4][5][7];
-    radius = 1;
-    wrapAround = false;
-    z = 1;
-    y = 2;
-    x = 5;
-    numColumns = (4 * 5 * 7);
-
-    for (auto & elem : trueNeighbors1) {
-      for (auto & elem_j : elem) {
-        for (UInt k = 0; k < 7; k++) {
-          elem_j[k] = 0;
-        }
-      }
-    }
-
-    for (Int i = -(Int)radius; i <= (Int)radius; i++) {
-      for (Int j = -(Int)radius; j <= (Int)radius; j++) {
-        for (Int k = -(Int)radius; k <= (Int)radius; k++) {
-          Int zc = (z + i + dimensions[0]) % dimensions[0];
-          Int yc = (y + j + dimensions[1]) % dimensions[1];
-          Int xc = (x + k + dimensions[2]) % dimensions[2];
-          if (i == 0 && j == 0 && k == 0) {
-            continue;
-          }
-          trueNeighbors1[zc][yc][xc] = 1;
-        }
-      }
-    }
-
-    column = (UInt) (&trueNeighbors1[z][y][x] - &trueNeighbors1[0][0][0]);
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                       neighbors);
-
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq((UInt*) trueNeighbors1, neighborsMap));
-
-    neighborsMap.clear();
-    w = 4;
-    z = 1;
-    y = 6;
-    x = 3;
-    dimensions.clear();
-    dimensions.push_back(5);
-    dimensions.push_back(6);
-    dimensions.push_back(8);
-    dimensions.push_back(4);
-
-    UInt trueNeighbors2[5][6][8][4];
-    UInt trueNeighbors2Wrap[5][6][8][4];
-    radius = 2;
-    numColumns = (5 * 6 * 8 * 4);
-
-    for (UInt i = 0; i < numColumns; i++) {
-      ((UInt*)trueNeighbors2)[i] = 0;
-      ((UInt*)trueNeighbors2Wrap)[i] = 0;
-    }
-
-    for (Int i = -(Int)radius; i <= (Int)radius; i++) {
-      for (Int j = -(Int)radius; j <= (Int)radius; j++) {
-        for (Int k = -(Int)radius; k <= (Int)radius; k++) {
-          for (Int m = -(Int) radius; m <= (Int) radius; m++) {
-            Int wc = (w + i);
-            Int zc = (z + j);
-            Int yc = (y + k);
-            Int xc = (x + m);
-
-            Int wc_ = emod((w + i), dimensions[0]);
-            Int zc_ = emod((z + j), dimensions[1]);
-            Int yc_ = emod((y + k), dimensions[2]);
-            Int xc_ = emod((x + m), dimensions[3]);
-
-            if (i == 0 && j == 0 && k == 0 && m == 0) {
-              continue;
-            }
-
-            trueNeighbors2Wrap[wc_][zc_][yc_][xc_] = 1;
-
-            if (wc < 0 || wc >= (Int) dimensions[0] ||  // *)
-                zc < 0 || zc >= (Int) dimensions[1] ||
-                yc < 0 || yc >= (Int) dimensions[2] ||
-                xc < 0 || xc >= (Int) dimensions[3]) {
-              continue;
-            }
-// gcc 4.6 / 4.7 / 5.3 has a bug here, issues warning -Warray-bounds which is not true, see *), so suppress it
-#if ((__GNUC__ == 4 && (__GNUC_MINOR__ == 6 || __GNUC_MINOR__ == 7)) || \
-     (__GNUC__ == 5 && (__GNUC_MINOR__ == 3)))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-            trueNeighbors2[wc][zc][yc][xc] = 1;
-#if ((__GNUC__ == 4 && (__GNUC_MINOR__ == 6 || __GNUC_MINOR__ == 7)) || \
-     (__GNUC__ == 5 && (__GNUC_MINOR__ == 3)))
-#pragma GCC diagnostic pop
-#endif
-          }
-        }
-      }
-    }
-
-    column = (UInt) (&trueNeighbors2[w][z][y][x] -
-      &trueNeighbors2[0][0][0][0]);
-    sp.getNeighborsND_(column, dimensions, radius, false,
-                       neighbors);
-
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-
-    ASSERT_TRUE(check_vector_eq((UInt *) trueNeighbors2, neighborsMap));
-
-    sp.getNeighborsND_(column, dimensions, radius, true,
-                       neighbors);
-
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq((UInt *) trueNeighbors2Wrap, neighborsMap));
-
-
-    // 2D tests repeated here
-    dimensions.clear();
-    dimensions.push_back(6);
-    dimensions.push_back(5);
-
-    numColumns = 30;
-    UInt trueNeighborsMap3[30] =
-      {0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       0, 1, 1, 1, 0,
-       0, 1, 0, 1, 0,
-       0, 1, 1, 1, 0,
-       0, 0, 0, 0, 0};
-
-    column = 3*5+2;
-    radius = 1;
-    wrapAround = false;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap3, neighborsMap));
-
-    UInt trueNeighborsMap4[30] =
-      {0, 0, 0, 0, 0,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 0, 1, 1,
-       1, 1, 1, 1, 1,
-       1, 1, 1, 1, 1};
-
-    column = 3*5+2;
-    radius = 2;
-    wrapAround = false;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap4, neighborsMap));
-
-    UInt trueNeighborsMap5[30] =
-      {1, 0, 0, 1, 1,
-       0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0,
-       1, 0, 0, 1, 1,
-       1, 0, 0, 1, 0};
-
-    column = 29;
-    radius = 1;
-    wrapAround = true;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround, neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap5, neighborsMap));
-
-    dimensions.clear();
-    dimensions.push_back(8);
-    numColumns = 8;
-
-    UInt trueNeighborsMap6[8] = { 0, 0, 1, 0, 1, 0, 0, 0 };
-    column = 3;
-    radius = 1;
-    wrapAround = true;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap6, neighborsMap));
-
-    UInt trueNeighborsMap7[8] = { 0, 1, 1, 0, 1, 1, 0, 0 };
-    column = 3;
-    radius = 2;
-    wrapAround = false;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap7, neighborsMap));
-
-    UInt trueNeighborsMap8[8] = { 0, 1, 1, 0, 0, 0, 1, 1 };
-    column = 0;
-    radius = 2;
-    wrapAround = true;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap8, neighborsMap));
-
-    // Test with radius larger than the dimension range
-    UInt trueNeighborsMap9[8] = { 0, 1, 1, 1, 1, 1, 1, 1 };
-    column = 0;
-    radius = 100;
-    wrapAround = false;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap9, neighborsMap));
-
-    // Test with radius larger than the dimension range,
-    // with wrapAround enabled
-    UInt trueNeighborsMap10[8] = { 0, 1, 1, 1, 1, 1, 1, 1 };
-    column = 0;
-    radius = 100;
-    wrapAround = true;
-    sp.getNeighborsND_(column, dimensions, radius, wrapAround,
-                          neighbors);
-    neighborsMap.assign(numColumns, 0);
-    for (auto & neighbor : neighbors) {
-      neighborsMap[neighbor] = 1;
-    }
-    ASSERT_TRUE(check_vector_eq(trueNeighborsMap10, neighborsMap));
 
   }
 
@@ -2271,60 +1717,62 @@ namespace {
 
   TEST(SpatialPoolerTest, testMapColumn)
   {
-    vector<UInt> inputDim, columnDim;
-    SpatialPooler sp;
+    {
+      // Test 1D.
+      SpatialPooler sp(
+        /*inputDimensions*/{12},
+        /*columnDimensions*/{4});
 
-    // Test 1D
-    inputDim.push_back(12);
-    columnDim.push_back(4);
-    sp.initialize(inputDim, columnDim);
+      EXPECT_EQ(1, sp.mapColumn_(0));
+      EXPECT_EQ(4, sp.mapColumn_(1));
+      EXPECT_EQ(7, sp.mapColumn_(2));
+      EXPECT_EQ(10, sp.mapColumn_(3));
+    }
 
-    NTA_ASSERT(sp.mapColumn_(0) == 1);
-    NTA_ASSERT(sp.mapColumn_(1) == 4);
-    NTA_ASSERT(sp.mapColumn_(2) == 7);
-    NTA_ASSERT(sp.mapColumn_(3) == 10);
+    {
+      // Test 1D with same dimensions of columns and inputs.
+      SpatialPooler sp(
+        /*inputDimensions*/{4},
+        /*columnDimensions*/{4});
 
-    columnDim.clear();
-    inputDim.clear();
+      EXPECT_EQ(0, sp.mapColumn_(0));
+      EXPECT_EQ(1, sp.mapColumn_(1));
+      EXPECT_EQ(2, sp.mapColumn_(2));
+      EXPECT_EQ(3, sp.mapColumn_(3));
+    }
 
-    // Test 1D with same dimensions of columns and inputs
-    inputDim.push_back(4);
-    columnDim.push_back(4);
-    sp.initialize(inputDim, columnDim);
+    {
+      // Test 1D with dimensions of length 1.
+      SpatialPooler sp(
+        /*inputDimensions*/{1},
+        /*columnDimensions*/{1});
 
-    NTA_ASSERT(sp.mapColumn_(0) == 0);
-    NTA_ASSERT(sp.mapColumn_(1) == 1);
-    NTA_ASSERT(sp.mapColumn_(2) == 2);
-    NTA_ASSERT(sp.mapColumn_(3) == 3);
+      EXPECT_EQ(0, sp.mapColumn_(0));
+    }
 
-    columnDim.clear();
-    inputDim.clear();
+    {
+      // Test 2D.
+      SpatialPooler sp(
+        /*inputDimensions*/{36, 12},
+        /*columnDimensions*/{12, 4});
 
-    // Test 1D with dimensions of length 1
-    inputDim.push_back(1);
-    columnDim.push_back(1);
-    sp.initialize(inputDim, columnDim);
+      EXPECT_EQ(13, sp.mapColumn_(0));
+      EXPECT_EQ(49, sp.mapColumn_(4));
+      EXPECT_EQ(52, sp.mapColumn_(5));
+      EXPECT_EQ(58, sp.mapColumn_(7));
+      EXPECT_EQ(418, sp.mapColumn_(47));
+    }
 
-    NTA_ASSERT(sp.mapColumn_(0) == 0);
+    {
+      // Test 2D, some input dimensions smaller than column dimensions.
+      SpatialPooler sp(
+        /*inputDimensions*/{3, 5},
+        /*columnDimensions*/{4, 4});
 
-    columnDim.clear();
-    inputDim.clear();
-
-    // Test 2D
-    inputDim.push_back(36);
-    inputDim.push_back(12);
-    columnDim.push_back(12);
-    columnDim.push_back(4);
-    sp.initialize(inputDim, columnDim);
-
-    NTA_ASSERT(sp.mapColumn_(0) == 13);
-    NTA_ASSERT(sp.mapColumn_(4) == 49);
-    NTA_ASSERT(sp.mapColumn_(5) == 52);
-    NTA_ASSERT(sp.mapColumn_(7) == 58);
-    NTA_ASSERT(sp.mapColumn_(47) == 418);
-
-    columnDim.clear();
-    inputDim.clear();
+      EXPECT_EQ(0, sp.mapColumn_(0));
+      EXPECT_EQ(4, sp.mapColumn_(3));
+      EXPECT_EQ(14, sp.mapColumn_(15));
+    }
   }
 
   TEST(SpatialPoolerTest, testMapPotential1D)
@@ -2366,7 +1814,7 @@ namespace {
     sp.setPotentialPct(0.5);
     UInt supersetMask1[12] = {1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1};
     mask = sp.mapPotential_(0, true);
-    NTA_ASSERT(sum(mask) == 3);
+    ASSERT_TRUE(sum(mask) == 3);
 
     UInt unionMask1[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (UInt i = 0; i < 12; i++) {
@@ -2708,4 +2156,4 @@ namespace {
     ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
   }
 
-} // end namespace nupic
+} // end anonymous namespace

--- a/src/test/unit/math/TopologyTest.cpp
+++ b/src/test/unit/math/TopologyTest.cpp
@@ -1,0 +1,380 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * Unit tests for Topology.hpp
+ */
+
+#include <nupic/math/Topology.hpp>
+#include "gtest/gtest.h"
+
+using std::vector;
+using namespace nupic;
+using namespace nupic::math::topology;
+
+namespace {
+  TEST(TopologyTest, IndexFromCoordinates)
+  {
+    EXPECT_EQ(0, indexFromCoordinates({0}, {100}));
+    EXPECT_EQ(50, indexFromCoordinates({50}, {100}));
+    EXPECT_EQ(99, indexFromCoordinates({99}, {100}));
+
+    EXPECT_EQ(0, indexFromCoordinates({0, 0}, {100, 80}));
+    EXPECT_EQ(10, indexFromCoordinates({0, 10}, {100, 80}));
+    EXPECT_EQ(80, indexFromCoordinates({1, 0}, {100, 80}));
+    EXPECT_EQ(90, indexFromCoordinates({1, 10}, {100, 80}));
+
+    EXPECT_EQ(0, indexFromCoordinates({0, 0, 0}, {100, 10, 8}));
+    EXPECT_EQ(7, indexFromCoordinates({0, 0, 7}, {100, 10, 8}));
+    EXPECT_EQ(8, indexFromCoordinates({0, 1, 0}, {100, 10, 8}));
+    EXPECT_EQ(80, indexFromCoordinates({1, 0, 0}, {100, 10, 8}));
+    EXPECT_EQ(88, indexFromCoordinates({1, 1, 0}, {100, 10, 8}));
+    EXPECT_EQ(89, indexFromCoordinates({1, 1, 1}, {100, 10, 8}));
+  }
+
+  TEST(TopologyTest, CoordinatesFromIndex)
+  {
+    EXPECT_EQ(vector<UInt>({0}), coordinatesFromIndex(0, {100}));
+    EXPECT_EQ(vector<UInt>({50}), coordinatesFromIndex(50, {100}));
+    EXPECT_EQ(vector<UInt>({99}), coordinatesFromIndex(99, {100}));
+
+    EXPECT_EQ(vector<UInt>({0, 0}), coordinatesFromIndex(0, {100, 80}));
+    EXPECT_EQ(vector<UInt>({0, 10}), coordinatesFromIndex(10, {100, 80}));
+    EXPECT_EQ(vector<UInt>({1, 0}), coordinatesFromIndex(80, {100, 80}));
+    EXPECT_EQ(vector<UInt>({1, 10}), coordinatesFromIndex(90, {100, 80}));
+
+    EXPECT_EQ(vector<UInt>({0, 0, 0}), coordinatesFromIndex(0, {100, 10, 8}));
+    EXPECT_EQ(vector<UInt>({0, 0, 7}), coordinatesFromIndex(7, {100, 10, 8}));
+    EXPECT_EQ(vector<UInt>({0, 1, 0}), coordinatesFromIndex(8, {100, 10, 8}));
+    EXPECT_EQ(vector<UInt>({1, 0, 0}), coordinatesFromIndex(80, {100, 10, 8}));
+    EXPECT_EQ(vector<UInt>({1, 1, 0}), coordinatesFromIndex(88, {100, 10, 8}));
+    EXPECT_EQ(vector<UInt>({1, 1, 1}), coordinatesFromIndex(89, {100, 10, 8}));
+  }
+
+  // ==========================================================================
+  // NEIGHBORHOOD
+  // ==========================================================================
+
+  void expectNeighborhoodIndices(
+    const vector<UInt>& centerCoords,
+    const vector<UInt>& dimensions,
+    UInt radius,
+    const vector<UInt>& expected)
+  {
+    const UInt centerIndex = indexFromCoordinates(centerCoords, dimensions);
+
+    int i = 0;
+    for (UInt index : Neighborhood(centerIndex, radius, dimensions))
+    {
+      EXPECT_EQ(expected[i], index);
+      i++;
+    }
+
+    EXPECT_EQ(expected.size(), i);
+  }
+
+  void expectNeighborhoodCoords(
+    const vector<UInt>& centerCoords,
+    const vector<UInt>& dimensions,
+    UInt radius,
+    const vector<vector<UInt> >& expected)
+  {
+    const UInt centerIndex = indexFromCoordinates(centerCoords, dimensions);
+
+    int i = 0;
+    for (UInt index : Neighborhood(centerIndex, radius, dimensions))
+    {
+      EXPECT_EQ(indexFromCoordinates(expected[i], dimensions), index);
+      i++;
+    }
+
+    EXPECT_EQ(expected.size(), i);
+  }
+
+  TEST(TopologyTest, NeighborhoodOfOrigin1D)
+  {
+    expectNeighborhoodIndices(
+      /*centerCoords*/ {0},
+      /*dimensions*/ {100},
+      /*radius*/ 2,
+      /*expected*/ {0, 1, 2});
+  }
+
+  TEST(TopologyTest, NeighborhoodOfOrigin2D)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 2,
+      /*expected*/ {{0, 0}, {0, 1}, {0, 2},
+                    {1, 0}, {1, 1}, {1, 2},
+                    {2, 0}, {2, 1}, {2, 2}});
+  }
+
+  TEST(TopologyTest, NeighborhoodOfOrigin3D)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {0, 0, 0},
+      /*dimensions*/ {100, 80, 60},
+      /*radius*/ 1,
+      /*expected*/ {{0, 0, 0}, {0, 0, 1},
+                    {0, 1, 0}, {0, 1, 1},
+                    {1, 0, 0}, {1, 0, 1},
+                    {1, 1, 0}, {1, 1, 1}});
+  }
+
+  TEST(TopologyTest, NeighborhoodOfMiddle1D)
+  {
+    expectNeighborhoodIndices(
+      /*centerCoords*/ {50},
+      /*dimensions*/ {100},
+      /*radius*/ 1,
+      /*expected*/ {49, 50, 51});
+  }
+
+  TEST(TopologyTest, NeighborhoodOfMiddle2D)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {50, 50},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 1,
+      /*expected*/ {{49, 49}, {49, 50}, {49, 51},
+                    {50, 49}, {50, 50}, {50, 51},
+                    {51, 49}, {51, 50}, {51, 51}});
+  }
+
+  TEST(TopologyTest, NeighborhoodOfEnd2D)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {99, 79},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 2,
+      /*expected*/ {{97, 77}, {97, 78}, {97, 79},
+                    {98, 77}, {98, 78}, {98, 79},
+                    {99, 77}, {99, 78}, {99, 79}});
+  }
+
+  TEST(TopologyTest, NeighborhoodWiderThanWorld)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {3, 2},
+      /*radius*/ 3,
+      /*expected*/ {{0, 0}, {0, 1},
+                    {1, 0}, {1, 1},
+                    {2, 0}, {2, 1}});
+  }
+
+  TEST(TopologyTest, NeighborhoodRadiusZero)
+  {
+    expectNeighborhoodIndices(
+      /*centerCoords*/ {0},
+      /*dimensions*/ {100},
+      /*radius*/ 0,
+      /*expected*/ {0});
+
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 0,
+      /*expected*/ {{0, 0}});
+
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {0, 0, 0},
+      /*dimensions*/ {100, 80, 60},
+      /*radius*/ 0,
+      /*expected*/ {{0, 0, 0}});
+  }
+
+  TEST(TopologyTest, NeighborhoodDimensionOne)
+  {
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {5, 0},
+      /*dimensions*/ {10, 1},
+      /*radius*/ 1,
+      /*expected*/ {{4, 0}, {5, 0}, {6, 0}});
+
+    expectNeighborhoodCoords(
+      /*centerCoords*/ {5, 0, 0},
+      /*dimensions*/ {10, 1, 1},
+      /*radius*/ 1,
+      /*expected*/ {{4, 0, 0}, {5, 0, 0}, {6, 0, 0}});
+  }
+
+  // ==========================================================================
+  // WRAPPING NEIGHBORHOOD
+  // ==========================================================================
+
+
+  void expectWrappingNeighborhoodIndices(
+    const vector<UInt>& centerCoords,
+    const vector<UInt>& dimensions,
+    UInt radius,
+    const vector<UInt>& expected)
+  {
+    const UInt centerIndex = indexFromCoordinates(centerCoords, dimensions);
+
+    int i = 0;
+    for (UInt index : WrappingNeighborhood(centerIndex, radius, dimensions))
+    {
+      EXPECT_EQ(expected[i], index);
+      i++;
+    }
+
+    EXPECT_EQ(expected.size(), i);
+  }
+
+  void expectWrappingNeighborhoodCoords(
+    const vector<UInt>& centerCoords,
+    const vector<UInt>& dimensions,
+    UInt radius,
+    const vector<vector<UInt> >& expected)
+  {
+    const UInt centerIndex = indexFromCoordinates(centerCoords, dimensions);
+
+    int i = 0;
+    for (UInt index : WrappingNeighborhood(centerIndex, radius, dimensions))
+    {
+      EXPECT_EQ(indexFromCoordinates(expected[i], dimensions), index);
+      i++;
+    }
+
+    EXPECT_EQ(expected.size(), i);
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfOrigin1D)
+  {
+    expectWrappingNeighborhoodIndices(
+      /*centerCoords*/ {0},
+      /*dimensions*/ {100},
+      /*radius*/ 1,
+      /*expected*/ {99, 0, 1});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfOrigin2D)
+  {
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 1,
+      /*expected*/ {{99, 79}, {99, 0}, {99, 1},
+                    {0, 79}, {0, 0}, {0, 1},
+                    {1, 79}, {1, 0}, {1, 1}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfOrigin3D)
+  {
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {0, 0, 0},
+      /*dimensions*/ {100, 80, 60},
+      /*radius*/ 1,
+      /*expected*/ {{99, 79, 59}, {99, 79, 0}, {99, 79, 1},
+                    {99, 0, 59}, {99, 0, 0}, {99, 0, 1},
+                    {99, 1, 59}, {99, 1, 0}, {99, 1, 1},
+                    {0, 79, 59}, {0, 79, 0}, {0, 79, 1},
+                    {0, 0, 59}, {0, 0, 0}, {0, 0, 1},
+                    {0, 1, 59}, {0, 1, 0}, {0, 1, 1},
+                    {1, 79, 59}, {1, 79, 0}, {1, 79, 1},
+                    {1, 0, 59}, {1, 0, 0}, {1, 0, 1},
+                    {1, 1, 59}, {1, 1, 0}, {1, 1, 1}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfMiddle1D)
+  {
+    expectWrappingNeighborhoodIndices(
+      /*centerCoords*/ {50},
+      /*dimensions*/ {100},
+      /*radius*/ 1,
+      /*expected*/ {49, 50, 51});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfMiddle2D)
+  {
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {50, 50},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 1,
+      /*expected*/{{49, 49}, {49, 50}, {49, 51},
+                   {50, 49}, {50, 50}, {50, 51},
+                   {51, 49}, {51, 50}, {51, 51}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodOfEnd2D)
+  {
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {99, 79},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 1,
+      /*expected*/{{98, 78}, {98, 79}, {98, 0},
+                   {99, 78}, {99, 79}, {99, 0},
+                   {0, 78}, {0, 79}, {0, 0}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodWiderThanWorld)
+  {
+    // The order is weird because it starts walking from {-3, -3} and avoids
+    // walking the same point twice.
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {3, 2},
+      /*radius*/ 3,
+      /*expected*/{{0, 1}, {0, 0},
+                   {1, 1}, {1, 0},
+                   {2, 1}, {2, 0}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodRadiusZero)
+  {
+    expectWrappingNeighborhoodIndices(
+      /*centerCoords*/ {0},
+      /*dimensions*/ {100},
+      /*radius*/ 0,
+      /*expected*/ {0});
+
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {0, 0},
+      /*dimensions*/ {100, 80},
+      /*radius*/ 0,
+      /*expected*/ {{0, 0}});
+
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {0, 0, 0},
+      /*dimensions*/ {100, 80, 60},
+      /*radius*/ 0,
+      /*expected*/ {{0, 0, 0}});
+  }
+
+  TEST(TopologyTest, WrappingNeighborhoodDimensionOne)
+  {
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {5, 0},
+      /*dimensions*/ {10, 1},
+      /*radius*/ 1,
+      /*expected*/ {{4, 0}, {5, 0}, {6, 0}});
+
+    expectWrappingNeighborhoodCoords(
+      /*centerCoords*/ {5, 0, 0},
+      /*dimensions*/ {10, 1, 1},
+      /*radius*/ 1,
+      /*expected*/ {{4, 0, 0}, {5, 0, 0}, {6, 0, 0}});
+  }
+}

--- a/src/test/unit/math/TopologyTest.cpp
+++ b/src/test/unit/math/TopologyTest.cpp
@@ -220,10 +220,10 @@ namespace {
       /*expected*/ {{4, 0, 0}, {5, 0, 0}, {6, 0, 0}});
   }
 
+
   // ==========================================================================
   // WRAPPING NEIGHBORHOOD
   // ==========================================================================
-
 
   void expectWrappingNeighborhoodIndices(
     const vector<UInt>& centerCoords,


### PR DESCRIPTION
Introduces a `Neighborhood` class which lets you iterate over all points in a neighborhood without ever creating a list of points.

This change also fixes a bug in the SP's `mapColumn_`. When I removed the `sort` call, the compatibility tests started failing, and this was the root cause.

Fixes #1079 
Fixes #1080
Fixes #128 (no more extraneous sorting)

This affects algorithm results for two reasons:

- We walk neighbors in a different order.
- `mapColumn_` is no longer broken.
  - Though this bug wasn't showing up in the SP compatibility tests until I removed neighbor sorting.

## Perf results

**Before:**

~~~
> time python nupic.research/projects/sp_paper/train_sp_topology_simple.py

real	0m51.560s
~~~

**After:**

~~~
> time python nupic.research/projects/sp_paper/train_sp_topology_simple.py

real	0m7.755s
~~~

So with this topology, it's 6.5x faster. For larger topologies where each column has more neighbors, it will be more dramatic.