### PR TITLE
NUP-2316 Installing XCode 8 makes nupic.core build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
   - "VERBOSE=1 make|grep -v -F '\\-\\- Installing:'"
   - "make install 2>&1|grep -v -F 'Installing:'"
   - "cd $TRAVIS_BUILD_DIR"
-  - "python setup.py install --user"
+  - "python setup.py install --user --prefix="
 
 script:
   # Some tests (e.g., helloregion) expect this to be the current directory and

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: cpp
 
-osx_image: beta-xcode6.1
+osx_image: xcode8.2
 
 os:
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
   - "VERBOSE=1 make|grep -v -F '\\-\\- Installing:'"
   - "make install 2>&1|grep -v -F 'Installing:'"
   - "cd $TRAVIS_BUILD_DIR"
-  - "python setup.py install --user --prefix="
+  - "python setup.py install --user"
 
 script:
   # Some tests (e.g., helloregion) expect this to be the current directory and

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: cpp
 
-osx_image: xcode8.2
+osx_image: beta-xcode6.1
 
 os:
   - osx

--- a/src/CombineUnixArchives.cmake
+++ b/src/CombineUnixArchives.cmake
@@ -76,9 +76,10 @@ function(COMBINE_UNIX_ARCHIVES
 
     # Accumulate objects
     if(UNIX)
+      # Linux or OS X
       set(globbing_ext "o")
     else()
-      # i.e., Windows
+      # i.e., Windows with MINGW toolchain
       set(globbing_ext "obj")
     endif()
 

--- a/src/CombineUnixArchives.cmake
+++ b/src/CombineUnixArchives.cmake
@@ -68,16 +68,24 @@ function(COMBINE_UNIX_ARCHIVES
 
     # Extract objects from current source lib
     execute_process(COMMAND ${CMAKE_AR} -x ${lib}
-                    WORKING_DIRECTORY ${working_dir})
+                    WORKING_DIRECTORY ${working_dir}
+                    RESULT_VARIABLE exe_result)
+    if(NOT "${exe_result}" STREQUAL "0")
+      message(FATAL_ERROR "COMBINE_UNIX_ARCHIVES: obj extraction process failed exe_result='${exe_result}'")
+    endif()
 
     # Accumulate objects
-    file(GLOB_RECURSE objects "${working_dir}/*")
+    file(GLOB_RECURSE objects "${working_dir}/*.o")
     list(APPEND all_object_locations ${objects})
   endforeach()
 
   # Generate the target static library from all source objects
   file(TO_NATIVE_PATH ${TARGET_LOCATION} TARGET_LOCATION)
-  execute_process(COMMAND ${CMAKE_AR} rcs ${TARGET_LOCATION} ${all_object_locations})
+  execute_process(COMMAND ${CMAKE_AR} rcs ${TARGET_LOCATION} ${all_object_locations}
+                  RESULT_VARIABLE exe_result)
+  if(NOT "${exe_result}" STREQUAL "0")
+    message(FATAL_ERROR "COMBINE_UNIX_ARCHIVES: archive construction process failed exe_result='${exe_result}'")
+  endif()
 
   # Remove scratch directory
   file(REMOVE_RECURSE ${scratch_dir})

--- a/src/CombineUnixArchives.cmake
+++ b/src/CombineUnixArchives.cmake
@@ -75,7 +75,21 @@ function(COMBINE_UNIX_ARCHIVES
     endif()
 
     # Accumulate objects
-    file(GLOB_RECURSE objects "${working_dir}/*.o")
+    if(UNIX)
+      set(globbing_ext "o")
+    else()
+      # i.e., Windows
+      set(globbing_ext "obj")
+    endif()
+
+    file(GLOB_RECURSE objects "${working_dir}/*.${globbing_ext}")
+    if (NOT objects)
+      file(GLOB_RECURSE working_dir_listing "${working_dir}/*")
+      message(FATAL_ERROR
+              "COMBINE_UNIX_ARCHIVES: no extracted obj files from ${lib} "
+              "found in ${working_dir} using globbing_ext=${globbing_ext}, "
+              "but the following entries were found: ${working_dir_listing}.")
+    endif()
     list(APPEND all_object_locations ${objects})
   endforeach()
 


### PR DESCRIPTION
Fixes #1095.

NUP-2316 Fixed globbing statement that was picking up unexpected files after obj extraction (e.g., sort index file) and packaging then into the new archive.

NUP-2316 Add error-checks after archive extraction and construction commands.

I tested the fix on a OS X Sierra MacBookPro. I confirmed the failure before the fix and verified the fix afterwards.

NOTE1: also tried building on Travis using xcode8.2 OS X image (macos10.12-xcode8.2) at experimental commit bd8a79b7fe90c9e88580906a9f46d443fe265b23. nupic.core build succeeded; the build failed later on in the installation step. See https://s3.amazonaws.com/archive.travis-ci.org/jobs/191535267/log.txt. This was just an experiment. Switching the Travis build to xcode8* is outside the scope of this task.

NOTE2: at experimental commit 001de48ff2f7f9e087fad298bc12f1c9618b584e, all the tests passed, then something in travis itself failed with "/Users/travis/build.sh: line 148: shell_session_update: command not found" (apparently travis issue). **I am going to revert both experimental commits, but this experiment can help with the subsequent task when switching to a newer OS X.**