### PR TITLE
Reconfiguring OS X build script

### DIFF
--- a/ci/bamboo/build-osx-release.sh
+++ b/ci/bamboo/build-osx-release.sh
@@ -35,33 +35,12 @@
 set -o errexit
 set -o xtrace
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
 # Build and test the manylinux wheel; see build-and-test-nupic-bindings.sh for
 # destination wheelhouse
 BUILD_TYPE="Release" \
 WHEEL_PLAT="maxosx_10_9_intel"
 
-if [[ $1 == --help ]]; then
-  echo "${USAGE}"
-  exit 0
-fi
-
-if [[ $# > 0 ]]; then
-  echo "ERROR Unexpected arguments: ${@}" >&2
-  echo "${USAGE}" >&2
-  exit 1
-fi
-
-
-set -o xtrace
-
-
-# Apply defaults
-BUILD_TYPE=${BUILD_TYPE-"Release"}
-
-
-NUPIC_CORE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+NUPIC_CORE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 DEST_WHEELHOUSE="${NUPIC_CORE_ROOT}/nupic_bindings_wheelhouse"
 

--- a/ci/bamboo/build-osx-release.sh
+++ b/ci/bamboo/build-osx-release.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+# This script runs inside numenta's custom manylinux docker image
+# quay.io/numenta/manylinux1_x86_64_centos6 and builds the debug manylinux
+# x86_64 wide-unicode nupic.bindings wheel per PEP-513. See
+# https://github.com/numenta/manylinux.
+#
+# ASUMPTIONS: Expects a pristine nupic.core source tree without any remnant
+#             build artifacts from prior build attempts. Otherwise, behavior is
+#             undefined.
+#
+# OUTPUTS: see nupic.core/ci/build-and-test-nupic-bindings.sh
+
+
+set -o errexit
+set -o xtrace
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Build and test the manylinux wheel; see build-and-test-nupic-bindings.sh for
+# destination wheelhouse
+BUILD_TYPE="Release" \
+WHEEL_PLAT="maxosx_10_9_intel" \
+  ${DIR}/../build-and-test-nupic-bindings.sh "$@"


### PR DESCRIPTION
Trying to debug OS X build failures that are not really failures by re-using the same scripts being used to build and test on linux.