### PR TITLE
TM Perf: Densify prevActiveCells rather than binary searching

### DIFF
--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -235,7 +235,7 @@ static CellIdx getLeastUsedCell(
 static void adaptSegment(
   Connections& connections,
   Segment segment,
-  const vector<CellIdx>& prevActiveCells,
+  const vector<bool>& prevActiveCellsDense,
   Permanence permanenceIncrement,
   Permanence permanenceDecrement)
 {
@@ -244,12 +244,9 @@ static void adaptSegment(
   for (SynapseIdx i = 0; i < synapses.size();)
   {
     const SynapseData& synapseData = connections.dataForSynapse(synapses[i]);
-    const bool isActive =
-      std::binary_search(prevActiveCells.begin(), prevActiveCells.end(),
-                         synapseData.presynapticCell);
-    Permanence permanence = synapseData.permanence;
 
-    if (isActive)
+    Permanence permanence = synapseData.permanence;
+    if (prevActiveCellsDense[synapseData.presynapticCell])
     {
       permanence += permanenceIncrement;
     }
@@ -327,7 +324,7 @@ static void activatePredictedColumn(
   Random& rng,
   vector<Segment>::const_iterator columnActiveSegmentsBegin,
   vector<Segment>::const_iterator columnActiveSegmentsEnd,
-  const vector<CellIdx>& prevActiveCells,
+  const vector<bool>& prevActiveCellsDense,
   const vector<CellIdx>& prevWinnerCells,
   const vector<UInt32>& numActivePotentialSynapsesForSegment,
   UInt maxNewSynapseCount,
@@ -350,7 +347,7 @@ static void activatePredictedColumn(
       {
         adaptSegment(connections,
                      *activeSegment,
-                     prevActiveCells,
+                     prevActiveCellsDense,
                      permanenceIncrement, permanenceDecrement);
 
         const Int32 nGrowDesired = maxNewSynapseCount -
@@ -376,7 +373,7 @@ static void burstColumn(
   UInt column,
   vector<Segment>::const_iterator columnMatchingSegmentsBegin,
   vector<Segment>::const_iterator columnMatchingSegmentsEnd,
-  const vector<CellIdx>& prevActiveCells,
+  const vector<bool>& prevActiveCellsDense,
   const vector<CellIdx>& prevWinnerCells,
   const vector<UInt32>& numActivePotentialSynapsesForSegment,
   UInt cellsPerColumn,
@@ -416,7 +413,7 @@ static void burstColumn(
       // Learn on the best matching segment.
       adaptSegment(connections,
                    *bestMatchingSegment,
-                   prevActiveCells,
+                   prevActiveCellsDense,
                    permanenceIncrement, permanenceDecrement);
 
       const Int32 nGrowDesired = maxNewSynapseCount -
@@ -454,7 +451,7 @@ static void punishPredictedColumn(
   Connections& connections,
   vector<Segment>::const_iterator columnMatchingSegmentsBegin,
   vector<Segment>::const_iterator columnMatchingSegmentsEnd,
-  const vector<CellIdx>& prevActiveCells,
+  const vector<bool>& prevActiveCellsDense,
   Permanence predictedSegmentDecrement)
 {
   if (predictedSegmentDecrement > 0.0)
@@ -462,7 +459,7 @@ static void punishPredictedColumn(
     for (auto matchingSegment = columnMatchingSegmentsBegin;
          matchingSegment != columnMatchingSegmentsEnd; matchingSegment++)
     {
-      adaptSegment(connections, *matchingSegment, prevActiveCells,
+      adaptSegment(connections, *matchingSegment, prevActiveCellsDense,
                    -predictedSegmentDecrement, 0.0);
     }
   }
@@ -477,7 +474,13 @@ void TemporalMemory::activateCells(
                                       activeColumns + activeColumnsSize))
     << "The activeColumns must be a sorted list of indices without duplicates.";
 
-  const vector<CellIdx> prevActiveCells = std::move(activeCells_);
+  vector<bool> prevActiveCellsDense(numberOfCells(), false);
+  for (CellIdx cell : activeCells_)
+  {
+    prevActiveCellsDense[cell] = true;
+  }
+  activeCells_.clear();
+
   const vector<CellIdx> prevWinnerCells = std::move(winnerCells_);
 
   const auto columnForSegment = [&](Segment segment)
@@ -507,7 +510,7 @@ void TemporalMemory::activateCells(
         activatePredictedColumn(
           activeCells_, winnerCells_, connections, rng_,
           columnActiveSegmentsBegin, columnActiveSegmentsEnd,
-          prevActiveCells, prevWinnerCells,
+          prevActiveCellsDense, prevWinnerCells,
           numActivePotentialSynapsesForSegment_,
           maxNewSynapseCount_,
           initialPermanence_, permanenceIncrement_, permanenceDecrement_,
@@ -518,7 +521,7 @@ void TemporalMemory::activateCells(
         burstColumn(
           activeCells_, winnerCells_, connections, rng_,
           column, columnMatchingSegmentsBegin, columnMatchingSegmentsEnd,
-          prevActiveCells, prevWinnerCells,
+          prevActiveCellsDense, prevWinnerCells,
           numActivePotentialSynapsesForSegment_,
           cellsPerColumn_, maxNewSynapseCount_,
           initialPermanence_, permanenceIncrement_, permanenceDecrement_,
@@ -532,7 +535,7 @@ void TemporalMemory::activateCells(
         punishPredictedColumn(
           connections,
           columnMatchingSegmentsBegin, columnMatchingSegmentsEnd,
-          prevActiveCells,
+          prevActiveCellsDense,
           predictedSegmentDecrement_);
       }
     }

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -175,7 +175,7 @@ void TemporalMemory::initialize(
 
   // Initialize member variables
   connections = Connections(
-    numberOfCells(),
+    numberOfColumns() * cellsPerColumn_,
     maxSegmentsPerCell,
     maxSynapsesPerSegment);
   seed_((UInt64)(seed < 0 ? rand() : seed));
@@ -244,6 +244,8 @@ static void adaptSegment(
   for (SynapseIdx i = 0; i < synapses.size();)
   {
     const SynapseData& synapseData = connections.dataForSynapse(synapses[i]);
+
+    NTA_ASSERT(synapseData.presynapticCell < connections.numCells());
 
     Permanence permanence = synapseData.permanence;
     if (prevActiveCellsDense[synapseData.presynapticCell])
@@ -638,7 +640,7 @@ vector<CellIdx> TemporalMemory::cellsForColumn(Int column)
 
 UInt TemporalMemory::numberOfCells(void)
 {
-  return numberOfColumns() * cellsPerColumn_;
+  return connections.numCells();
 }
 
 vector<CellIdx> TemporalMemory::getActiveCells() const

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -910,16 +910,20 @@ namespace {
     const UInt activeColumns[1] = {4};
 
     Segment matchingSegment = tm.connections.createSegment(4);
-    tm.connections.createSynapse(matchingSegment, 81, 0.6);
+
+    // Create a synapse with a high permanence.
+    tm.connections.createSynapse(matchingSegment, 31, 0.6);
 
     // Create a synapse that is still the weakest after adding
     // permanenceIncrement.
     tm.connections.createSynapse(matchingSegment, 0, 0.11);
 
+    // Activate a synapse on the segment, making it "matching".
     tm.compute(3, previousActiveColumns);
 
     ASSERT_EQ(prevWinnerCells, tm.getWinnerCells());
 
+    // Now mark the segment as "correct" by activating its cell.
     tm.compute(1, activeColumns);
 
     // There should now be 3 synapses, and none of them should be to cell 0.


### PR DESCRIPTION
Fixes #1224

I learned while changing the SparseMatrix that this strategy is much faster.

Hotgym runtime:
**Before:** 2.04 seconds
**After:** 0.90 seconds

So yeah, in some situations it's at least twice as fast.