### PR TITLE
Reduce build times by removing some executables from build.

### DIFF
--- a/ci/bamboo/build-windows.ps1
+++ b/ci/bamboo/build-windows.ps1
@@ -204,12 +204,15 @@ Write-Host "Running nupic.core C++ tests."
 pushd .\build\release\bin
 
 WrapCmd { .\py_region_test.exe }
-WrapCmd { .\connections_performance_test.exe }
 WrapCmd { .\cpp_region_test.exe }
-WrapCmd { .\helloregion.exe }
-WrapCmd { .\hello_sp_tp.exe }
-WrapCmd { .\prototest.exe }
 WrapCmd { .\unit_tests.exe }
+
+# These executables aren't necessary for good test coverage. Leave them out
+# of regular build to reduce build time.
+#WrapCmd { .\helloregion.exe }
+#WrapCmd { .\hello_sp_tp.exe }
+#WrapCmd { .\prototest.exe }
+#WrapCmd { .\connections_performance_test.exe }
 popd
 
 

--- a/ci/build-and-test-nupic-bindings.sh
+++ b/ci/build-and-test-nupic-bindings.sh
@@ -137,13 +137,16 @@ pip install --ignore-installed ${DEST_WHEELHOUSE}/nupic.bindings-*.whl
 
 # Run the nupic.core c++ tests
 cd ${NUPIC_CORE_ROOT}/build/release/bin
-./connections_performance_test
 ./cpp_region_test
-./helloregion
-./hello_sp_tp
-./prototest
 ./py_region_test
 ./unit_tests
+
+# These are utilities or demonstration executables so leave out of main build
+# to keep build times down.
+#./connections_performance_test
+#./hello_sp_tp
+#./helloregion
+#./prototest
 
 
 # Run nupic.bindings python tests


### PR DESCRIPTION
@vitaly-krugl please review - the connections performance test in particular is really long and just wasn't intended as a CI test. I'm not sure we even care that much to keep it from breaking but we could create a nightly build or something if we want to run it regularly.

CC @rhyolight @oxtopus