### PR TITLE
SP: Stop putting tie-break info in the overlaps

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -1018,8 +1018,9 @@ namespace nupic
 
               @param activeColumns an int array containing the indices of the active columns.
           */
-          void inhibitColumns_(vector<Real>& overlaps,
-                               vector<UInt>& activeColumns);
+          void inhibitColumns_(
+            const vector<Real>& overlaps,
+            vector<UInt>& activeColumns);
 
           /**
              Perform global inhibition.
@@ -1042,8 +1043,10 @@ namespace nupic
              @param activeColumns
              an int array containing the indices of the active columns.
           */
-          void inhibitColumnsGlobal_(vector<Real>& overlaps, Real density,
-                                     vector<UInt>& activeColumns);
+          void inhibitColumnsGlobal_(
+            const vector<Real>& overlaps,
+            Real density,
+            vector<UInt>& activeColumns);
 
           /**
              Performs local inhibition.
@@ -1071,8 +1074,10 @@ namespace nupic
              @param activeColumns
              an int array containing the indices of the active columns.
           */
-          void inhibitColumnsLocal_(vector<Real>& overlaps, Real density,
-                                    vector<UInt>& activeColumns);
+          void inhibitColumnsLocal_(
+            const vector<Real>& overlaps,
+            Real density,
+            vector<UInt>& activeColumns);
 
           /**
               The primary method in charge of learning.


### PR DESCRIPTION
Fixes #1160

Rather than making a copy of the overlaps and using the same logic, this change moves away from doing the tie-break logic with math and an "arbitration" constant. Instead, it handles the tie-break case explicitly, checking if the neighboring column is selected in the event of a tie.

This change makes the code less error-prone because:

1. We're not corrupting the overlaps (which are exposed via `getBoostedOverlaps`)
2. We're not having to use a heuristic to choose an arbitration constant.