### PR TITLE
SparseMatrix: rightVecSumAtNZ cleanup

### DIFF
--- a/bindings/py/tests/sparse_matrix_test.py
+++ b/bindings/py/tests/sparse_matrix_test.py
@@ -1404,25 +1404,197 @@ class SparseMatrixTest(unittest.TestCase):
     # relies on a pre-allocated buffer.
 
     for i in range(5):
-      m = rgen.randint(1,10)
-      n = rgen.randint(1,10)
-      a = rgen.randint(0,100,(m,n))
+      nRows = rgen.randint(1,10)
+      nCols = rgen.randint(1,10)
+      a = rgen.randint(0,100,(nRows,nCols))
       a[numpy.where(a < 75)] = 0
-      a[rgen.randint(0,m)] = 0
-      a[:,rgen.randint(0,n)] = 0
-      x = rgen.randint(0,100,(n)).astype(float32)
-      y = zeros((m))
-      a2 = array(a)
-      a2[where(a2 > 0)] = 1
-      yr = dot(a2,x)
+      a[rgen.randint(0, nRows)] = 0
+      a[:,rgen.randint(0, nCols)] = 0
       mat = SM32(a)
+
+      x = rgen.randint(2, size=nCols).astype(float32)
+
+      aNonzero = array(a)
+      aNonzero[where(aNonzero > 0)] = 1
+      expected = dot(aNonzero, x)
+
       y = mat.rightVecSumAtNZ(x)
