### PR TITLE
Add conditional to virtualenv symlink in case it already exists.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ machine:
     PYBIN: "$HOME/Library/Python/2.7/bin"
   pre:
     - pip install --user --ignore-installed --upgrade --verbose virtualenv
-    - [ ! -d /usr/local/bin/virtualenv ] && ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv
+    - "[ ! -d /usr/local/bin/virtualenv ] && ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv"
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ machine:
     PYBIN: "$HOME/Library/Python/2.7/bin"
   pre:
     - pip install --user --ignore-installed --upgrade --verbose virtualenv
-    - ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv
+    - [ ! -d /usr/local/bin/virtualenv ] && ln -s ~/Library/Python/2.7/bin/virtualenv /usr/local/bin/virtualenv
 
 dependencies:
   override:


### PR DESCRIPTION
The hack I needed to make virtualenv available doesn't always seem to be necessary as virtualenv is already present in the target location when Circle runs jobs from the "numenta" fork of nupic.core. This change makes the symlinking happen only when virtualenv isn't yet present.

@oxtopus @rhyolight someone review when you have a chance