### PR TITLE
Stop changing floats during save/load serialization

### DIFF
--- a/src/examples/prototest.cpp
+++ b/src/examples/prototest.cpp
@@ -104,9 +104,8 @@ void testSP()
     UInt outputBaseline[numColumns];
     sp1.compute(input, true, outputBaseline);
 
-    UInt outputA[numColumns];
-
     // A - First do iostream version
+    UInt outputA[numColumns];
     {
       SpatialPooler spTemp;
 
@@ -134,42 +133,34 @@ void testSP()
       NTA_CHECK(outputBaseline[i] == outputA[i]);
     }
 
-    // TODO https://github.com/numenta/nupic.core/issues/1165
-    //
-    // Serializing and deserializing the active duty cycles causes
-    // little variations over time which eventually lead to columns
-    // having slightly different boost factors, causing different
-    // results.
-    //
-    // UInt outputC[numColumns];
-    //
-    // // C - Next do old version
-    // {
-    //   SpatialPooler spTemp;
+    // C - Next do old version
+    UInt outputC[numColumns];
+    {
+      SpatialPooler spTemp;
 
-    //   testTimer.start();
+      testTimer.start();
 
-    //   // Deserialize
-    //   ifstream is("outC.proto", ifstream::binary);
-    //   spTemp.load(is);
-    //   is.close();
+      // Deserialize
+      ifstream is("outC.proto", ifstream::binary);
+      spTemp.load(is);
+      is.close();
 
-    //   // Feed new record through
-    //   spTemp.compute(input, true, outputC);
+      // Feed new record through
+      spTemp.compute(input, true, outputC);
 
-    //   // Serialize
-    //   ofstream os("outC.proto", ofstream::binary);
-    //   spTemp.save(os);
-    //   os.close();
+      // Serialize
+      ofstream os("outC.proto", ofstream::binary);
+      spTemp.save(os);
+      os.close();
 
-    //   testTimer.stop();
-    //   timeC = timeC + testTimer.getElapsed();
-    // }
+      testTimer.stop();
+      timeC = timeC + testTimer.getElapsed();
+    }
 
-    // for (UInt i = 0; i < numColumns; ++i)
-    // {
-    //   NTA_CHECK(outputBaseline[i] == outputC[i]);
-    // }
+    for (UInt i = 0; i < numColumns; ++i)
+    {
+      NTA_CHECK(outputBaseline[i] == outputC[i]);
+    }
 
   }
 

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <climits>
+#include <iomanip>
 #include <iostream>
 
 #include <capnp/message.h>
@@ -438,6 +439,14 @@ void Connections::startNewIteration()
   iteration_++;
 }
 
+template<typename FloatType>
+static void saveFloat_(std::ostream& outStream, FloatType v)
+{
+  outStream << std::setprecision(std::numeric_limits<FloatType>::max_digits10)
+            << v
+            << " ";
+}
+
 void Connections::save(std::ostream& outStream) const
 {
   // Write a starting marker.
@@ -467,7 +476,7 @@ void Connections::save(std::ostream& outStream) const
       {
         const SynapseData& synapseData = synapses_[synapse];
         outStream << synapseData.presynapticCell << " ";
-        outStream << synapseData.permanence << " ";
+        saveFloat_(outStream, synapseData.permanence);
       }
       outStream << endl;
     }

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1419,6 +1419,14 @@ UInt SpatialPooler::persistentSize() const
   return s.str().size();
 }
 
