### PR TITLE
Fixes #1108 by only throwing exception when registering region with c…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ script:
   # legacy binary tests
   - "${TRAVIS_BUILD_DIR}/build/release/bin/connections_performance_test"
   - "${TRAVIS_BUILD_DIR}/build/release/bin/cpp_region_test"
+  - "${TRAVIS_BUILD_DIR}/build/release/bin/py_region_test"
   - "${TRAVIS_BUILD_DIR}/build/release/bin/helloregion"
   - "${TRAVIS_BUILD_DIR}/build/release/bin/hello_sp_tp"
   - "${TRAVIS_BUILD_DIR}/build/release/bin/prototest"

--- a/ci/bamboo/build-osx.sh
+++ b/ci/bamboo/build-osx.sh
@@ -24,6 +24,7 @@ mkdir -p build/scripts
 cmake -DCMAKE_INSTALL_PREFIX=`pwd`/build/release -DPY_EXTENSIONS_DIR=`pwd`/bindings/py/nupic/bindings .
 make install
 ./build/release/bin/cpp_region_test
+./build/release/bin/py_region_test
 ./build/release/bin/unit_tests
 
 # Build wheel

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -50,7 +50,9 @@
 
 namespace nupic
 {
-  // Path from site-packages to packages that contain NuPIC Python regions
+  // Keys are Python modules and the values are sets of class names for the
+  // regions that have been registered in the corresponding module. E.g.
+  // pyRegions["nupic.regions.sample_region"] = "SampleRegion"
   static std::map<const std::string, std::set<std::string>> pyRegions;
 
   // Mappings for C++ regions
@@ -61,14 +63,21 @@ namespace nupic
   // Allows the user to add custom regions
   void RegionImplFactory::registerPyRegion(const std::string module, const std::string className)
   {
-    // Verify that no regions exist with the same className
+    // Verify that no regions exist with the same className in any module
     for (auto pyRegion : pyRegions)
     {
       if (pyRegion.second.find(className) != pyRegion.second.end())
       {
-        NTA_THROW << "A pyRegion with name '" << className << "' already exists. "
-                  << "Unregister the existing region or register the new region using a "
-                  << "different name.";
+        if (pyRegion.first != module)
+        {
+          // New region class name conflicts with previously registered region
+          NTA_THROW << "A pyRegion with name '" << className << "' already exists. "
+                    << "Unregister the existing region or register the new region using a "
+                    << "different name.";
+        } else {
+          // Same region registered again, ignore
+          return;
+        }
       }
     }
 

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -286,9 +286,8 @@ void testSecondTimeLeak()
   n.addRegion("r2", "py.TestNode", "");
 }
 
-void testFailOnRegisterDuplicateRegion()
+void testRegionDuplicateRegister()
 {
-  bool caughtException = false;
   Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
                             "TestDuplicateNodes");
   try
@@ -296,16 +295,10 @@ void testFailOnRegisterDuplicateRegion()
     Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
                               "TestDuplicateNodes");
   } catch (std::exception& e) {
-    NTA_DEBUG << "Caught exception as expected: '" << e.what() << "'";
-    caughtException = true;
+    NTA_THROW << "testRegionDuplicateRegister failed with exception: '"
+              << e.what() << "'";
   }
-  if (caughtException)
-  {
-    NTA_DEBUG << "testFailOnRegisterDuplicateRegion passed";
-  } else {
-    NTA_THROW << "testFailOnRegisterDuplicateRegion did not "
-              << "throw an exception as expected";
-  }
+  NTA_DEBUG << "testRegionDuplicateRegister passed";
 }
 
 void testCreationParamTypes()

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -505,7 +505,7 @@ int realmain(bool leakTest)
   testPynodeInputOutputAccess(level2);
   testPynodeArrayParameters(level2);
   testPynodeLinking();
-  testFailOnRegisterDuplicateRegion();
+  testRegionDuplicateRegister();
   testCreationParamTypes();
 
   if (!leakTest)

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -288,8 +288,10 @@ void testSecondTimeLeak()
 
 void testRegionDuplicateRegister()
 {
+  // Register a region
   Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
                             "TestDuplicateNodes");
+  // Validate that the same region can be registered multiple times
   try
   {
     Network::registerPyRegion("nupic.regions.TestDuplicateNodes",
@@ -298,7 +300,17 @@ void testRegionDuplicateRegister()
     NTA_THROW << "testRegionDuplicateRegister failed with exception: '"
               << e.what() << "'";
   }
-  NTA_DEBUG << "testRegionDuplicateRegister passed";
+  // Validate that a region from a different module but with the same name
+  // cannot be registered
+  try
+  {
+    Network::registerPyRegion("nupic.regions.DifferentModule",
+                              "TestDuplicateNodes");
+    NTA_THROW << "testRegionDuplicateRegister failed to throw exception for "
+              << "region with same name but different module as existing "
+              << "registered region";
+  } catch (std::exception& e) {
+  }
 }
 
 void testCreationParamTypes()


### PR DESCRIPTION
…lass name that is already registered if the new region is from a different module than the original.

fixes #1108 

@mrcslws please review