### PR TITLE
SparseMatrix: Stop copying input vectors

### DIFF
--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -820,67 +820,158 @@ def __div__(self, other):
                                         threshold, delta);
   }
 
-  void incrementNonZerosOnOuter(PyObject* py_i, PyObject* py_j,
-                                nupic::Real ## N2 delta)
+
+  %pythoncode %{
+    def incrementNonZerosOnOuter(self, rows, cols, delta):
+      self._incrementNonZerosOnOuter(numpy.asarray(rows, dtype="uint32"),
+                                     numpy.asarray(cols, dtype="uint32"),
+                                     delta)
+  %}
+
+  void _incrementNonZerosOnOuter(PyObject* py_rows, PyObject* py_cols,
+                                 nupic::Real ## N2 delta)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    nupic::NumpyVectorT<nupic::UInt ## N1> j(py_j);
-    self->incrementNonZerosOnOuter(i.begin(), i.end(),
-                                   j.begin(), j.end(),
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    PyArrayObject* npCols = (PyArrayObject*) py_cols;
+    size_t colsSize = PyArray_DIMS(npCols)[0];
+    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
+
+    self->incrementNonZerosOnOuter(rows, rows + rowsSize,
+                                   cols, cols + colsSize,
                                    delta);
   }
 
-  void incrementNonZerosOnRowsExcludingCols(PyObject* py_i, PyObject* py_j,
-                                            nupic::Real ## N2 delta)
+
+  %pythoncode %{
+    def incrementNonZerosOnRowsExcludingCols(self, rows, cols, delta):
+      self._incrementNonZerosOnRowsExcludingCols(numpy.asarray(rows, dtype="uint32"),
+                                                 numpy.asarray(cols, dtype="uint32"),
+                                                 delta)
+  %}
+
+  void _incrementNonZerosOnRowsExcludingCols(PyObject* py_rows, PyObject* py_cols,
+                                             nupic::Real ## N2 delta)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    nupic::NumpyVectorT<nupic::UInt ## N1> j(py_j);
-    self->incrementNonZerosOnRowsExcludingCols(i.begin(), i.end(),
-                                               j.begin(), j.end(),
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    PyArrayObject* npCols = (PyArrayObject*) py_cols;
+    size_t colsSize = PyArray_DIMS(npCols)[0];
+    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
+
+    self->incrementNonZerosOnRowsExcludingCols(rows, rows + rowsSize,
+                                               cols, cols + colsSize,
                                                delta);
   }
 
-  void setZerosOnOuter(PyObject* py_i, PyObject* py_j,
-                       nupic::Real ## N2 value)
+
+  %pythoncode %{
+    def setZerosOnOuter(self, rows, cols, value):
+      self._setZerosOnOuter(numpy.asarray(rows, dtype="uint32"),
+                            numpy.asarray(cols, dtype="uint32"),
+                            value)
+  %}
+
+  void _setZerosOnOuter(PyObject* py_rows, PyObject* py_cols,
+                        nupic::Real ## N2 value)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    nupic::NumpyVectorT<nupic::UInt ## N1> j(py_j);
-    self->setZerosOnOuter(i.begin(), i.end(),
-                          j.begin(), j.end(), value);
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    PyArrayObject* npCols = (PyArrayObject*) py_cols;
+    size_t colsSize = PyArray_DIMS(npCols)[0];
+    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
+
+    self->setZerosOnOuter(rows, rows + rowsSize,
+                          cols, cols + colsSize,
+                          value);
   }
 
-  void setRandomZerosOnOuter(PyObject* py_i, PyObject* py_j,
-                             nupic::UInt ## N1 numNewNonZerosPerRow,
-                             nupic::Real ## N2 value,
-                             nupic::Random& rng)
+
+  %pythoncode %{
+    def setRandomZerosOnOuter(self, rows, cols, numNewNonZeros, value, rng):
+      self._setRandomZerosOnOuter(
+        numpy.asarray(rows, dtype="uint32"),
+        numpy.asarray(cols, dtype="uint32"),
+        numNewNonZeros,
+        value,
+        rng)
+  %}
+
+  void _setRandomZerosOnOuter(PyObject* py_rows,
+                              PyObject* py_cols,
+                              nupic::UInt ## N1 numNewNonZeros,
+                              nupic::Real ## N2 value,
+                              nupic::Random& rng)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    nupic::NumpyVectorT<nupic::UInt ## N1> j(py_j);
-    self->setRandomZerosOnOuter(i.begin(), i.end(),
-                                j.begin(), j.end(),
-                                numNewNonZerosPerRow, value, rng);
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    PyArrayObject* npCols = (PyArrayObject*) py_cols;
+    size_t colsSize = PyArray_DIMS(npCols)[0];
+    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
+
+    self->setRandomZerosOnOuter(rows, rows + rowsSize,
+                                cols, cols + colsSize,
+                                numNewNonZeros,
+                                value, rng);
   }
 
-  void increaseRowNonZeroCountsOnOuterTo(PyObject* py_i, PyObject* py_j,
-                                         nupic::UInt ## N1 numDesiredNonzeros,
-                                         nupic::Real ## N2 initialValue,
-                                         nupic::Random& rng)
+
+  %pythoncode %{
+    def increaseRowNonZeroCountsOnOuterTo(self, rows, cols, numDesiredNonZeros,
+                                          initialValue, rng):
+      self._increaseRowNonZeroCountsOnOuterTo(
+        numpy.asarray(rows, dtype="uint32"),
+        numpy.asarray(cols, dtype="uint32"),
+        numDesiredNonZeros, initialValue, rng)
+  %}
+
+  void _increaseRowNonZeroCountsOnOuterTo(PyObject* py_rows, PyObject* py_cols,
+                                          nupic::UInt ## N1 numDesiredNonZeros,
+                                          nupic::Real ## N2 initialValue,
+                                          nupic::Random& rng)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    nupic::NumpyVectorT<nupic::UInt ## N1> j(py_j);
-    self->increaseRowNonZeroCountsOnOuterTo(i.begin(), i.end(),
-                                            j.begin(), j.end(),
-                                            numDesiredNonzeros, initialValue,
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    PyArrayObject* npCols = (PyArrayObject*) py_cols;
+    size_t colsSize = PyArray_DIMS(npCols)[0];
+    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
+
+    self->increaseRowNonZeroCountsOnOuterTo(rows, rows + rowsSize,
+                                            cols, cols + colsSize,
+                                            numDesiredNonZeros, initialValue,
                                             rng);
   }
 
-  void clipRowsBelowAndAbove(PyObject* py_i,
-                             nupic::Real ## N2 a,
-                             nupic::Real ## N2 b)
+
+  %pythoncode %{
+    def clipRowsBelowAndAbove(self, rows, a, b):
+      self._clipRowsBelowAndAbove(numpy.asarray(rows, dtype="uint32"),
+                                  a,
+                                  b)
+  %}
+
+  void _clipRowsBelowAndAbove(PyObject* py_rows,
+                              nupic::Real ## N2 a,
+                              nupic::Real ## N2 b)
   {
-    nupic::NumpyVectorT<nupic::UInt ## N1> i(py_i);
-    self->clipRowsBelowAndAbove(i.begin(), i.end(), a, b);
+    PyArrayObject* npRows = (PyArrayObject*) py_rows;
+    size_t rowsSize = PyArray_DIMS(npRows)[0];
+    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+
+    self->clipRowsBelowAndAbove(rows, rows + rowsSize,
+                                a, b);
   }
+
 
   // Returns the number of non-zeros per row, for all rows
   PyObject* nNonZerosPerRow() const

--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -835,16 +835,11 @@ def __div__(self, other):
   void _incrementNonZerosOnOuter(PyObject* py_rows, PyObject* py_cols,
                                  nupic::Real ## N2 delta)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    self->incrementNonZerosOnOuter(rows, rows + rowsSize,
-                                   cols, cols + colsSize,
+    self->incrementNonZerosOnOuter(rows.begin(), rows.end(),
+                                   cols.begin(), cols.end(),
                                    delta);
   }
 
@@ -859,16 +854,11 @@ def __div__(self, other):
   void _incrementNonZerosOnRowsExcludingCols(PyObject* py_rows, PyObject* py_cols,
                                              nupic::Real ## N2 delta)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    self->incrementNonZerosOnRowsExcludingCols(rows, rows + rowsSize,
-                                               cols, cols + colsSize,
+    self->incrementNonZerosOnRowsExcludingCols(rows.begin(), rows.end(),
+                                               cols.begin(), cols.end(),
                                                delta);
   }
 
@@ -883,16 +873,11 @@ def __div__(self, other):
   void _setZerosOnOuter(PyObject* py_rows, PyObject* py_cols,
                         nupic::Real ## N2 value)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    self->setZerosOnOuter(rows, rows + rowsSize,
-                          cols, cols + colsSize,
+    self->setZerosOnOuter(rows.begin(), rows.end(),
+                          cols.begin(), cols.end(),
                           value);
   }
 
@@ -921,16 +906,11 @@ def __div__(self, other):
                                           nupic::Real ## N2 value,
                                           nupic::Random& rng)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    self->setRandomZerosOnOuter(rows, rows + rowsSize,
-                                cols, cols + colsSize,
+    self->setRandomZerosOnOuter(rows.begin(), rows.end(),
+                                cols.begin(), cols.end(),
                                 numNewNonZeros,
                                 value, rng);
   }
@@ -941,23 +921,15 @@ def __div__(self, other):
                                              nupic::Real ## N2 value,
                                              nupic::Random& rng)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32>
+      newNonZeroCounts(py_newNonZeroCounts);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    PyArrayObject* npNewNonZeroCounts = (PyArrayObject*) py_newNonZeroCounts;
-    size_t newNonZeroCountsSize = PyArray_DIMS(npNewNonZeroCounts)[0];
-    nupic::UInt32* newNonZeroCounts =
-      (nupic::UInt32*)PyArray_DATA(npNewNonZeroCounts);
-
-    self->setRandomZerosOnOuter(rows, rows + rowsSize,
-                                cols, cols + colsSize,
-                                newNonZeroCounts,
-                                newNonZeroCounts + newNonZeroCountsSize,
+    self->setRandomZerosOnOuter(rows.begin(), rows.end(),
+                                cols.begin(), cols.end(),
+                                newNonZeroCounts.begin(),
+                                newNonZeroCounts.end(),
                                 value, rng);
   }
 
@@ -975,16 +947,11 @@ def __div__(self, other):
                                           nupic::Real ## N2 initialValue,
                                           nupic::Random& rng)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> cols(py_cols);
 
-    PyArrayObject* npCols = (PyArrayObject*) py_cols;
-    size_t colsSize = PyArray_DIMS(npCols)[0];
-    nupic::UInt32* cols = (nupic::UInt32*)PyArray_DATA(npCols);
-
-    self->increaseRowNonZeroCountsOnOuterTo(rows, rows + rowsSize,
-                                            cols, cols + colsSize,
+    self->increaseRowNonZeroCountsOnOuterTo(rows.begin(), rows.end(),
+                                            cols.begin(), cols.end(),
                                             numDesiredNonZeros, initialValue,
                                             rng);
   }
@@ -1001,11 +968,9 @@ def __div__(self, other):
                               nupic::Real ## N2 a,
                               nupic::Real ## N2 b)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
 
-    self->clipRowsBelowAndAbove(rows, rows + rowsSize,
+    self->clipRowsBelowAndAbove(rows.begin(), rows.end(),
                                 a, b);
   }
 
@@ -1027,12 +992,10 @@ def __div__(self, other):
 
   PyObject* _nNonZerosPerRow(PyObject* py_rows)
   {
-    PyArrayObject* npRows = (PyArrayObject*) py_rows;
-    size_t rowsSize = PyArray_DIMS(npRows)[0];
-    nupic::UInt32* rows = (nupic::UInt32*)PyArray_DATA(npRows);
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> rows(py_rows);
 
-    nupic::NumpyVectorT<nupic::UInt ## N1> out(rowsSize);
-    self->nNonZerosPerRow(rows, rows + rowsSize, out.begin());
+    nupic::NumpyVectorT<nupic::UInt ## N1> out(rows.size());
+    self->nNonZerosPerRow(rows.begin(), rows.end(), out.begin());
 
     return out.forPython();
   }
@@ -1605,15 +1568,12 @@ def __div__(self, other):
 
   inline void _rightVecSumAtNZ(PyObject* py_denseArray, PyObject* py_out) const
   {
-    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
-    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
-    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> denseArray(py_denseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZ(denseArray, out);
+    self->rightVecSumAtNZ(denseArray.begin(), out.begin());
   }
 
 
@@ -1634,16 +1594,15 @@ def __div__(self, other):
   inline void _rightVecSumAtNZSparse(PyObject* py_sparseBinaryArray,
                                      PyObject* py_out) const
   {
-    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseBinaryArray;
-    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
-    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+    nupic::NumpyVectorWeakRefT<nupic::UInt ## N1>
+      sparseBinaryArray(py_sparseBinaryArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZSparse(sparseArray, sparseArray + sparseArraySize,
-                                out);
+    self->rightVecSumAtNZSparse(sparseBinaryArray.begin(),
+                                sparseBinaryArray.end(),
+                                out.begin());
   }
 
 
@@ -1672,15 +1631,13 @@ def __div__(self, other):
                                           nupic::Real ## N2 threshold,
                                           PyObject* py_out) const
   {
-    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
-    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
-    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> denseArray(py_denseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZGtThreshold(denseArray, out, threshold);
+    self->rightVecSumAtNZGtThreshold(denseArray.begin(), out.begin(),
+                                     threshold);
   }
 
 
@@ -1698,20 +1655,19 @@ def __div__(self, other):
       return out
   %}
 
-  inline void _rightVecSumAtNZGtThresholdSparse(PyObject* py_sparseArray,
+  inline void _rightVecSumAtNZGtThresholdSparse(PyObject* py_sparseBinaryArray,
                                                 nupic::Real ## N2 threshold,
                                                 PyObject* py_out) const
   {
-    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseArray;
-    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
-    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+    nupic::NumpyVectorWeakRefT<nupic::UInt ## N1>
+      sparseBinaryArray(py_sparseBinaryArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZGtThresholdSparse(sparseArray, sparseArray + sparseArraySize,
-                                           out, threshold);
+    self->rightVecSumAtNZGtThresholdSparse(sparseBinaryArray.begin(),
+                                           sparseBinaryArray.end(),
+                                           out.begin(), threshold);
   }
 
 
@@ -1733,15 +1689,13 @@ def __div__(self, other):
                                           nupic::Real ## N2 threshold,
                                           PyObject* py_out) const
   {
-    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
-    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
-    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> denseArray(py_denseArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZGteThreshold(denseArray, out, threshold);
+    self->rightVecSumAtNZGteThreshold(denseArray.begin(), out.begin(),
+                                      threshold);
   }
 
 
@@ -1759,20 +1713,19 @@ def __div__(self, other):
       return out
   %}
 
-  inline void _rightVecSumAtNZGteThresholdSparse(PyObject* py_sparseArray,
+  inline void _rightVecSumAtNZGteThresholdSparse(PyObject* py_sparseBinaryArray,
                                                 nupic::Real ## N2 threshold,
                                                 PyObject* py_out) const
   {
-    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseArray;
-    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
-    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+    nupic::NumpyVectorWeakRefT<nupic::UInt ## N1>
+      sparseBinaryArray(py_sparseBinaryArray);
+    nupic::NumpyVectorWeakRefT<nupic::Real ## N2> out(py_out);
 
-    PyArrayObject* npOut = (PyArrayObject*) py_out;
-    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
-    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+    NTA_ASSERT(out.size() >= self->nRows());
 
-    self->rightVecSumAtNZGteThresholdSparse(sparseArray, sparseArray + sparseArraySize,
-                                            out, threshold);
+    self->rightVecSumAtNZGteThresholdSparse(sparseBinaryArray.begin(),
+                                            sparseBinaryArray.end(),
+                                            out.begin(), threshold);
   }
 
 

--- a/src/nupic/py_support/NumpyVector.hpp
+++ b/src/nupic/py_support/NumpyVector.hpp
@@ -45,7 +45,7 @@ namespace nupic {
   extern int LookupNumpyDType(const nupic::Real32 *);
   extern int LookupNumpyDType(const nupic::Real64 *);
   /**
-   * Concrete Numpy multi-d array wrapper who's implementation cannot be visible
+   * Concrete Numpy multi-d array wrapper whose implementation cannot be visible
    * due to the specifics of dynamically loading the Numpy C function API.
    */
   class NumpyArray
@@ -124,8 +124,9 @@ namespace nupic {
   /// using a slow and feature-poor set of SWIG typemap definitions
   /// provided as an example with the numpy documentation.
   /// This class bypasses that method of access, in favor of
-  /// a faster interface that nags (warns) about potential performance
-  /// problems. This wrapper should only be used within Python bindings,
+  /// a faster interface.
+  ///
+  /// This wrapper should only be used within Python bindings,
   /// as numpy data structures will only be passed in from Python code.
   /// For an example of its use, see the nupic::SparseMatrix Python bindings
   /// in nupic/python/bindings/math/SparseMatrix.i
@@ -163,14 +164,6 @@ namespace nupic {
     /// the appropriate format (1D contiguous numpy array of type
     /// equivalent to nupic::Real). If nupic::Real is float,
     /// the incoming array should have been created with dtype=numpy.float32
-    ///
-    /// @note I do not believe the data is copied unless necessary.
-    ///       This has not been confirmed.
-    ///       This means that ownership has two very different semantics:
-    ///       if the data is not copied, then any modifications to this
-    ///       vector affect the original.
-    ///       If the data is copied (slow), then any modifications do not
-    ///       affect the original.
     ///////////////////////////////////////////////////////////
     NumpyVectorT(PyObject *p)
       : NumpyArray(p, LookupNumpyDType((const T *) 0), 1)
@@ -416,9 +409,41 @@ namespace nupic {
     return p;
   }
 
-  //--------------------------------------------------------------------------------
+
+  /**
+   * Extract a 1D Numpy array's buffer.
+   */
+  template<typename T>
+  class NumpyVectorWeakRefT
+  {
+  public:
+    NumpyVectorWeakRefT(PyObject* pyArray)
+      : pyArray_((PyArrayObject*)pyArray)
+    {
+      NTA_ASSERT(PyArray_NDIM(pyArray_) == 1);
+      NTA_ASSERT(PyArray_EquivTypenums(
+                   PyArray_TYPE(pyArray_), LookupNumpyDType((const T *) 0)));
+    }
+
+    T* begin() const
+    {
+      return (T*) PyArray_DATA(pyArray_);
+    }
+
+    T* end() const
+    {
+      return (T*) PyArray_DATA(pyArray_) + size();
+    }
+
+    size_t size() const
+    {
+      return PyArray_DIMS(pyArray_)[0];
+    }
+
+  protected:
+    PyArrayObject* pyArray_;
+  };
 
 } // End namespace nupic.
 
 #endif
-

--- a/src/nupic/py_support/NumpyVector.hpp
+++ b/src/nupic/py_support/NumpyVector.hpp
@@ -28,6 +28,7 @@
  */
 
 #include <nupic/types/Types.hpp> // For nupic::Real.
+#include <nupic/utils/Log.hpp> // For NTA_ASSERT
 #include <algorithm> // For std::copy.
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
The approach: use `numpy.asarray` to get a numpy array. This function only copies the array if necessary. So these methods will never silently fail. Then the C code will use the memory buffer of the numpy array.

Fixes #1186

(Well, it fixes it partly. I only changed this for the methods that I'm using in the TemporalMemory.)