### PR TITLE
ETM: Split external active cells from winner cells. Check inputs.

### DIFF
--- a/src/nupic/bindings/experimental.i
+++ b/src/nupic/bindings/experimental.i
@@ -195,28 +195,28 @@ using namespace nupic;
       Calculate the active cells, using the current active columns and dendrite
       segments. Grow and reinforce synapses.
 
-      @param activeColumns (list)
-      A sorted list of active column indices.
+      @param activeColumns (sequence)
+      A sorted sequence of active column indices.
 
-      @param reinforceCandidatesExternalBasal (list)
+      @param reinforceCandidatesExternalBasal (sequence)
       Sorted list of external cells. Any learning basal dendrite segments will
       use this list to decide which synapses to reinforce and which synapses to
       punish. Typically this list should be the 'activeCellsExternalBasal' from
       the prevous time step.
 
-      @param reinforceCandidatesExternalApical (list)
+      @param reinforceCandidatesExternalApical (sequence)
       Sorted list of external cells. Any learning apical dendrite segments will
       use this list to decide which synapses to reinforce and which synapses to
       punish. Typically this list should be the 'activeCellsExternalApical' from
       the prevous time step.
 
-      @param growthCandidatesExternalBasal (list)
+      @param growthCandidatesExternalBasal (sequence)
       Sorted list of external cells. Any learning basal dendrite segments can
       grow synapses to cells in this list. Typically this list should be a
       subset of the 'activeCellsExternalBasal' from the previous
       'depolarizeCells'.
 
-      @param growthCandidatesExternalApical (list)
+      @param growthCandidatesExternalApical (sequence)
       Sorted list of external cells. Any learning apical dendrite segments can
       grow synapses to cells in this list. Typically this list should be a
       subset of the 'activeCellsExternalApical' from the previous
