### PR TITLE
Add missing argument to `Set-PsDebug -Trace`

### DIFF
--- a/ci/bamboo/build-windows.ps1
+++ b/ci/bamboo/build-windows.ps1
@@ -47,7 +47,8 @@
 # Stop and fail script if any command fails
 $ErrorActionPreference = "Stop"
 
-Set-PsDebug -Trace
+# Trace script lines as they run
+Set-PsDebug -Trace 1
 
 
 


### PR DESCRIPTION
Fixes #1075

Follow-on fix to the merged PR #1082