-      if (y != yr).any():
-        error('rightVecSumAtNZ')
-      y2 = zeros((m)).astype(float32)
-      mat.rightVecSumAtNZ_fast(x, y2)
-      if (y2 != yr).any():
-        error('rightVecSumAtNZ_fast')
+      numpy.testing.assert_equal(y, expected, 'rightVecSumAtNZ')
+      y2 = zeros((nRows)).astype(float32)
+      mat.rightVecSumAtNZ(x, out=y2)
+      numpy.testing.assert_equal(y2, expected, 'rightVecSumAtNZ with out')
+
+
+  def test_rightVecSumAtNZSparse(self):
+
+    print 'Testing rightVecSumAtNZSparse'
+
+    # This is like rightVecSumAtNZ, but the right vector is described as a list
+    # of indices of the value 1.0.
+
+    for i in range(5):
+      nRows = rgen.randint(1,10)
+      nCols = rgen.randint(1,10)
+      a = rgen.randint(0,100,(nRows,nCols))
+      a[numpy.where(a < 75)] = 0
+      a[rgen.randint(0, nRows)] = 0
+      a[:,rgen.randint(0, nCols)] = 0
+      mat = SM32(a)
+
+      xDense = rgen.randint(2, size=nCols).astype(float32)
+      xSparse = flatnonzero(xDense)
+
+      aNonzero = array(a)
+      aNonzero[where(aNonzero > 0)] = 1
+      expected = dot(aNonzero, xDense)
+
+      y = mat.rightVecSumAtNZSparse(xSparse)
+      numpy.testing.assert_equal(y, expected, 'rightVecSumAtNZSparse')
+      y2 = zeros((nRows)).astype(float32)
+      mat.rightVecSumAtNZSparse(xSparse, out=y2)
+      numpy.testing.assert_equal(y2, expected, 'rightVecSumAtNZSparse with out')
+
+
+  def test_rightVecSumAtNZGtThreshold(self):
+
+    print 'Testing rightVecSumAtNZGtThreshold'
+
+    for name, matrix, rightVec, threshold, expected in (
+        ("Test 1",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 1, 1, 1],
+         0.5,
+         [1, 0, 3, 1]),
+        ("Use the values from rightVec",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 2, 3, 4],
+         0.5,
+         [4,
+          0,
+          1 + 3 + 4,
+          1]),
+        ):
+
+      rightVec = array(rightVec, dtype="float32")
+
+      mat = SM32(matrix)
+      result = mat.rightVecSumAtNZGtThreshold(rightVec, threshold)
+
+      numpy.testing.assert_almost_equal(result, expected,
+                                        err_msg=name)
+
+
+  def test_rightVecSumAtNZGtThresholdSparse(self):
+
+    print 'Testing rightVecSumAtNZGtThresholdSparse'
+
+    for name, matrix, sparseRightVec, threshold, expected in (
+        ("Test 1",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [0, 1, 2, 3], # i.e. [1, 1, 1, 1]
+         0.5,
+         [1, 0, 3, 1]),
+        ("Zeros",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 2], # i.e. [0, 1, 1, 0]
+         0.5,
+         [0,
+          0,
+          1,
+          0]),
+        ):
+
+      mat = SM32(matrix)
+
+      sparseRightVec = array(sparseRightVec, dtype="uint32")
+
+      result = mat.rightVecSumAtNZGtThresholdSparse(sparseRightVec, threshold)
+
+      numpy.testing.assert_almost_equal(result, expected,
+                                        err_msg=name)
+
+
+  def test_rightVecSumAtNZGteThreshold(self):
+
+    print 'Testing rightVecSumAtNZGteThreshold'
+
+    for name, matrix, rightVec, threshold, expected in (
+        ("Test 1",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 1, 1, 1],
+         0.5,
+         [2, 0, 3, 1]),
+        ("Use the values from rightVec",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 2, 3, 4],
+         0.5,
+         [3 + 4,
+          0,
+          1 + 3 + 4,
+          1]),
+        ):
+
+      rightVec = array(rightVec, dtype="float32")
+
+      mat = SM32(matrix)
+      result = mat.rightVecSumAtNZGteThreshold(rightVec, threshold)
+
+      numpy.testing.assert_almost_equal(result, expected,
+                                        err_msg=name)
+
+
+  def test_rightVecSumAtNZGteThresholdSparse(self):
+
+    print 'Testing rightVecSumAtNZGteThresholdSparse'
+
+    for name, matrix, sparseRightVec, threshold, expected in (
+        ("Test 1",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [0, 1, 2, 3], # i.e. [1, 1, 1, 1]
+         0.5,
+         [2, 0, 3, 1]),
+        ("Zeros",
+         [[  0.0,  0.49, 0.5, 0.51],
+          [  0.0,  0.0,  0.0, 0.0],
+          [100.0,-50.0, 75.0, 2.0],
+          [  1.0,  0.0,  0.0, 0.0]],
+         [1, 2], # i.e. [0, 1, 1, 0]
+         0.5,
+         [1,
+          0,
+          1,
+          0]),
+        ):
+
+      mat = SM32(matrix)
+
+      sparseRightVec = array(sparseRightVec, dtype="uint32")
+
+      result = mat.rightVecSumAtNZGteThresholdSparse(sparseRightVec, threshold)
+
+      numpy.testing.assert_almost_equal(result, expected,
+                                        err_msg=name)
 
 
   def test_leftVecSumAtNZ(self):

--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -1433,40 +1433,200 @@ def __div__(self, other):
     return y.forPython();
   }
 