@@ -243,10 +243,10 @@ using namespace nupic;
       """
       Calculate dendrite segment activity, using the current active cells.
 
-      @param activeCellsExternalBasal (list)
+      @param activeCellsExternalBasal (sequence)
       Sorted list of active external cells for activating basal dendrites.
 
-      @param activeCellsExternalApical (list)
+      @param activeCellsExternalApical (sequence)
       Sorted list of active external cells for activating apical dendrites.
 
       @param learn (bool)
@@ -277,35 +277,35 @@ using namespace nupic;
       TemporalMemory via its compute method ensures that you'll always be able to
       call getPredictiveCells to get predictions for the next time step.
 
-      @param activeColumns (list)
+      @param activeColumns (sequence)
       Sorted list of active columns.
 
-      @param activeCellsExternalBasal (list)
+      @param activeCellsExternalBasal (sequence)
       Sorted list of active external cells for activating basal dendrites at the
       end of this time step.
 
-      @param activeCellsExternalApical (list)
+      @param activeCellsExternalApical (sequence)
       Sorted list of active external cells for activating apical dendrites at the
       end of this time step.
 
-      @param reinforceCandidatesExternalBasal (list)
+      @param reinforceCandidatesExternalBasal (sequence)
       Sorted list of external cells. Any learning basal dendrite segments will use
       this list to decide which synapses to reinforce and which synapses to
       punish. Typically this list should be the 'activeCellsExternalBasal' from
       the prevous time step.
 
-      @param reinforceCandidatesExternalApical (list)
+      @param reinforceCandidatesExternalApical (sequence)
       Sorted list of external cells. Any learning apical dendrite segments will use
       this list to decide which synapses to reinforce and which synapses to
       punish. Typically this list should be the 'activeCellsExternalApical' from
       the prevous time step.
 
-      @param growthCandidatesExternalBasal (list)
+      @param growthCandidatesExternalBasal (sequence)
       Sorted list of external cells. Any learning basal dendrite segments can grow
       synapses to cells in this list. Typically this list should be a subset of
       the 'activeCellsExternalBasal' from the prevous time step.
 
-      @param growthCandidatesExternalApical (list)
+      @param growthCandidatesExternalApical (sequence)
       Sorted list of external cells. Any learning apical dendrite segments can grow
       synapses to cells in this list. Typically this list should be a subset of
       the 'activeCellsExternalApical' from the prevous time step.

--- a/src/nupic/experimental/ExtendedTemporalMemory.cpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.cpp
@@ -834,35 +834,35 @@ void ExtendedTemporalMemory::activateCells(
 
     NTA_CHECK(std::all_of(activeColumns,
                           activeColumns + activeColumnsSize,
-                          [&](UInt c) { return c >= 0 && c < numColumns_; }))
+                          [&](UInt c) { return c < numColumns_; }))
       << "Values in activeColumns must be within the range "
       << "[0," << numColumns_ << ").";
     NTA_CHECK(std::all_of(
                 reinforceCandidatesExternalBasal,
                 reinforceCandidatesExternalBasal +
                 reinforceCandidatesExternalBasalSize,
-                [&](UInt c) { return c >= 0 && c < numBasalInputs_; }))
+                [&](UInt c) { return c < numBasalInputs_; }))
       << "Values in reinforceCandidatesExternalBasal must be within the range "
       << "[0," << numBasalInputs_ << ").";
     NTA_CHECK(std::all_of(
                 reinforceCandidatesExternalApical,
                 reinforceCandidatesExternalApical +
                 reinforceCandidatesExternalApicalSize,
-                [&](UInt c) { return c >= 0 && c < numApicalInputs_; }))
+                [&](UInt c) { return c < numApicalInputs_; }))
       << "Values in reinforceCandidatesExternalApical must be within the range "
       << "[0," << numApicalInputs_ << ").";
     NTA_CHECK(std::all_of(
                 growthCandidatesExternalBasal,
                 growthCandidatesExternalBasal +
                 growthCandidatesExternalBasalSize,
-                [&](UInt c) { return c >= 0 && c < numBasalInputs_; }))
+                [&](UInt c) { return c < numBasalInputs_; }))
       << "Values in growthCandidatesExternalBasal must be within the range " <<
       "[0," << numBasalInputs_ << ").";
     NTA_CHECK(std::all_of(
                 growthCandidatesExternalApical,
                 growthCandidatesExternalApical +
                 growthCandidatesExternalApicalSize,
-                [&](UInt c) { return c >= 0 && c < numApicalInputs_; }))
+                [&](UInt c) { return c < numApicalInputs_; }))
       << "Values in growthCandidatesExternalApical must be within the range "
       << "[0," << numApicalInputs_ << ").";
   }
@@ -1090,14 +1090,14 @@ void ExtendedTemporalMemory::depolarizeCells(
                 activeCellsExternalBasal,
                 activeCellsExternalBasal +
                 activeCellsExternalBasalSize,
-                [&](UInt c) { return c >= 0 && c < numBasalInputs_; }))
+                [&](UInt c) { return c < numBasalInputs_; }))
       << "Values in activeCellsExternalBasal must be within the range [0,"
       << numBasalInputs_ << ").";
     NTA_CHECK(std::all_of(
                 activeCellsExternalApical,
                 activeCellsExternalApical +
                 activeCellsExternalApicalSize,
-                [&](UInt c) { return c >= 0 && c < numApicalInputs_; }))
+                [&](UInt c) { return c < numApicalInputs_; }))
       << "Values in activeCellsExternalApical must be within the range [0,"
       << numApicalInputs_ << ").";
   }

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -147,8 +147,8 @@ namespace nupic {
          */
         ExtendedTemporalMemory(
           vector<UInt> columnDimensions,
-          vector<UInt> basalInputDimensions = {},
-          vector<UInt> apicalInputDimensions = {},
+          vector<UInt> basalInputDimensions,
+          vector<UInt> apicalInputDimensions,
           UInt cellsPerColumn = 32,
           UInt activationThreshold = 13,
           Permanence initialPermanence = 0.21,
@@ -166,9 +166,9 @@ namespace nupic {
           bool checkInputs = true);
 
         virtual void initialize(
-          vector<UInt> columnDimensions = { 2048 },
-          vector<UInt> basalInputDimensions = {},
-          vector<UInt> apicalInputDimensions = {},
+          vector<UInt> columnDimensions,
+          vector<UInt> basalInputDimensions,
+          vector<UInt> apicalInputDimensions,
           UInt cellsPerColumn = 32,
           UInt activationThreshold = 13,
           Permanence initialPermanence = 0.21,

--- a/src/nupic/experimental/ExtendedTemporalMemory.hpp
+++ b/src/nupic/experimental/ExtendedTemporalMemory.hpp
@@ -46,6 +46,31 @@ namespace nupic {
       /**
        * Extended Temporal Memory implementation in C++.
        *
+       *
+       * Public interface 1: compute
+       *
+       * Just call compute repeatedly.
+       *
+       *   tm.compute(...);
+       *   tm.compute(...);
+       *
+       * The getPredictiveCells() method gets predictions for the next compute.
+       *
+       *
+       * Public interface 2: depolarizeCells + activateColumns
+       *
+       * Call depolarizeCells() to change the predictive cells.
+       * Call activateCells() to change the active cells.
+       *
+       *   tm.depolarizeCells(...);
+       *   tm.activateCells(...);
+       *   tm.depolarizeCells(...);
+       *   tm.activateCells(...);
+       *
+       * The getPredictiveCells() method gets predictions from the most recent
+       * depolarizeCells().
+       *
+       *
        * The public API uses C arrays, not std::vectors, as inputs. C arrays are
        * a good lowest common denominator. You can get a C array from a vector,
        * but you can't get a vector from a C array without copying it. This is
@@ -63,6 +88,12 @@ namespace nupic {
          *
          * @param columnDimensions
          * Dimensions of the column space
+         *
+         * @param basalInputDimensions
+         * Dimensions of the external basal input.
+         *
+         * @param apicalInputDimensions
+         * Dimensions of the external apical input.
          *
          * @param cellsPerColumn
          * Number of cells per column
@@ -116,6 +147,8 @@ namespace nupic {
          */
         ExtendedTemporalMemory(
           vector<UInt> columnDimensions,
+          vector<UInt> basalInputDimensions = {},
+          vector<UInt> apicalInputDimensions = {},
           UInt cellsPerColumn = 32,
           UInt activationThreshold = 13,
           Permanence initialPermanence = 0.21,
@@ -129,10 +162,13 @@ namespace nupic {
           bool learnOnOneCell = false,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
-          UInt maxSynapsesPerSegment=255);
+          UInt maxSynapsesPerSegment=255,
+          bool checkInputs = true);
 
         virtual void initialize(
           vector<UInt> columnDimensions = { 2048 },
+          vector<UInt> basalInputDimensions = {},
+          vector<UInt> apicalInputDimensions = {},
           UInt cellsPerColumn = 32,
           UInt activationThreshold = 13,
           Permanence initialPermanence = 0.21,
@@ -146,7 +182,8 @@ namespace nupic {
           bool learnOnOneCell = false,
           Int seed = 42,
           UInt maxSegmentsPerCell=255,
-          UInt maxSynapsesPerSegment=255);
+          UInt maxSynapsesPerSegment=255,
+          bool checkInputs = true);
 
         virtual ~ExtendedTemporalMemory();
 
@@ -184,23 +221,39 @@ namespace nupic {
          * @param activeColumns
          * A sorted list of active column indices.
          *
-         * @param prevActiveExternalCellsBasalSize
-         * Size of prevActiveExternalCellsBasal.
+         * @param reinforceCandidatesExternalBasalSize
+         * Size of reinforceCandidatesExternalBasal.
          *
-         * @param prevActiveExternalCellsBasal
-         * A sorted list of the external cells that were used to calculate the
-         * current basal segment excitation. This class doesn't save a copy of
-         * these cells because the caller is more flexible to find ways of
-         * keeping this list available without extra copying.
+         * @param reinforceCandidatesExternalBasal
+         * Sorted list of external cells. Any learning basal dendrite segments
+         * will use this list to decide which synapses to reinforce and which
+         * synapses to punish. Typically this list should be the
+         * 'activeCellsExternalBasal' from the prevous time step.
          *
-         * @param prevActiveExternalCellsApicalSize
-         * Size of prevActiveExternalCellsApical.
+         * @param reinforceCandidatesExternalApical
+         * Size of reinforceCandidatesExternalApical.
          *
-         * @param prevActiveExternalCellsApical
-         * A sorted list of the external cells that were used to calculate the
-         * current apical segment excitation. This class doesn't save a copy of
-         * these cells because the caller is more flexible to find ways of
-         * keeping this list available without extra copying.
+         * @param reinforceCandidatesExternalApical
+         * Sorted list of external cells. Any learning apical dendrite segments will use
+         * this list to decide which synapses to reinforce and which synapses to
+         * punish. Typically this list should be the 'activeCellsExternalApical' from
+         * the prevous time step.
+         *
+         * @param growthCandidatesExternalBasal
+         * Size of growthCandidatesExternalBasal.
+         *
+         * @param growthCandidatesExternalBasal
+         * Sorted list of external cells. Any learning basal dendrite segments can grow
+         * synapses to cells in this list. Typically this list should be a subset of
+         * the 'activeCellsExternalBasal' from the previous 'activateDendrites'.
+         *
+         * @param growthCandidatesExternalApical
+         * Size of growthCandidatesExternalApical.
+         *
+         * @param growthCandidatesExternalApical
+         * Sorted list of external cells. Any learning apical dendrite segments can grow
+         * synapses to cells in this list. Typically this list should be a subset of
+         * the 'activeCellsExternalApical' from the previous 'activateDendrites'.
          *
          * @param learn
          * If true, reinforce / punish / grow synapses.
@@ -209,39 +262,47 @@ namespace nupic {
           size_t activeColumnsSize,
           const UInt activeColumns[],
 
-          size_t prevActiveExternalCellsBasalSize,
-          const CellIdx prevActiveExternalCellsBasal[],
+          size_t reinforceCandidatesExternalBasalSize,
+          const CellIdx reinforceCandidatesExternalBasal[],
 
-          size_t activeExternalCellsApicalSize,
-          const CellIdx activeExternalCellsApical[],
+          size_t reinforceCandidatesExternalApicalSize,
+          const CellIdx reinforceCandidatesExternalApical[],
+
+          size_t growthCandidatesExternalBasalSize,
+          const CellIdx growthCandidatesExternalBasal[],
+
+          size_t growthCandidatesExternalApicalSize,
+          const CellIdx growthCandidatesExternalApical[],
 
           bool learn);
 
         /**
          * Calculate dendrite segment activity, using the current active cells.
          *
-         * @param activeExternalCellsBasalSize
-         * Size of activeExternalCellsBasal.
+         * This changes the result of getPredictiveCells().
          *
-         * @param activeExternalCellsBasal
+         * @param activeCellsExternalBasalSize
+         * Size of activeCellsExternalBasal.
+         *
+         * @param activeCellsExternalBasal
          * Sorted list of active external cells for activating basal dendrites.
          *
-         * @param activeExternalCellsApicalSize
-         * Size of activeExternalCellsApical.
+         * @param activeCellsExternalApicalSize
+         * Size of activeCellsExternalApical.
          *
-         * @param activeExternalCellsApical
+         * @param activeCellsExternalApical
          * Sorted list of active external cells for activating apical dendrites.
          *
          * @param learn
          * If true, segment activations will be recorded. This information is
          * used during segment cleanup.
          */
-        void activateDendrites(
-          size_t activeExternalCellsBasalSize,
-          const CellIdx activeExternalCellsBasal[],
+        void depolarizeCells(
+          size_t activeCellsExternalBasalSize,
+          const CellIdx activeCellsExternalBasal[],
 
-          size_t activeExternalCellsApicalSize,
-          const CellIdx activeExternalCellsApical[],
+          size_t activeCellsExternalApicalSize,
+          const CellIdx activeCellsExternalApical[],
 
           bool learn = true);
 
@@ -259,37 +320,51 @@ namespace nupic {
          * @param activeColumns
          * Sorted list of indices of active columns.
          *
-         * @param prevActiveExternalCellsBasalSize
-         * Size of prevActiveExternalCellsBasal.
+         * @param activeCellsExternalBasalSize
+         * Size of activeCellsExternalBasal.
          *
-         * @param prevActiveExternalCellsBasal
-         * The external cells that were used to calculate the current basal
-         * segment excitation. This class doesn't save a copy of these cells
-         * because the caller is more flexible to find ways of keeping this list
-         * available without extra copying.
+         * @param activeCellsExternalBasal
+         * Sorted list of active external cells for activating basal dendrites.
          *
-         * @param activeExternalCellsBasalSize
-         * Size of activeExternalCellsBasal.
+         * @param activeCellsExternalApicalSize
+         * Size of activeCellsExternalApical.
          *
-         * @param activeExternalCellsBasal
-         * Sorted list of active external cells that should be used for
-         * activating basal dendrites in this timestep.
+         * @param activeCellsExternalApical
+         * Sorted list of active external cells for activating apical dendrites.
          *
-         * @param prevActiveExternalCellsApicalSize
-         * Size of prevActiveExternalCellsApical.
+         * @param reinforceCandidatesExternalBasalSize
+         * Size of reinforceCandidatesExternalBasal.
          *
-         * @param prevActiveExternalCellsApical
-         * The external cells that were used to calculate the current apical
-         * segment excitation. This class doesn't save a copy of these cells
-         * because the caller is more flexible to find ways of keeping this list
-         * available without extra copying.
+         * @param reinforceCandidatesExternalBasal
+         * Sorted list of external cells. Any learning basal dendrite segments
+         * will use this list to decide which synapses to reinforce and which
+         * synapses to punish. Typically this list should be the
+         * 'activeCellsExternalBasal' from the prevous time step.
          *
-         * @param activeExternalCellsApicalSize
-         * Size of activeExternalCellsApical.
+         * @param reinforceCandidatesExternalApical
+         * Size of reinforceCandidatesExternalApical.
          *
-         * @param activeExternalCellsApical
-         * Sorted list of active external cells that should be used for
-         * activating apical dendrites in this timestep.
+         * @param reinforceCandidatesExternalApical
+         * Sorted list of external cells. Any learning apical dendrite segments will use
+         * this list to decide which synapses to reinforce and which synapses to
+         * punish. Typically this list should be the 'activeCellsExternalApical' from
+         * the prevous time step.
+         *
+         * @param growthCandidatesExternalBasal
+         * Size of growthCandidatesExternalBasal.
+         *
+         * @param growthCandidatesExternalBasal
+         * Sorted list of external cells. Any learning basal dendrite segments can grow
+         * synapses to cells in this list. Typically this list should be a subset of
+         * the 'activeCellsExternalBasal' from the previous 'activateDendrites'.
+         *
+         * @param growthCandidatesExternalApical
+         * Size of growthCandidatesExternalApical.
+         *
+         * @param growthCandidatesExternalApical
+         * Sorted list of external cells. Any learning apical dendrite segments can grow
+         * synapses to cells in this list. Typically this list should be a subset of
+         * the 'activeCellsExternalApical' from the previous 'activateDendrites'.
          *
          * @param learn
          * Whether or not learning is enabled.
@@ -298,17 +373,23 @@ namespace nupic {
           size_t activeColumnsSize,
           const UInt activeColumns[],
 
-          size_t prevActiveExternalCellsBasalSize = 0,
-          const CellIdx prevActiveExternalCellsBasal[] = nullptr,
+          size_t activeCellsExternalBasalSize = 0,
+          const CellIdx activeCellsExternalBasal[] = nullptr,
 
-          size_t activeExternalCellsBasalSize = 0,
-          const CellIdx activeExternalCellsBasal[] = nullptr,
+          size_t activeCellsExternalApicalSize = 0,
+          const CellIdx activeCellsExternalApical[] = nullptr,
 
-          size_t prevActiveExternalCellsApicalSize = 0,
-          const CellIdx prevActiveExternalCellsApical[] = nullptr,
+          size_t reinforceCandidatesExternalBasalSize = 0,
+          const CellIdx reinforceCandidatesExternalBasal[] = nullptr,
 
-          size_t activeExternalCellsApicalSize = 0,
-          const CellIdx activeExternalCellsApical[] = nullptr,
+          size_t reinforceCandidatesExternalApicalSize = 0,
+          const CellIdx reinforceCandidatesExternalApical[] = nullptr,
+
+          size_t growthCandidatesExternalBasalSize = 0,
+          const CellIdx growthCandidatesExternalBasal[] = nullptr,
+
+          size_t growthCandidatesExternalApicalSize = 0,
+          const CellIdx growthCandidatesExternalApical[] = nullptr,
 
           bool learn = true);
 
@@ -323,7 +404,7 @@ namespace nupic {
          *
          * @return (vector<CellIdx>) Cell indices
          */
-        vector<CellIdx> cellsForColumn(Int column);
+        vector<CellIdx> cellsForColumn(UInt column);
 
         /**
          * Returns the number of cells in this layer.
@@ -359,11 +440,25 @@ namespace nupic {
         vector<Segment> getMatchingApicalSegments() const;
 
         /**
-         * Returns the dimensions of the columns in the region.
+         * Returns the dimensions of the columns.
          *
-         * @returns Integer number of column dimension
+         * @returns List of column dimension
          */
         vector<UInt> getColumnDimensions() const;
+
+        /**
+         * Returns the dimensions of the basal input.
+         *
+         * @returns List of basal input dimensions
+         */
+        vector<UInt> getBasalInputDimensions() const;
+
+        /**
+         * Returns the dimensions of the apical input.
+         *
+         * @returns List of apical input dimensions
+         */
+        vector<UInt> getApicalInputDimensions() const;
 
         /**
          * Returns the total number of columns.
@@ -461,6 +556,14 @@ namespace nupic {
         void setPredictedSegmentDecrement(Permanence);
 
         /**
+         * Returns the checkInputs parameter.
+         *
+         * @returns the checkInputs parameter
+         */
+        bool getCheckInputs() const;
+        void setCheckInputs(bool checkInputs);
+
+        /**
          * Raises an error if cell index is invalid.
          *
          * @param cell Cell index
@@ -529,12 +632,17 @@ namespace nupic {
 
       protected:
         UInt numColumns_;
+        UInt numBasalInputs_;
+        UInt numApicalInputs_;
         vector<UInt> columnDimensions_;
+        vector<UInt> basalInputDimensions_;
+        vector<UInt> apicalInputDimensions_;
         UInt cellsPerColumn_;
         UInt activationThreshold_;
         UInt minThreshold_;
         UInt maxNewSynapseCount_;
         bool formInternalBasalConnections_;
+        bool checkInputs_;
         Permanence initialPermanence_;
         Permanence connectedPermanence_;
         Permanence permanenceIncrement_;

--- a/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
+++ b/src/test/unit/experimental/ExtendedTemporalMemoryTest.cpp
@@ -57,13 +57,21 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testInitInvalidParams)
   {
     // Invalid columnDimensions
-    vector<UInt> columnDim = {};
     ExtendedTemporalMemory tm1;
-    EXPECT_THROW(tm1.initialize(columnDim, 32), exception);
+    EXPECT_THROW(tm1.initialize(
+                   /*columnDimensions*/ {},
+                   /*basalInputDimensions*/ {},
+                   /*apicalInputDimensions*/ {},
+                   /*cellsPerColumn*/ 32),
+                 exception);
 
     // Invalid cellsPerColumn
-    columnDim.push_back(2048);
-    EXPECT_THROW(tm1.initialize(columnDim, 0), exception);
+    EXPECT_THROW(tm1.initialize(
+                   /*columnDimensions*/ {},
+                   /*basalInputDimensions*/ {},
+                   /*apicalInputDimensions*/ {},
+                   /*cellsPerColumn*/ 0),
+                 exception);
   }
 
   /**
@@ -74,6 +82,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -116,6 +126,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -147,6 +159,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -193,6 +207,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -243,6 +259,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -277,6 +295,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -329,6 +349,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -395,6 +417,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -456,6 +480,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -523,6 +549,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -554,6 +582,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -603,6 +633,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -654,6 +686,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 1,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -703,6 +737,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 1,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -749,6 +785,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 1,
       /*activationThreshold*/ 2,
       /*initialPermanence*/ 0.21,
@@ -797,6 +835,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -839,6 +879,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -881,6 +923,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 1,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -933,6 +977,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 1,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.50,
@@ -1008,6 +1054,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -1053,6 +1101,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -1122,6 +1172,8 @@ namespace {
     {
       ExtendedTemporalMemory tm(
         /*columnDimensions*/ {32},
+        /*basalInputDimensions*/ {},
+        /*apicalInputDimensions*/ {},
         /*cellsPerColumn*/ 4,
         /*activationThreshold*/ 3,
         /*initialPermanence*/ 0.2,
@@ -1205,6 +1257,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -1253,6 +1307,8 @@ namespace {
   {
     ExtendedTemporalMemory tm(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.2,
@@ -1296,10 +1352,12 @@ namespace {
     Connections before = tm.basalConnections;
 
     tm.compute(1, previousActiveColumns,
-               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               0, nullptr, 0, nullptr, 0, nullptr,
+               0, nullptr, 0, nullptr, 0, nullptr,
                false);
     tm.compute(2, activeColumns,
-               0, nullptr, 0, nullptr, 0, nullptr, 0, nullptr,
+               0, nullptr, 0, nullptr, 0, nullptr,
+               0, nullptr, 0, nullptr, 0, nullptr,
                false);
 
     EXPECT_EQ(before, tm.basalConnections);
@@ -1308,7 +1366,11 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testColumnForCell1D)
   {
     ExtendedTemporalMemory tm;
-    tm.initialize(vector<UInt>{2048}, 5);
+    tm.initialize(
+      /*columnDimensions*/ {2048},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 5);
 
     ASSERT_EQ(0, tm.columnForCell(0));
     ASSERT_EQ(0, tm.columnForCell(4));
@@ -1319,7 +1381,11 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testColumnForCell2D)
   {
     ExtendedTemporalMemory tm;
-    tm.initialize(vector<UInt>{64, 64}, 4);
+    tm.initialize(
+      /*columnDimensions*/ {64, 64},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 4);
 
     ASSERT_EQ(0, tm.columnForCell(0));
     ASSERT_EQ(0, tm.columnForCell(3));
@@ -1330,7 +1396,11 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testColumnForCellInvalidCell)
   {
     ExtendedTemporalMemory tm;
-    tm.initialize(vector<UInt>{64, 64}, 4);
+    tm.initialize(
+      /*columnDimensions*/ {64, 64},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 4);
 
     EXPECT_NO_THROW(tm.columnForCell(16383));
     EXPECT_THROW(tm.columnForCell(16384), std::exception);
@@ -1340,7 +1410,11 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testNumberOfColumns)
   {
     ExtendedTemporalMemory tm;
-    tm.initialize(vector<UInt>{64, 64}, 32);
+    tm.initialize(
+      /*columnDimensions*/ {64, 64},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 32);
 
     int numOfColumns = tm.numberOfColumns();
     ASSERT_EQ(numOfColumns, 64 * 64);
@@ -1349,7 +1423,11 @@ namespace {
   TEST(ExtendedTemporalMemoryTest, testNumberOfCells)
   {
     ExtendedTemporalMemory tm;
-    tm.initialize(vector<UInt>{64, 64}, 32);
+    tm.initialize(
+      /*columnDimensions*/ {64, 64},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 32);
 
     Int numberOfCells = tm.numberOfCells();
     ASSERT_EQ(numberOfCells, 64 * 64 * 32);
@@ -1361,6 +1439,8 @@ namespace {
 
     ExtendedTemporalMemory tm1(
       /*columnDimensions*/ {32},
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
       /*cellsPerColumn*/ 4,
       /*activationThreshold*/ 3,
       /*initialPermanence*/ 0.21,
@@ -1419,7 +1499,22 @@ namespace {
   {
     ExtendedTemporalMemory tm1, tm2;
 
-    tm1.initialize({ 100 }, 4, 7, 0.37, 0.58, 4, 18, 0.23, 0.08, 0.0, 91);
+    tm1.initialize(
+      /*columnDimensions*/ { 100 },
+      /*basalInputDimensions*/ {},
+      /*apicalInputDimensions*/ {},
+      /*cellsPerColumn*/ 4,
+      /*activationThreshold*/ 7,
+      /*initialPermanence*/ 0.37,
+      /*connectedPermanence*/ 0.58,
+      /*minThreshold*/ 4,
+      /*maxNewSynapseCount*/ 18,
+      /*permanenceIncrement*/ 0.23,
+      /*permanenceDecrement*/ 0.08,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*formInternalBasalConnections*/ true,
+      /*learnOnOneCell*/ false,
+      /*seed*/ 42);
 
     // Run some data through before serializing
     /*


### PR DESCRIPTION
This change adds 3 parameters to the ETM:
- "checkInputs" - Tell the ETM to perform a bunch of slow checks on the input. We'll usually have this turned on.
- "basalInputDimensions" - Used for input checking, for visualizations, and maybe for future use in the ETM. (Up until now we've had to design around not knowing this)
- "apicalInputDimensions" - Same as above

Second, this change stops assuming that the "active external cells" are also "winner cells". They are now passed in as "reinforce candidates" and "growth candidates". So now we'll be able to respond appropriately to external bursting columns, only growing synapses to the winner cells.

Third, this change embraces this terminology. It never describes external inputs as "prev active" or "prev winner". Instead it calls them "reinforce candidate" and "growth candidate". I think this is a good change for 3 reasons:

1. This naming makes it clear why these parameters being passed in and how they'll be used.
2. It makes the API less normative -- maybe the cells are currently active (no time delay), or maybe they're only partly active, or maybe we only want to reinforce connections to external winner cells.
3. The synapse/segment learning code is now oblivious to time. `learnOnCell` and everything beneath it could be reused in non-temporal learning, e.g. a spatial pooler or L2's proximal input. Maybe soon we'll find a reason to move this code out of the ETM and into some reusable place.

Fourth, this changes the name "activateDendrites" to "depolarizeCells". This makes the public API more intuitive. "activateCells" changes the active cells, while "depolarizeCells" changes the predictive cells.

Finally, this change makes the Python -> C++ leap more efficient. We assume the input is sorted, and we use the numpy array that the input is already in. If it's not in a numpy array, we copy it into one.

Fixes #1106