### PR TITLE
NUP-2324 When built with -D_GLIBCXX_DEBUG, c++ detects out-of-bounds access to _synapses in Segment::freeNSynapses

### DIFF
--- a/CommonCompilerConfig.cmake
+++ b/CommonCompilerConfig.cmake
@@ -345,6 +345,10 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     # to examine containers in gdb.
     # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html
     list(APPEND COMMON_COMPILER_DEFINITIONS -D_GLIBCXX_DEBUG)
+  elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # NOTE: debug mode is immature in Clang, and values of _LIBCPP_DEBUG above 0
+    # require  the debug build of libc++ to be present at linktime on OS X.
+    list(APPEND COMMON_COMPILER_DEFINITIONS -D_LIBCPP_DEBUG=0)
   endif()
 
   # Disable optimizations

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -555,6 +555,7 @@ set_target_properties(${src_executable_hellosptp}
 set(src_executable_gtests unit_tests)
 add_executable(${src_executable_gtests}
                test/unit/algorithms/AnomalyTest.cpp
+               test/unit/algorithms/Cells4Test.cpp
                test/unit/algorithms/CondProbTableTest.cpp
                test/unit/algorithms/ConnectionsTest.cpp
                test/unit/algorithms/FastCLAClassifierTest.cpp

--- a/src/nupic/algorithms/Cell.hpp
+++ b/src/nupic/algorithms/Cell.hpp
@@ -166,6 +166,7 @@ namespace nupic {
           }
 
           // Sort segments according to activation frequency
+          // ZZZ Where is the sort?
 
           // Redo free segments list
           _freeSegments.clear();

--- a/src/nupic/algorithms/Cell.hpp
+++ b/src/nupic/algorithms/Cell.hpp
@@ -166,7 +166,8 @@ namespace nupic {
           }
 
           // Sort segments according to activation frequency
-          // ZZZ Where is the sort?
+          // TODO Comment not backed by code. Investigate whether the
+          //      above-mentioned sort is needed.
 
           // Redo free segments list
           _freeSegments.clear();

--- a/src/nupic/algorithms/Cells4.cpp
+++ b/src/nupic/algorithms/Cells4.cpp
@@ -1739,7 +1739,8 @@ void Cells4::adaptSegment(const SegmentUpdate& update)
     segment.updateSynapses(synToDec, - _permDec, _permMax, _permConnected, removed);
 
     if (!removed.empty()) {
-      // Fix up inactive and active synapse indexes and inactive source cells
+      // Fix up inactive source cell indexes and inactive and active synapse
+      // indexes
       _fixupIndexesAfterSynapseRemovalsInAdaptSegment(
         removed /*removedSrcCellIdxs*/,
         synToDec /*inactiveSrcCellIdxs*/,

--- a/src/nupic/algorithms/Cells4.cpp
+++ b/src/nupic/algorithms/Cells4.cpp
@@ -1686,7 +1686,8 @@ void Cells4::adaptSegment(const SegmentUpdate& update)
     // If any synapses were removed as the result of permanence decrements,
     // regenerate affected parameters
     if (!removed.empty()) {
-      synapsesSet.insert(synToInc.begin(), synToInc.end());
+      synapsesSet.clear();
+      synapsesSet.insert(update.begin(), update.end());
 
       _generateListsOfSynapsesToAdjustForAdaptSegment(
         segment, synapsesSet,

--- a/src/nupic/algorithms/Cells4.cpp
+++ b/src/nupic/algorithms/Cells4.cpp
@@ -1740,11 +1740,11 @@ void Cells4::adaptSegment(const SegmentUpdate& update)
 
     if (!removed.empty()) {
       // Fix up inactive and active synapse indexes and inactive source cells
-    _fixupIndexesAfterSynapseRemovalsInAdaptSegment(
-      removed /*removedSrcCellIdxs*/,
-      synToDec /*inactiveSrcCellIdxs*/,
-      inactiveSegmentIndices /*inactiveSynapseIdxs*/,
-      activeSegmentIndices /*activeSynapseIdxs*/);
+      _fixupIndexesAfterSynapseRemovalsInAdaptSegment(
+        removed /*removedSrcCellIdxs*/,
+        synToDec /*inactiveSrcCellIdxs*/,
+        inactiveSegmentIndices /*inactiveSynapseIdxs*/,
+        activeSegmentIndices /*activeSynapseIdxs*/);
     }
 
     // Update synapses which need to be incremented

--- a/src/nupic/algorithms/Cells4.hpp
+++ b/src/nupic/algorithms/Cells4.hpp
@@ -960,50 +960,56 @@ namespace nupic {
          */
         void applyGlobalDecay();
 
+
+        //-----------------------------------------------------------------------
         /**
-         * This private function contains specialized logic used by
-         * Cells4::adaptSegment to fix up several internal containers after
-         * deletion of synapses. We break it out into a separate function to
-         * facilitate unit testing.
+         * Private Helper function for Cells4::adaptSegment. Generates lists of
+         * synapses to decrement, increment, add, and remove.
          *
-         * Parameters:
+         * We break it out into a separate function to facilitate unit testing.
          *
-         * removedSrcCellIdxs: Source cell indexes corresponding to inactive
-         *                     synapses that were removed by
-         *                     Segment::updateSynapses. Ordered by relative
-         *                     position of the corresponding InSynapses in the
-         *                     segment. The contents are a subset of the values
-         *                     in inactiveSrcCellIdxs arg.
+         * On Entry, purges resudual data from inactiveSrcCellIdxs,
+         * inactiveSynapseIdxs, activeSrcCellIdxs, and activeSynapseIdxs.
          *
-         * inactiveSrcCellIdxs: Source cell indexes corresponding to all
-         *                     inactive synapses prior to removal of some
-         *                     synapses by Segment::updateSynapses. Ordered by
+         * segment:            The segment being adapted.
+         *
+         * synapsesSet:        IN/OUT On entry, the union of source cell indexes
+         *                     corresponding to existing active synapses in the
+         *                     segment as well as new synapses to be created. On
+         *                     return, it's former self sans elements returned
+         *                     in activeSrcCellIdxs. The remaining elements
+         *                     correspond to new synapses to be created within
+         *                     the segment.
+         *
+         * inactiveSrcCellIdxs: OUT Source cell indexes corresponding to
+         *                     inactive synapses in the segment. Ordered by
          *                     relative position of the corresponding InSynapses
-         *                     in the segment. The elements here match
-         *                     corresponding elements in the inactiveSynapseIdxs
-         *                     arg. We will remove elements matching the ones in
-         *                     the removedSrcCellIdxs arg.
+         *                     in the segment. The elements here correlate to
+         *                     elements in inactiveSynapseIdxs.
          *
-         * inactiveSynapseIdxs: Synapse indexes corresponding to all inactive
-         *                     synapses prior to removal of some inactive
-         *                     synapses by Segment::updateSynapses. Sorted in
-         *                     ascending order. The elements here match
-         *                     corresponding elements in the inactiveSrcCellIdxs
-         *                     arg. We will remove elements corresponding to the
-         *                     ones removed from the inactiveSrcCellIdxs arg and
-         *                     adjust the remaining indexes to account for the
-         *                     removals.
+         * inactiveSynapseIdxs: OUT Synapse indexes corresponding to inactive
+         *                     synapses in the segment. Sorted in
+         *                     ascending order. The elements here correlate to
+         *                     elements in inactiveSrcCellIdxs.
          *
-         * activeSynapseIdxs:  Synapse indexes corresponding to all active
-         *                     synapses in the segment prior to removal of some
-         *                     inactive synapses by Segment::updateSynapses. In
-         *                     ascending order. We will adjust these indexes to
-         *                     account for the removals of inactive synapses.
+         * activeSrcCellIdxs:  OUT Source cell indexes corresponding to
+         *                     active synapses in the segment. Ordered by
+         *                     relative position of the corresponding InSynapses
+         *                     in the segment. The elements correlate to
+         *                     elements in activeSynapseIdxs.
+         *
+         * activeSynapseIdxs:  OUT Synapse indexes corresponding to active
+         *                     synapses in the segment. In ascending order. The
+         *                     elements correlate to elements in
+         *                     activeSrcCellIdxs.
+         *
          */
-        static void _fixupIndexesAfterSynapseRemovalsInAdaptSegment(
-          std::vector<UInt>& removedSrcCellIdxs,
+        static void _generateListsOfSynapsesToAdjustForAdaptSegment(
+          const Segment& segment,
+          std::set<UInt>& synapsesSet,
           std::vector<UInt>& inactiveSrcCellIdxs,
           std::vector<UInt>& inactiveSynapseIdxs,
+          std::vector<UInt>& activeSrcCellIdxs,
           std::vector<UInt>& activeSynapseIdxs);
 
         //-----------------------------------------------------------------------

--- a/src/nupic/algorithms/Cells4.hpp
+++ b/src/nupic/algorithms/Cells4.hpp
@@ -960,6 +960,52 @@ namespace nupic {
          */
         void applyGlobalDecay();
 
+        /**
+         * This private function contains specialized logic used by
+         * Cells4::adaptSegment to fix up several internal containers after
+         * deletion of synapses. We break it out into a separate function to
+         * facilitate unit testing.
+         *
+         * Parameters:
+         *
+         * removedSrcCellIdxs: Source cell indexes corresponding to inactive
+         *                     synapses that were removed by
+         *                     Segment::updateSynapses. Ordered by relative
+         *                     position of the corresponding InSynapses in the
+         *                     segment. The contents are a subset of the values
+         *                     in inactiveSrcCellIdxs arg.
+         *
+         * inactiveSrcCellIdxs: Source cell indexes corresponding to all
+         *                     inactive synapses prior to removal of some
+         *                     synapses by Segment::updateSynapses. Ordered by
+         *                     relative position of the corresponding InSynapses
+         *                     in the segment. The elements here match
+         *                     corresponding elements in the inactiveSynapseIdxs
+         *                     arg. We will remove elements matching the ones in
+         *                     the removedSrcCellIdxs arg.
+         *
+         * inactiveSynapseIdxs: Synapse indexes corresponding to all inactive
+         *                     synapses prior to removal of some inactive
+         *                     synapses by Segment::updateSynapses. Sorted in
+         *                     ascending order. The elements here match
+         *                     corresponding elements in the inactiveSrcCellIdxs
+         *                     arg. We will remove elements corresponding to the
+         *                     ones removed from the inactiveSrcCellIdxs arg and
+         *                     adjust the remaining indexes to account for the
+         *                     removals.
+         *
+         * activeSynapseIdxs:  Synapse indexes corresponding to all active
+         *                     synapses in the segment prior to removal of some
+         *                     inactive synapses by Segment::updateSynapses. In
+         *                     ascending order. We will adjust these indexes to
+         *                     account for the removals of inactive synapses.
+         */
+        static void _fixupIndexesAfterSynapseRemovalsInAdaptSegment(
+          std::vector<UInt>& removedSrcCellIdxs,
+          std::vector<UInt>& inactiveSrcCellIdxs,
+          std::vector<UInt>& inactiveSynapseIdxs,
+          std::vector<UInt>& activeSynapseIdxs);
+
         //-----------------------------------------------------------------------
         /**
          * Applies segment update information to a segment in a cell as follows:

--- a/src/nupic/algorithms/Segment.cpp
+++ b/src/nupic/algorithms/Segment.cpp
@@ -351,6 +351,8 @@ void Segment::freeNSynapses(UInt numToFree,
                             std::vector<UInt>& removed, UInt verbosity,
                             UInt nCellsPerCol, Real permMax)
 {
+  // ZZZ inactiveSynapseIndices, activeSynapseIndices, and nCellsPerCol are not
+  // needed by this function.
 
   NTA_CHECK(inactiveSegmentIndices.size() == inactiveSynapseIndices.size());
 

--- a/src/nupic/algorithms/Segment.cpp
+++ b/src/nupic/algorithms/Segment.cpp
@@ -351,10 +351,8 @@ void Segment::freeNSynapses(UInt numToFree,
                             std::vector<UInt>& removed, UInt verbosity,
                             UInt nCellsPerCol, Real permMax)
 {
-  // ZZZ inactiveSynapseIndices, activeSynapseIndices, and nCellsPerCol are not
-  // needed by this function.
-
   NTA_CHECK(inactiveSegmentIndices.size() == inactiveSynapseIndices.size());
+  NTA_CHECK(activeSegmentIndices.size() == activeSynapseIndices.size());
 
   if (verbosity >= 4) {
     std::cout << "\nIn CPP freeNSynapses with numToFree = " << numToFree

--- a/src/nupic/algorithms/Segment.cpp
+++ b/src/nupic/algorithms/Segment.cpp
@@ -353,6 +353,9 @@ void Segment::freeNSynapses(UInt numToFree,
 {
   NTA_CHECK(inactiveSegmentIndices.size() == inactiveSynapseIndices.size());
   NTA_CHECK(activeSegmentIndices.size() == activeSynapseIndices.size());
+  NTA_ASSERT(numToFree <= _synapses.size());
+  NTA_ASSERT(numToFree <=
+             (inactiveSegmentIndices.size() + activeSegmentIndices.size()));
 
   if (verbosity >= 4) {
     std::cout << "\nIn CPP freeNSynapses with numToFree = " << numToFree

--- a/src/nupic/algorithms/Segment.hpp
+++ b/src/nupic/algorithms/Segment.hpp
@@ -622,7 +622,7 @@ namespace nupic {
         //-----------------------------------------------------------------------
         /**
          * Updates synapses permanences, possibly removing synapses from the segment if their
-         * permanence drops below 0.
+         * permanence drops to or below 0.
          *
          * Parameters:
          * ==========

--- a/src/test/unit/algorithms/Cells4Test.cpp
+++ b/src/test/unit/algorithms/Cells4Test.cpp
@@ -88,6 +88,33 @@ TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoRemovals)
 
 
 /*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with
+ * consecutive removals.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithConsecutiveRemovals)
+{
+  std::vector<UInt> removedSrcCellIdxs  {    88, 77,         44};
+  std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  std::vector<UInt> activeSynapseIdxs {2, 4, 6, 9, 10, 50, 60};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {88, 77, 44};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {99, 66, 55};
+  const std::vector<UInt> expectedInactiveSynapseIdxs {1, 9, 10};
+  const std::vector<UInt> expectedActiveSynapseIdxs {2, 3, 5, 7, 8, 47, 57};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
  * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment without inactive
  * synapses.
  */

--- a/src/test/unit/algorithms/Cells4Test.cpp
+++ b/src/test/unit/algorithms/Cells4Test.cpp
@@ -41,12 +41,12 @@ TEST(Cells4Test, fixupIndexesInAdaptSegmentWithRemovalsInMiddleAndEdges)
   std::vector<UInt> removedSrcCellIdxs {99, 77, 44};
   std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
   std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
-  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 6, 9, 10, 50, 60};
 
   const std::vector<UInt> expectedRemovedSrcCellIdxs {99, 77, 44};
   const std::vector<UInt> expectedInactiveSrcCellIdxs {88, 66, 55};
   const std::vector<UInt> expectedInactiveSynapseIdxs { 2,  9, 10};
-  const std::vector<UInt> expectedActiveSynapseIdxs {0,  1, 3, 6, 7, 47, 57};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0,  1, 3, 5, 7, 8, 47, 57};
 
   Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
                                                           inactiveSrcCellIdxs,
@@ -88,8 +88,8 @@ TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoRemovals)
 
 
 /*
- * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with removals,
- * inactive, and active synapses.
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment without inactive
+ * synapses.
  */
 TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoInactiveSynapses)
 {

--- a/src/test/unit/algorithms/Cells4Test.cpp
+++ b/src/test/unit/algorithms/Cells4Test.cpp
@@ -1,0 +1,250 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * Implementation of unit tests for Segment
+ */
+
+#include <vector>
+
+#include <nupic/algorithms/Cells4.hpp>
+#include <gtest/gtest.h>
+
+using namespace nupic::algorithms::Cells4;
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with removals,
+ * inactive, and active synapses.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithRemovalsInMiddleAndEdges)
+{
+  std::vector<UInt> removedSrcCellIdxs {99, 77, 44};
+  std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {99, 77, 44};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {88, 66, 55};
+  const std::vector<UInt> expectedInactiveSynapseIdxs { 2,  9, 10};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0,  1, 3, 6, 7, 47, 57};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with nothing
+ * removed.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoRemovals)
+{
+  std::vector<UInt> removedSrcCellIdxs {};
+  std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  const std::vector<UInt> expectedInactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with removals,
+ * inactive, and active synapses.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoInactiveSynapses)
+{
+  std::vector<UInt> removedSrcCellIdxs {};
+  std::vector<UInt> inactiveSrcCellIdxs {};
+  std::vector<UInt> inactiveSynapseIdxs {};
+  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSynapseIdxs {};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with no
+ * active synapses.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoActiveSynapses)
+{
+  std::vector<UInt> removedSrcCellIdxs {99, 77, 44};
+  std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  std::vector<UInt> activeSynapseIdxs {};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {99, 77, 44};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {88, 66, 55};
+  const std::vector<UInt> expectedInactiveSynapseIdxs { 2,  9, 10};
+  const std::vector<UInt> expectedActiveSynapseIdxs {};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with one
+ * removal in middle, and with innactive, and active synapses.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithSingleRemovalInMiddle)
+{
+  std::vector<UInt> removedSrcCellIdxs {77};
+  std::vector<UInt> inactiveSrcCellIdxs {99, 88, 77, 66, 55, 44};
+  std::vector<UInt> inactiveSynapseIdxs { 1,  3,  7, 11, 12, 23};
+  std::vector<UInt> activeSynapseIdxs {0, 2, 4, 8, 9, 50, 60};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {77};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {99, 88, 66, 55, 44};
+  const std::vector<UInt> expectedInactiveSynapseIdxs { 1,  3, 10, 11, 22};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0, 2, 4, 7, 8, 49, 59};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with one
+ * removal, single inactive synapse, and active synapses out of range.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithSingleRemovalSingleInactiveAndSingleActiveOutOfRange)
+{
+  std::vector<UInt> removedSrcCellIdxs {77};
+  std::vector<UInt> inactiveSrcCellIdxs {77};
+  std::vector<UInt> inactiveSynapseIdxs {7};
+  std::vector<UInt> activeSynapseIdxs {0};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {77};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSynapseIdxs {};
+  const std::vector<UInt> expectedActiveSynapseIdxs {0};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+
+
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with one
+ * removal, single inactive synapse, and single active in range.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithSingleRemovalSingleInactiveAndSingleActiveInRange)
+{
+  std::vector<UInt> removedSrcCellIdxs {77};
+  std::vector<UInt> inactiveSrcCellIdxs {77};
+  std::vector<UInt> inactiveSynapseIdxs {7};
+  std::vector<UInt> activeSynapseIdxs {8};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {77};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSynapseIdxs {};
+  const std::vector<UInt> expectedActiveSynapseIdxs {7};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}
+/*
+ * Test Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment with no
+ * synapses.
+ */
+TEST(Cells4Test, fixupIndexesInAdaptSegmentWithNoSynapses)
+{
+  std::vector<UInt> removedSrcCellIdxs {};
+  std::vector<UInt> inactiveSrcCellIdxs {};
+  std::vector<UInt> inactiveSynapseIdxs {};
+  std::vector<UInt> activeSynapseIdxs {};
+
+  const std::vector<UInt> expectedRemovedSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSrcCellIdxs {};
+  const std::vector<UInt> expectedInactiveSynapseIdxs {};
+  const std::vector<UInt> expectedActiveSynapseIdxs {};
+
+  Cells4::_fixupIndexesAfterSynapseRemovalsInAdaptSegment(removedSrcCellIdxs,
+                                                          inactiveSrcCellIdxs,
+                                                          inactiveSynapseIdxs,
+                                                          activeSynapseIdxs);
+
+  ASSERT_EQ(expectedRemovedSrcCellIdxs, removedSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSrcCellIdxs, inactiveSrcCellIdxs);
+  ASSERT_EQ(expectedInactiveSynapseIdxs, inactiveSynapseIdxs);
+  ASSERT_EQ(expectedActiveSynapseIdxs, activeSynapseIdxs);
+}

--- a/src/test/unit/algorithms/SegmentTest.cpp
+++ b/src/test/unit/algorithms/SegmentTest.cpp
@@ -32,7 +32,7 @@ using namespace nupic::algorithms::Cells4;
 using namespace std;
 
 
-void setUpSegment(Segment &segment, 
+void setUpSegment(Segment &segment,
                   vector<UInt> &inactiveSegmentIndices,
                   vector<UInt> &activeSegmentIndices,
                   vector<UInt> &activeSynapseIndices,
@@ -76,7 +76,7 @@ TEST(SegmentTest, freeNSynapsesInactiveFirst)
   vector<UInt> inactiveSynapseIndices;
   vector<UInt> removed;
 
-  setUpSegment(segment, 
+  setUpSegment(segment,
                inactiveSegmentIndices,
                activeSegmentIndices,
                activeSynapseIndices,
@@ -100,7 +100,7 @@ TEST(SegmentTest, freeNSynapsesInactiveFirst)
 }
 
 /*
-* Test that active synapses are removed once all active synapses are
+* Test that active synapses are removed once all inactive synapses are
 * exhausted.
 */
 TEST(SegmentTest, freeNSynapsesActiveFallback)
@@ -114,7 +114,7 @@ TEST(SegmentTest, freeNSynapsesActiveFallback)
   vector<UInt> inactiveSynapseIndices;
   vector<UInt> removed;
 
-  setUpSegment(segment, 
+  setUpSegment(segment,
                inactiveSegmentIndices,
                activeSegmentIndices,
                activeSynapseIndices,
@@ -150,7 +150,7 @@ TEST(SegmentTest, freeNSynapsesStableSort)
   vector<UInt> inactiveSynapseIndices;
   vector<UInt> removed;
 
-  setUpSegment(segment, 
+  setUpSegment(segment,
                inactiveSegmentIndices,
                activeSegmentIndices,
                activeSynapseIndices,


### PR DESCRIPTION
Fixes #1014.

This PR prevents wrong synapses from being deleted by `Segment::freeNSynapses` when `segment.updateSynapses` invalidates the lists of candidate synapses in `Cells4::adaptSegment`.

NOTE: Once this PR is merged, need to merge nupic PR https://github.com/numenta/nupic/pull/3469 that updates nupic test `tests/integration/nupic/opf/hotgym_regression_test.py`