+template<typename FloatType>
+static void saveFloat_(ostream& outStream, FloatType v)
+{
+  outStream << std::setprecision(std::numeric_limits<FloatType>::max_digits10)
+            << v
+            << " ";
+}
+
 void SpatialPooler::save(ostream& outStream) const
 {
   // Write a starting marker and version.
@@ -1428,31 +1436,38 @@ void SpatialPooler::save(ostream& outStream) const
   // Store the simple variables first.
   outStream << numInputs_ << " "
             << numColumns_ << " "
-            << potentialRadius_ << " "
-            << potentialPct_ << " "
-            << initConnectedPct_ << " "
-            << globalInhibition_ << " "
-            << numActiveColumnsPerInhArea_ << " "
-            << localAreaDensity_ << " "
-            << stimulusThreshold_ << " "
+            << potentialRadius_ << " ";
+
+  saveFloat_(outStream, potentialPct_);
+  saveFloat_(outStream, initConnectedPct_);
+
+  outStream << globalInhibition_ << " "
+            << numActiveColumnsPerInhArea_ << " ";
+
+  saveFloat_(outStream, localAreaDensity_);
+
+  outStream << stimulusThreshold_ << " "
             << inhibitionRadius_ << " "
-            << dutyCyclePeriod_ << " "
-            << maxBoost_ << " "
-            << iterationNum_ << " "
+            << dutyCyclePeriod_ << " ";
+
+  saveFloat_(outStream, maxBoost_);
+
+  outStream << iterationNum_ << " "
             << iterationLearnNum_ << " "
             << spVerbosity_ << " "
-            << updatePeriod_ << " "
+            << updatePeriod_ << " ";
 
-            << synPermMin_ << " "
-            << synPermMax_ << " "
-            << synPermTrimThreshold_ << " "
-            << synPermInactiveDec_ << " "
-            << synPermActiveInc_ << " "
-            << synPermBelowStimulusInc_ << " "
-            << synPermConnected_ << " "
-            << minPctOverlapDutyCycles_ << " "
-            << minPctActiveDutyCycles_ << " "
-            << wrapAround_ << " "
+  saveFloat_(outStream, synPermMin_);
+  saveFloat_(outStream, synPermMax_);
+  saveFloat_(outStream, synPermTrimThreshold_);
+  saveFloat_(outStream, synPermInactiveDec_);
+  saveFloat_(outStream, synPermActiveInc_);
+  saveFloat_(outStream, synPermBelowStimulusInc_);
+  saveFloat_(outStream, synPermConnected_);
+  saveFloat_(outStream, minPctOverlapDutyCycles_);
+  saveFloat_(outStream, minPctActiveDutyCycles_);
+
+  outStream << wrapAround_ << " "
             << endl;
 
   // Store vectors.
@@ -1472,31 +1487,31 @@ void SpatialPooler::save(ostream& outStream) const
 
   for (UInt i = 0; i < numColumns_; i++)
   {
-    outStream << boostFactors_[i] << " ";
+    saveFloat_(outStream, boostFactors_[i]);
   }
   outStream << endl;
 
   for (UInt i = 0; i < numColumns_; i++)
   {
-    outStream << overlapDutyCycles_[i] << " ";
+    saveFloat_(outStream, overlapDutyCycles_[i]);
   }
   outStream << endl;
 
   for (UInt i = 0; i < numColumns_; i++)
   {
-    outStream << activeDutyCycles_[i] << " ";
+    saveFloat_(outStream, activeDutyCycles_[i]);
   }
   outStream << endl;
 
   for (UInt i = 0; i < numColumns_; i++)
   {
-    outStream << minOverlapDutyCycles_[i] << " ";
+    saveFloat_(outStream, minOverlapDutyCycles_[i]);
   }
   outStream << endl;
 
   for (UInt i = 0; i < numColumns_; i++)
   {
-    outStream << minActiveDutyCycles_[i] << " ";
+    saveFloat_(outStream, minActiveDutyCycles_[i]);
   }
   outStream << endl;
 
@@ -1530,7 +1545,8 @@ void SpatialPooler::save(ostream& outStream) const
     permanences_.getRowToSparse(i, perm.begin());
     for (auto & elem : perm)
     {
-      outStream << elem.first << " " << elem.second << " ";
+      outStream << elem.first << " ";
+      saveFloat_(outStream, elem.second);
     }
     outStream << endl;
   }

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -35,6 +35,7 @@
 
 #include <cstring>
 #include <climits>
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include <iterator>
@@ -820,6 +821,14 @@ UInt TemporalMemory::persistentSize() const
   return s.str().size();
 }
 
+template<typename FloatType>
+static void saveFloat_(ostream& outStream, FloatType v)
+{
+  outStream << std::setprecision(std::numeric_limits<FloatType>::max_digits10)
+            << v
+            << " ";
+}
+
 void TemporalMemory::save(ostream& outStream) const
 {
   // Write a starting marker and version.
@@ -827,16 +836,20 @@ void TemporalMemory::save(ostream& outStream) const
   outStream << TM_VERSION << endl;
 
   outStream << numColumns_ << " "
-    << cellsPerColumn_ << " "
-    << activationThreshold_ << " "
-    << initialPermanence_ << " "
-    << connectedPermanence_ << " "
-    << minThreshold_ << " "
-    << maxNewSynapseCount_ << " "
-    << permanenceIncrement_ << " "
-    << permanenceDecrement_ << " "
-    << predictedSegmentDecrement_ << " "
-    << endl;
+            << cellsPerColumn_ << " "
+            << activationThreshold_ << " ";
+
+  saveFloat_(outStream, initialPermanence_);
+  saveFloat_(outStream, connectedPermanence_);
+
+  outStream << minThreshold_ << " "
+            << maxNewSynapseCount_ << " ";
+
+  saveFloat_(outStream, permanenceIncrement_);
+  saveFloat_(outStream, permanenceDecrement_);
+  saveFloat_(outStream, predictedSegmentDecrement_);
+
+  outStream << endl;
 
   connections.save(outStream);
   outStream << endl;


### PR DESCRIPTION
Fixes #1165

I went ahead and also made the change in the Connections and the TemporalMemory.

I tried to write this in a way that is pretty robust. This approach lets us use any mix of float32 and float64, and the code will just keep working.