### PR TITLE
Fix some build and runtime errors with NTA_DOUBLE_PRECISION

### DIFF
--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -905,10 +905,10 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
                            (nupic::Byte*) PyArray_DATA(infActiveStateT1),
                            (nupic::Byte*) PyArray_DATA(infPredictedStateT),
                            (nupic::Byte*) PyArray_DATA(infPredictedStateT1),
-                           (nupic::Real32*) PyArray_DATA(colConfidenceT),
-                           (nupic::Real32*) PyArray_DATA(colConfidenceT1),
-                           (nupic::Real32*) PyArray_DATA(cellConfidenceT),
-                           (nupic::Real32*) PyArray_DATA(cellConfidenceT1));
+                           (nupic::Real*) PyArray_DATA(colConfidenceT),
+                           (nupic::Real*) PyArray_DATA(colConfidenceT1),
+                           (nupic::Real*) PyArray_DATA(cellConfidenceT),
+                           (nupic::Real*) PyArray_DATA(cellConfidenceT1));
   }
 
   inline PyObject* getStates() const
@@ -918,8 +918,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 
     nupic::Byte* cpp_activeT, *cpp_activeT1;
     nupic::Byte* cpp_predT, *cpp_predT1;
-    nupic::Real32* cpp_colConfidenceT, *cpp_colConfidenceT1;
-    nupic::Real32* cpp_confidenceT, *cpp_confidenceT1;
+    nupic::Real* cpp_colConfidenceT, *cpp_colConfidenceT1;
+    nupic::Real* cpp_confidenceT, *cpp_confidenceT1;
 
     self->getStatePointers(cpp_activeT, cpp_activeT1,
                            cpp_predT, cpp_predT1,
@@ -930,10 +930,10 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
     nupic::NumpyVectorT<nupic::Byte> activeT1(nCells, cpp_activeT1);
     nupic::NumpyVectorT<nupic::Byte> predT(nCells, cpp_predT);
     nupic::NumpyVectorT<nupic::Byte> predT1(nCells, cpp_predT1);
-    nupic::NumpyVectorT<nupic::Real32> colConfidenceT(nColumns, cpp_colConfidenceT);
-    nupic::NumpyVectorT<nupic::Real32> colConfidenceT1(nColumns, cpp_colConfidenceT1);
-    nupic::NumpyVectorT<nupic::Real32> confidenceT(nCells, cpp_confidenceT);
-    nupic::NumpyVectorT<nupic::Real32> confidenceT1(nCells, cpp_confidenceT1);
+    nupic::NumpyVectorT<nupic::Real> colConfidenceT(nColumns, cpp_colConfidenceT);
+    nupic::NumpyVectorT<nupic::Real> colConfidenceT1(nColumns, cpp_colConfidenceT1);
+    nupic::NumpyVectorT<nupic::Real> confidenceT(nCells, cpp_confidenceT);
+    nupic::NumpyVectorT<nupic::Real> confidenceT1(nCells, cpp_confidenceT1);
 
     PyObject *result = PyTuple_New(8);
     PyTuple_SET_ITEM(result, 0, activeT.forPython());
@@ -999,8 +999,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
   inline PyObject* compute(PyObject* py_x, bool doInference, bool doLearning)
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
-    nupic::NumpyVectorT<nupic::Real32> y(self->nCells());
-    self->compute((nupic::Real32*) PyArray_DATA(x), y.begin(), doInference, doLearning);
+    nupic::NumpyVectorT<nupic::Real> y(self->nCells());
+    self->compute((nupic::Real*) PyArray_DATA(x), y.begin(), doInference, doLearning);
     return y.forPython();
   }
 }

--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -3549,9 +3549,9 @@ def __setstate__(self, inString):
   inline PyObject* rightVecSumAtNZ(PyObject* py_x) const
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
-    nupic::Real32* x_begin = (nupic::Real32*)(PyArray_DATA(x));
-    nupic::Real32* x_end = x_begin + PyArray_DIMS(x)[0];
-    nupic::NumpyVectorT<nupic::Real32> y(self->nRows());
+    nupic::Real* x_begin = (nupic::Real*)(PyArray_DATA(x));
+    nupic::Real* x_end = x_begin + PyArray_DIMS(x)[0];
+    nupic::NumpyVectorT<nupic::Real> y(self->nRows());
     self->rightVecSumAtNZ(x_begin, x_end, y.begin(), y.end());
     return y.forPython();
   }