-  // Regular matrix vector multiplication, but assumes that all the non-zeros
-  // in the SparseMatrix are 1, so that we can save computing the multiplications:
-  // this routine just adds the values of xIn at the positions of the non-zeros
-  // on each row.
-  inline PyObject* rightVecSumAtNZ(PyObject* xIn) const
+
+  %pythoncode %{
+    def rightVecSumAtNZ(self, denseArray, out=None):
+      denseArray = numpy.asarray(denseArray, dtype="float32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZ(denseArray, out)
+
+      return out
+
+
+    def rightVecSumAtNZ_fast(self, denseArray, out):
+      """
+      Deprecated. Use rightVecSumAtNZ with an 'out' specified.
+      """
+      self.rightVecSumAtNZ(denseArray, out)
+  %}
+
+  inline void _rightVecSumAtNZ(PyObject* py_denseArray, PyObject* py_out) const
   {
-    nupic::NumpyVectorT<nupic::Real ## N2> x(xIn);
-    nupic::NumpyVectorT<nupic::Real ## N2> y(self->nRows());
-    self->rightVecSumAtNZ(x.begin(), y.begin());
-    return y.forPython();
+    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
+    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
+    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZ(denseArray, out);
   }
 
-  inline PyObject*
-    rightVecSumAtNZGtThreshold(PyObject* xIn, nupic::Real ## 32 threshold) const
+
+  %pythoncode %{
+    def rightVecSumAtNZSparse(self, sparseBinaryArray, out=None):
+      sparseBinaryArray = numpy.asarray(sparseBinaryArray, dtype="uint32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZSparse(sparseBinaryArray, out)
+
+      return out
+  %}
+
+  inline void _rightVecSumAtNZSparse(PyObject* py_sparseBinaryArray,
+                                     PyObject* py_out) const
   {
-    nupic::NumpyVectorT<nupic::Real ## N2> x(xIn);
-    nupic::NumpyVectorT<nupic::Real ## N2> y(self->nRows());
-    self->rightVecSumAtNZGtThreshold(x.begin(), y.begin(), threshold);
-    return y.forPython();
+    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseBinaryArray;
+    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
+    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZSparse(sparseArray, sparseArray + sparseArraySize,
+                                out);
   }
 
-  // Regular matrix vector multiplication, without allocation of the result,
-  // and assuming that the values of the non-zeros are always 1 in the
-  // sparse matrix, so that we can save computing multiplications explicitly.
-  // Also fast because doesn't go through NumpyVectorT and doesn't allocate
-  // memory.
-  inline void rightVecSumAtNZ_fast(PyObject *xIn, PyObject *yOut) const
+
+  %pythoncode %{
+    def rightVecSumAtNZGtThreshold(self, denseArray, threshold, out=None):
+      denseArray = numpy.asarray(denseArray, dtype="float32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZGtThreshold(denseArray, threshold, out)
+
+      return out
+
+
+    def rightVecSumAtNZGtThreshold_fast(self, denseArray, threshold, out):
+      """
+      Deprecated. Use rightVecSumAtNZGtThreshold with an 'out' specified.
+      """
+      self.rightVecSumAtNZGtThreshold(denseArray, threshold, out)
+  %}
+
+  inline void _rightVecSumAtNZGtThreshold(PyObject* py_denseArray,
+                                          nupic::Real ## N2 threshold,
+                                          PyObject* py_out) const
   {
-    PyArrayObject* x = (PyArrayObject*) xIn;
-    nupic::Real ## N2* x_begin = (nupic::Real ## N2*)(PyArray_DATA(x));
-    PyArrayObject* y = (PyArrayObject*) yOut;
-    nupic::Real ## N2* y_begin = (nupic::Real ## N2*)(PyArray_DATA(y));
-    self->rightVecSumAtNZ(x_begin, y_begin);
+    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
+    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
+    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZGtThreshold(denseArray, out, threshold);
   }
+
+
+  %pythoncode %{
+    def rightVecSumAtNZGtThresholdSparse(self, sparseBinaryArray, threshold, out=None):
+      sparseBinaryArray = numpy.asarray(sparseBinaryArray, dtype="uint32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZGtThresholdSparse(sparseBinaryArray, threshold, out)
+
+      return out
+  %}
+
+  inline void _rightVecSumAtNZGtThresholdSparse(PyObject* py_sparseArray,
+                                                nupic::Real ## N2 threshold,
+                                                PyObject* py_out) const
+  {
+    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseArray;
+    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
+    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZGtThresholdSparse(sparseArray, sparseArray + sparseArraySize,
+                                           out, threshold);
+  }
+
+
+  %pythoncode %{
+    def rightVecSumAtNZGteThreshold(self, denseArray, threshold, out=None):
+      denseArray = numpy.asarray(denseArray, dtype="float32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZGteThreshold(denseArray, threshold, out)
+
+      return out
+  %}
+
+  inline void _rightVecSumAtNZGteThreshold(PyObject* py_denseArray,
+                                          nupic::Real ## N2 threshold,
+                                          PyObject* py_out) const
+  {
+    PyArrayObject* npDenseArray = (PyArrayObject*) py_denseArray;
+    size_t denseArraySize = PyArray_DIMS(npDenseArray)[0];
+    nupic::Real ## N2 *denseArray = (nupic::Real ## N2 *) PyArray_DATA(npDenseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZGteThreshold(denseArray, out, threshold);
+  }
+
+
+  %pythoncode %{
+    def rightVecSumAtNZGteThresholdSparse(self, sparseBinaryArray, threshold, out=None):
+      sparseBinaryArray = numpy.asarray(sparseBinaryArray, dtype="uint32")
+
+      if out is None:
+        out = numpy.empty(self.nRows(), dtype="float32")
+      else:
+        assert out.dtype == "float32"
+
+      self._rightVecSumAtNZGteThresholdSparse(sparseBinaryArray, threshold, out)
+
+      return out
+  %}
+
+  inline void _rightVecSumAtNZGteThresholdSparse(PyObject* py_sparseArray,
+                                                nupic::Real ## N2 threshold,
+                                                PyObject* py_out) const
+  {
+    PyArrayObject* npSparseArray = (PyArrayObject*) py_sparseArray;
+    size_t sparseArraySize = PyArray_DIMS(npSparseArray)[0];
+    nupic::UInt ## N1 *sparseArray = (nupic::UInt ## N1 *) PyArray_DATA(npSparseArray);
+
+    PyArrayObject* npOut = (PyArrayObject*) py_out;
+    NTA_ASSERT(PyArray_DIMS(npOut)[0] >= self->nRows());
+    nupic::Real ## N2 *out = (nupic::Real ## N2 *) PyArray_DATA(npOut);
+
+    self->rightVecSumAtNZGteThresholdSparse(sparseArray, sparseArray + sparseArraySize,
+                                            out, threshold);
+  }
+
 
   // Regular matrix vector multiplication on the left side, assuming that the
   // values of the non-zeros are all 1, so that we can save actually computing
@@ -1493,15 +1653,6 @@ def __div__(self, other):
     self->leftVecSumAtNZ(x_begin, y_begin);
   }
 
-   inline void
-    rightVecSumAtNZGtThreshold_fast(PyObject* xIn, PyObject *yOut, nupic::Real ## 32 threshold) const
-  {
-    PyArrayObject* x = (PyArrayObject*) xIn;
-    nupic::Real ## N2* x_begin = (nupic::Real ## N2*)(PyArray_DATA(x));
-    PyArrayObject* y = (PyArrayObject*) yOut;
-    nupic::Real ## N2* y_begin = (nupic::Real ## N2*)(PyArray_DATA(y));
-    self->rightVecSumAtNZGtThreshold(x_begin, y_begin, threshold);
-  }
 
   PyObject* rightDenseMatProdAtNZ(PyObject* mIn) const
   {

--- a/src/nupic/math/SparseMatrix.hpp
+++ b/src/nupic/math/SparseMatrix.hpp
@@ -10112,6 +10112,10 @@ public:
    */
   template <typename InputIterator, typename OutputIterator>
   inline void rightVecSumAtNZ(InputIterator x, OutputIterator y) const {
+    // Note:
+    // 'rightVecSumAtNZSparse' passes nzb_ in as x,
+    // so this method shouldn't explicitly touch nzb_.
+
     ITERATE_ON_ALL_ROWS {
 
       size_type nnzr = nnzr_[row];
@@ -10157,13 +10161,12 @@ public:
     // matrix. But x is queried for every nonzero in the matrix, so in practice
     // it's much faster to create an x dense array and then perform simple
     // lookups on the dense array.
-    std::vector<value_type> x(nCols(), 0);
-
+    std::fill(nzb_, nzb_ + nCols(), (value_type)0.0);
     for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
-      x[*x_one] = 1.0;
+      nzb_[*x_one] = 1.0;
     }
 
-    rightVecSumAtNZ(x.begin(), out_begin);
+    rightVecSumAtNZ(nzb_, out_begin);
   }
 
 
@@ -10174,6 +10177,10 @@ public:
   template <typename InputIterator, typename OutputIterator>
   inline void rightVecSumAtNZGtThreshold(InputIterator x, OutputIterator y,
                                          value_type threshold) const {
+    // Note:
+    // 'rightVecSumAtNZGtThresholdSparse' passes nzb_ in as x,
+    // so this method shouldn't explicitly touch nzb_.
+
     ITERATE_ON_ALL_ROWS {
 
       size_type nnzr = nnzr_[row];
@@ -10204,13 +10211,12 @@ public:
                                  "rightVecSumAtNZGtThresholdSparse");
     } // End pre-conditions
 
-    std::vector<value_type> x(nCols(), 0);
-
+    std::fill(nzb_, nzb_ + nCols(), (value_type)0.0);
     for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
-      x[*x_one] = 1.0;
+      nzb_[*x_one] = 1.0;
     }
 
-    rightVecSumAtNZGtThreshold(x.begin(), out_begin, threshold);
+    rightVecSumAtNZGtThreshold(nzb_, out_begin, threshold);
   }
 
   /**
@@ -10220,6 +10226,10 @@ public:
   template <typename InputIterator, typename OutputIterator>
   inline void rightVecSumAtNZGteThreshold(InputIterator x, OutputIterator y,
                                           value_type threshold) const {
+    // Note:
+    // 'rightVecSumAtNZGteThresholdSparse' passes nzb_ in as x,
+    // so this method shouldn't explicitly touch nzb_.
+
     ITERATE_ON_ALL_ROWS {
 
       size_type nnzr = nnzr_[row];
@@ -10250,13 +10260,12 @@ public:
                                  "rightVecSumAtNZGteThresholdSparse");
     } // End pre-conditions
 
-    std::vector<value_type> x(nCols(), 0);
-
+    std::fill(nzb_, nzb_ + nCols(), (value_type)0.0);
     for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
-      x[*x_one] = 1.0;
+      nzb_[*x_one] = 1.0;
     }
 
-    rightVecSumAtNZGteThreshold(x.begin(), out_begin, threshold);
+    rightVecSumAtNZGteThreshold(nzb_, out_begin, threshold);
   }
 
   /**

--- a/src/nupic/math/SparseMatrix.hpp
+++ b/src/nupic/math/SparseMatrix.hpp
@@ -10109,9 +10109,6 @@ public:
    * @param x [InputIterator<value_type>] input vector (size = number of
    * columns)
    * @param y [OutputIterator<value_type>] output vector (size = number of rows)
-   *
-   * @b Exceptions:
-   *  @li None
    */
   template <typename InputIterator, typename OutputIterator>
   inline void rightVecSumAtNZ(InputIterator x, OutputIterator y) const {
@@ -10133,9 +10130,46 @@ public:
   }
 
   /**
-   * Same as above, except that we add to the sum only if the value of the
-   * non-zero
-   * is greater than the given threshold.
+   * Adds the values of x corresponding to non-zeros, for each row.
+   * The operation is:
+   *
+   *  for row in [0,nrows):
+   *   y[row] = sum(x[col], for col in [0,ncols) s.t. this[row,col] != 0)
+   *
+   * @param x_ones
+   * Indices of 1.0 in a vector of length nCols
+   *
+   * @param y
+   * Output vector (size = number of rows)
+   */
+  template <typename InputIterator, typename OutputIterator>
+  inline void rightVecSumAtNZSparse(InputIterator x_ones_begin,
+                                    InputIterator x_ones_end,
+                                    OutputIterator out_begin) const {
+    { // Pre-conditions
+      ASSERT_INPUT_ITERATOR(InputIterator);
+      ASSERT_OUTPUT_ITERATOR(OutputIterator, size_type);
+      assert_valid_col_it_range_(x_ones_begin, x_ones_end,
+                                 "rightVecSumAtNZSparse");
+    } // End pre-conditions
+
+    // One approach would be to walk a sorted list of ones for every row in the
+    // matrix. But x is queried for every nonzero in the matrix, so in practice
+    // it's much faster to create an x dense array and then perform simple
+    // lookups on the dense array.
+    std::vector<value_type> x(nCols(), 0);
+
+    for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
+      x[*x_one] = 1.0;
+    }
+
+    rightVecSumAtNZ(x.begin(), out_begin);
+  }
+
+
+  /**
+   * Like rightVecSumAtNZ, except that we add to the sum only if the value of
+   * the non-zero is > threshold.
    */
   template <typename InputIterator, typename OutputIterator>
   inline void rightVecSumAtNZGtThreshold(InputIterator x, OutputIterator y,
@@ -10153,6 +10187,76 @@ public:
 
       *y++ = val;
     }
+  }
+
+  /**
+   * Like rightVecSumAtNZSparse, except that we add to the sum only if the value
+   * of the non-zero is > threshold.
+   */
+  template <typename InputIterator, typename OutputIterator>
+  inline void rightVecSumAtNZGtThresholdSparse(
+    InputIterator x_ones_begin, InputIterator x_ones_end,
+    OutputIterator out_begin, value_type threshold) const {
+    { // Pre-conditions
+      ASSERT_INPUT_ITERATOR(InputIterator);
+      ASSERT_OUTPUT_ITERATOR(OutputIterator, size_type);
+      assert_valid_col_it_range_(x_ones_begin, x_ones_end,
+                                 "rightVecSumAtNZGtThresholdSparse");
+    } // End pre-conditions
+
+    std::vector<value_type> x(nCols(), 0);
+
+    for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
+      x[*x_one] = 1.0;
+    }
+
+    rightVecSumAtNZGtThreshold(x.begin(), out_begin, threshold);
+  }
+
+  /**
+   * Like rightVecSumAtNZ, except that we add to the sum only if the value of
+   * the non-zero is >= threshold.
+   */
+  template <typename InputIterator, typename OutputIterator>
+  inline void rightVecSumAtNZGteThreshold(InputIterator x, OutputIterator y,
+                                          value_type threshold) const {
+    ITERATE_ON_ALL_ROWS {
+
+      size_type nnzr = nnzr_[row];
+      size_type *ind = ind_[row];
+      value_type *nz = nz_[row];
+      value_type val = 0.0;
+
+      for (size_type i = 0; i != nnzr; ++i)
+        if (nz[i] >= threshold)
+          val += x[ind[i]];
+
+      *y++ = val;
+    }
+  }
+
+  /**
+   * Like rightVecSumAtNZSparse, except that we add to the sum only if the value
+   * of the non-zero is >= threshold.
+   */
+  template <typename InputIterator, typename OutputIterator>
+  inline void rightVecSumAtNZGteThresholdSparse(
+    InputIterator x_ones_begin, InputIterator x_ones_end,
+    OutputIterator out_begin, value_type threshold) const {
+    { // Pre-conditions
+      ASSERT_INPUT_ITERATOR(InputIterator);
+      ASSERT_OUTPUT_ITERATOR(OutputIterator, size_type);
+      assert_valid_col_it_range_(x_ones_begin, x_ones_end,
+                                 "rightVecSumAtNZGteThresholdSparse");
+    } // End pre-conditions
+
+    std::vector<value_type> x(nCols(), 0);
+
+    for (InputIterator x_one = x_ones_begin; x_one != x_ones_end; ++x_one) {
+      x[*x_one] = 1.0;
+    }
+
+    rightVecSumAtNZGteThreshold(x.begin(), out_begin, threshold);
   }
 
   /**


### PR DESCRIPTION
With this change, `SparseMatrix.hpp` now has:

- rightVecSumAtNZ
- rightVecSumAtNZSparse **(new)**
- rightVecSumAtNZGtThreshold
- rightVecSumAtNZGtThresholdSparse **(new)**
- rightVecSumAtNZGteThreshold **(new)**
- rightVecSumAtNZGteThresholdSparse **(new)**

In the bindings, I get rid of having variants like `rightVecSumAtNZ`, and instead add an `out` parameter to the methods. So it feels like numpy.

Fixes #1190