### PR TITLE
SP: Stop rounding the boost factors

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -61,22 +61,6 @@ static Real round5_(const Real f)
 }
 
 
-// Equivalent to numpy.round(f, decimals=2)
-//
-// Storing the intermediate value causes the result to occasionally differ. For
-// example, 2.7549998760 seems like it would round down to 2.75, but when
-// multiplied by 100 it becomes 275.5, so it will round to 2.76. If you don't
-// store the intermediate value, the compiler might generate something that
-// rounds it to 2.75.
-//
-// We choose this approach because it mimics numpy.
-static Real round2LikeNumpy_(Real f)
-{
-  Real intermediate = f * 100.0;
-  return round(intermediate) / 100.0;
-}
-
-
 class CoordinateConverter2D
 {
 
@@ -1168,10 +1152,7 @@ void SpatialPooler::updateBoostFactorsGlobal_()
 
   for (UInt i = 0; i < numColumns_; ++i)
   {
-    Real boostFactor = exp((targetDensity - activeDutyCycles_[i])* maxBoost_);
-
-    // Avoid floating point mismatches between implementations.
-    boostFactors_[i] = round2LikeNumpy_(boostFactor);
+    boostFactors_[i] = exp((targetDensity - activeDutyCycles_[i])* maxBoost_);
   }
 }
 
@@ -1200,11 +1181,9 @@ void SpatialPooler::updateBoostFactorsLocal_()
         numNeighbors += 1;
       }
     }
-    Real targetDensity = localActivityDensity / numNeighbors;
-    Real boostFactor = exp((targetDensity - activeDutyCycles_[i]) * maxBoost_);
 
-    // Avoid floating point mismatches between implementations.
-    boostFactors_[i] = round2LikeNumpy_(boostFactor);
+    Real targetDensity = localActivityDensity / numNeighbors;
+    boostFactors_[i] = exp((targetDensity - activeDutyCycles_[i]) * maxBoost_);
   }
 
 }

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -113,6 +113,19 @@ namespace {
     return true;
   }
 
+  bool check_vector_eq(vector<Real> vec1, vector<Real> vec2)
+  {
+    if (vec1.size() != vec2.size()) {
+      return false;
+    }
+    for (UInt i = 0; i < vec1.size(); i++) {
+      if (!almost_eq(vec1[i], vec2[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void check_spatial_eq(SpatialPooler sp1, SpatialPooler sp2)
   {
     UInt numColumns = sp1.getNumColumns();
@@ -1131,14 +1144,14 @@ namespace {
     sp.setActiveDutyCycles(initActiveDutyCycles1);
     sp.updateBoostFactors_();
     sp.getBoostFactors(resultBoostFactors1.data());
-    ASSERT_EQ(trueBoostFactors1, resultBoostFactors1);
+    ASSERT_TRUE(check_vector_eq(trueBoostFactors1, resultBoostFactors1));
 
     Real initActiveDutyCycles2[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors2[] =
       {0, 0, 0, 0, 0, 0};
     vector<Real> trueBoostFactors2 =
-      {3.11, 0.42, 6.91, 5.66, 0.01, 2.54};
+      {3.10599, 0.42035, 6.91251, 5.65949, 0.00769898, 2.54297};
     vector<Real> resultBoostFactors2(6, 0);
     sp.setGlobalInhibition(false);
     sp.setMaxBoost(10);
@@ -1147,14 +1160,14 @@ namespace {
     sp.updateBoostFactors_();
     sp.getBoostFactors(resultBoostFactors2.data());
 
-    ASSERT_EQ(trueBoostFactors2, resultBoostFactors2);
+    ASSERT_TRUE(check_vector_eq(trueBoostFactors2, resultBoostFactors2));
 
     Real initActiveDutyCycles3[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors3[] =
       {0, 0, 0, 0, 0, 0};
     vector<Real> trueBoostFactors3 =
-      {1.25, 0.84, 1.47, 1.41, 0.38, 1.21};
+      { 1.25441, 0.840857, 1.47207, 1.41435, 0.377822, 1.20523 };
     vector<Real> resultBoostFactors3(6, 0);
     sp.setWrapAround(true);
     sp.setGlobalInhibition(false);
@@ -1166,14 +1179,14 @@ namespace {
     sp.updateBoostFactors_();
     sp.getBoostFactors(resultBoostFactors3.data());
 
-    ASSERT_EQ(trueBoostFactors3, resultBoostFactors3);
+    ASSERT_TRUE(check_vector_eq(trueBoostFactors3, resultBoostFactors3));
 
     Real initActiveDutyCycles4[] =
       {0.1, 0.3, 0.02, 0.04, 0.7, 0.12};
     Real initBoostFactors4[] =
       {0, 0, 0, 0, 0, 0};
     vector<Real> trueBoostFactors4 =
-      {1.95, 0.26, 4.33, 3.55, 0.00, 1.59};
+      { 1.94773, 0.263597, 4.33476, 3.549, 0.00482795, 1.59467 };
     vector<Real> resultBoostFactors4(6, 0);
     sp.setGlobalInhibition(true);
     sp.setMaxBoost(10);
@@ -1184,7 +1197,7 @@ namespace {
     sp.updateBoostFactors_();
     sp.getBoostFactors(resultBoostFactors4.data());
 
-    ASSERT_EQ(trueBoostFactors4, resultBoostFactors4);
+    ASSERT_TRUE(check_vector_eq(trueBoostFactors3, resultBoostFactors3));
   }
 
   TEST(SpatialPoolerTest, testUpdateBookeepingVars)


### PR DESCRIPTION
Fixes #1175

Actually, it gives up on trying to get identical boost factors between implementations. This is proving too difficult.

Instead, we'll use a similar strategy to what we do with permanences: https://github.com/numenta/nupic/blob/380bf1be4a62c961a9af0ebfa3def63b6c6141eb/tests/unit/nupic/research/spatial_pooler_compatability_test.py#L205

We'll make sure the boost factors are "close enough", and then force them to be equal so that little variations don't cause different columns to become active.

I put a lot of thought into this. Our options are:

1. Write two implementations that get identical results.
2. Use shared C code to handle boost factors, duty cycles, etc.
3. Only expect totally identical results in very controlled environments (like the spatial pooler compatibility test)

I think 1 is nearly impossible.

I think 2 would throw away a lot of what's good about having C++ and Python implementations. We want two implementations so that we can test them against each other, and we want the freedom to prototype in Python.

I think 3 is the best option, and it also already describes the current situation (we already do this with permanences). It manages to test the implementations against each other, without being too obsessive.