@@ -3562,11 +3562,11 @@ def __setstate__(self, inString):
   inline void rightVecSumAtNZ_fast(PyObject* py_x, PyObject* py_y) const
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
-    nupic::Real32* x_begin = (nupic::Real32*)(PyArray_DATA(x));
-    nupic::Real32* x_end = x_begin + PyArray_DIMS(x)[0];
+    nupic::Real* x_begin = (nupic::Real*)(PyArray_DATA(x));
+    nupic::Real* x_end = x_begin + PyArray_DIMS(x)[0];
     PyArrayObject* y = (PyArrayObject*) py_y;
-    nupic::Real32* y_begin = (nupic::Real32*)(PyArray_DATA(y));
-    nupic::Real32* y_end = y_begin + PyArray_DIMS(y)[0];
+    nupic::Real* y_begin = (nupic::Real*)(PyArray_DATA(y));
+    nupic::Real* y_end = y_begin + PyArray_DIMS(y)[0];
     self->rightVecSumAtNZ(x_begin, x_end, y_begin, y_end);
   }
 
@@ -3576,9 +3576,9 @@ def __setstate__(self, inString):
   inline PyObject* leftVecSumAtNZ(PyObject* py_x) const
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
-    nupic::Real32* x_begin = (nupic::Real32*)(PyArray_DATA(x));
-    nupic::Real32* x_end = x_begin + PyArray_DIMS(x)[0];
-    nupic::NumpyVectorT<nupic::Real32> y(self->nCols());
+    nupic::Real* x_begin = (nupic::Real*)(PyArray_DATA(x));
+    nupic::Real* x_end = x_begin + PyArray_DIMS(x)[0];
+    nupic::NumpyVectorT<nupic::Real> y(self->nCols());
     self->leftVecSumAtNZ(x_begin, x_end, y.begin(), y.end());
     return y.forPython();
   }
@@ -3589,11 +3589,11 @@ def __setstate__(self, inString):
   inline void leftVecSumAtNZ_fast(PyObject* py_x, PyObject* py_y) const
   {
     PyArrayObject* x = (PyArrayObject*) py_x;
-    nupic::Real32* x_begin = (nupic::Real32*)(PyArray_DATA(x));
-    nupic::Real32* x_end = x_begin + PyArray_DIMS(x)[0];
+    nupic::Real* x_begin = (nupic::Real*)(PyArray_DATA(x));
+    nupic::Real* x_end = x_begin + PyArray_DIMS(x)[0];
     PyArrayObject* y = (PyArrayObject*) py_y;
-    nupic::Real32* y_begin = (nupic::Real32*)(PyArray_DATA(y));
-    nupic::Real32* y_end = y_begin + PyArray_DIMS(y)[0];
+    nupic::Real* y_begin = (nupic::Real*)(PyArray_DATA(y));
+    nupic::Real* y_end = y_begin + PyArray_DIMS(y)[0];
     self->leftVecSumAtNZ(x_begin, x_end, y_begin, y_end);
   }
 

--- a/src/nupic/regions/VectorFileSensor.cpp
+++ b/src/nupic/regions/VectorFileSensor.cpp
@@ -167,14 +167,14 @@ void VectorFileSensor::compute()
 
   if (hasCategoryOut_)
   {
-    Real32 * categoryOut = reinterpret_cast<Real32 *>(categoryOut_.getBuffer());
+    Real * categoryOut = reinterpret_cast<Real *>(categoryOut_.getBuffer());
     vectorFile_.getRawVector((nupic::UInt)curVector_, categoryOut, offset, 1);
     offset++;
   }
 
   if (hasResetOut_)
   {
-    Real32 * resetOut = reinterpret_cast<Real32 *>(resetOut_.getBuffer());
+    Real * resetOut = reinterpret_cast<Real *>(resetOut_.getBuffer());
     vectorFile_.getRawVector((nupic::UInt)curVector_, resetOut, offset, 1);
     offset++;
   }


### PR DESCRIPTION
Fixes #1161

This flag is still not fully supported. For example, the sparse_binary_matrix bindings tests will crash with this flag enabled. But this change is enough to fix the build and to get it working at runtime with the Python SpatialPooler.