### PR TITLE
Circle CI initial yaml file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,20 +15,15 @@ machine:
     - ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv
 
 dependencies:
-  pre:
-    - cat ~/.circlerc
-    #- sed -i '' -e '$ d' ~/.circlerc
-    # Make sure that the user site-packages is first on the PATH
-    #- echo 'export PATH=$HOME/Library/Python/2.7/bin:$PATH' >> ~/.bash_profile
-    #- echo 'export PATH=$HOME/Library/Python/2.7/bin:$PATH' >> ~/.bashrc
   override:
-    - pip install --user --upgrade pip setuptools wheel
+    - curl --silent --show-error --retry 5 -O http://releases.numenta.org/pip/1ebd3cb7a5a3073058d0c9552ab074bd/get-pip.py
+    - python get-pip.py --user --upgrade --ignore-installed pip setuptools wheel
+    # Still don't get the user-installed version of pip, but this seems manageable.
     - pip --version
     - pip install --use-wheel --user -r bindings/py/requirements.txt --quiet || exit
     - pip install --user pycapnp==0.5.8
     - pip install --user pytest
 
-#database:
 compile:
   override:
     - mkdir -p build/scripts

--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,10 @@ machine:
 
 dependencies:
   override:
-    - curl --silent --show-error --retry 5 -O http://releases.numenta.org/pip/1ebd3cb7a5a3073058d0c9552ab074bd/get-pip.py
-    - python get-pip.py --user --upgrade --ignore-installed pip setuptools wheel
+    # TODO: Use get-pip.py
+    #- curl --silent --show-error --retry 5 -O http://releases.numenta.org/pip/1ebd3cb7a5a3073058d0c9552ab074bd/get-pip.py
+    #- python get-pip.py --user --upgrade --ignore-installed pip setuptools wheel
+    - pip install --user --ignore-installed --upgrade pip setuptools wheel
     # Still don't get the user-installed version of pip, but this seems manageable.
     - pip --version
     - pip install --use-wheel --user -r bindings/py/requirements.txt --quiet || exit

--- a/circle.yml
+++ b/circle.yml
@@ -43,3 +43,6 @@ test:
     - echo $PATH
     - ls -la $HOME/Library/Python/2.7/bin/
     - py.test bindings/py/tests
+  post:
+    mv dist/*.whl $CIRCLE_ARTIFACTS/
+    ls -l $CIRCLE_ARTIFACTS/

--- a/circle.yml
+++ b/circle.yml
@@ -44,5 +44,5 @@ test:
     - ls -la $HOME/Library/Python/2.7/bin/
     - py.test bindings/py/tests
   post:
-    mv dist/*.whl $CIRCLE_ARTIFACTS/
-    ls -l $CIRCLE_ARTIFACTS/
+    - mv dist/*.whl $CIRCLE_ARTIFACTS/
+    - ls -l $CIRCLE_ARTIFACTS/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,45 @@
+machine:
+  timezone:
+    GMT
+  xcode:
+    version: 8.0
+  environment:
+    XCODE_SCHEME: nupic
+    XCODE_WORKSPACE: nupic
+    ARCHFLAGS: "-arch x86_64"
+    PYTHONPATH: "$HOME/Library/Python/2.7/lib/python/site-packages"
+    PATH: "$HOME/Library/Python/2.7/bin:$PATH"
+    PYBIN: "$HOME/Library/Python/2.7/bin"
+  pre:
+    - pip install --user --ignore-installed --upgrade --verbose virtualenv
+    - ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv
+
+dependencies:
+  pre:
+    - cat ~/.circlerc
+    #- sed -i '' -e '$ d' ~/.circlerc
+    # Make sure that the user site-packages is first on the PATH
+    #- echo 'export PATH=$HOME/Library/Python/2.7/bin:$PATH' >> ~/.bash_profile
+    #- echo 'export PATH=$HOME/Library/Python/2.7/bin:$PATH' >> ~/.bashrc
+  override:
+    - pip install --user --upgrade pip setuptools wheel
+    - pip --version
+    - pip install --use-wheel --user -r bindings/py/requirements.txt --quiet || exit
+    - pip install --user pycapnp==0.5.8
+    - pip install --user pytest
+
+#database:
+compile:
+  override:
+    - mkdir -p build/scripts
+    - cd build/scripts && cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release -DPY_EXTENSIONS_DIR=../../bindings/py/nupic/bindings
+    - cd build/scripts && make -j6
+    - cd build/scripts && make install
+    - python setup.py bdist_wheel
+    - mkdir dist && mv bindings/py/dist/*.whl dist/
+    - pip install --use-wheel --user --find-links=`pwd`/dist/ nupic.bindings
+test:
+  override:
+    - echo $PATH
+    - ls -la $HOME/Library/Python/2.7/bin/
+    - py.test bindings/py/tests


### PR DESCRIPTION
This is a proof-of-concept for Circle CI OS X build.

fixes #1219 

Note the following Circle CI limitations discovered so far:

- The circle environment has some inferred stages that cannot be overridden. One of these is setting up virtualenv when it detects a Python project.
- There is a bug in the circle environment where virtualenv is missing but the inferred stage requires it. I found a solution online where you install it in the machine "pre" section.
- I have found no way to get a newer version of pip. I tried while inside the virtualenv but the pip being used is from the system installation. And the circle .bashrc/.bash_profile modifies the PATH (AFTER applying the `PATH` changes made in the machine "environment" section) so that `/usr/local/bin` occurs before anything that I set.
- I also tried avoiding virtualenv. I was able to do this and also modify the bash config scripts to get the `PATH` and `PYTHONPATH` that I wanted. However, even with this set up properly and the latest `pip` installed to the user location, the new `pip` executable still ended up using the system installation of `pip`. You can see this setup here: https://github.com/scottpurdy/nupic.core/blob/cf25537ea7974c034f307eab29220cde39242145/circle.yml

fyi @oxtopus @rhyolight 