### PR TITLE
Get rid of SWIG warnings by importing base class and ignoring read/wr…

### DIFF
--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -24,6 +24,8 @@
 %include <nupic/bindings/exception.i>
 %import <nupic/bindings/math.i>
 
+%import "nupic/types/Serializable.hpp"
+
 %pythoncode %{
 import os
 
@@ -636,68 +638,6 @@ void forceRetentionOfImageSensorLiteLibrary(void) {
 }
 
 //--------------------------------------------------------------------------------
-// LearningSet for continuous FDR TP
-//--------------------------------------------------------------------------------
-%extend nupic::algorithms::Inhibition
-{
-  %pythoncode %{
-
-    def __init__(self, *args):
-      this = _ALGORITHMS.new_Inhibition(*args)
-      try:
-        self.this.append(this)
-      except:
-        self.this = this
-  %}
-
-  inline
-    nupic::UInt32 compute(PyObject* py_x, PyObject* py_y, nupic::UInt32 stimulus_threshold,
-                          nupic::Real32 k =.95f)
-  {
-    PyArrayObject* _x = (PyArrayObject*) py_x;
-    CHECKSIZE(_x);
-    nupic::Real32* x = (nupic::Real32*)(PyArray_DATA(_x));
-
-    PyArrayObject* _y = (PyArrayObject*) py_y;
-    CHECKSIZE(_y);
-    nupic::UInt32* y = (nupic::UInt32*)(PyArray_DATA(_y));
-
-    return self->compute(x, y, stimulus_threshold, k);
-  }
-
-}; // end extend nupic::Inhibition
-
-//--------------------------------------------------------------------------------
-%extend nupic::algorithms::Inhibition2
-{
-  %pythoncode %{
-
-    def __init__(self, *args):
-      this = _ALGORITHMS.new_Inhibition2(*args)
-      try:
-        self.this.append(this)
-      except:
-        self.this = this
-  %}
-
-  inline
-    nupic::UInt32 compute(PyObject* py_x, PyObject* py_y,
-        nupic::Real32 stimulus_threshold, nupic::Real32 add_to_winners)
-  {
-    PyArrayObject* _x = (PyArrayObject*) py_x;
-    CHECKSIZE(_x);
-    nupic::Real32* x = (nupic::Real32*)(PyArray_DATA(_x));
-
-    PyArrayObject* _y = (PyArrayObject*) py_y;
-    CHECKSIZE(_y);
-    nupic::UInt32* y = (nupic::UInt32*)(PyArray_DATA(_y));
-
-    return self->compute(x, y, stimulus_threshold, add_to_winners);
-  }
-
-}; // end extend nupic::Inhibition2
-
-//--------------------------------------------------------------------------------
 %inline {
 
 inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 ncols,
@@ -1004,6 +944,15 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
     return y.forPython();
   }
 }
+
+
+//----------------------------------------------------------------------
+// Spatial Pooler
+//----------------------------------------------------------------------
+
+%template(SerializableSpatialPoolerProto) nupic::Serializable<SpatialPoolerProto>;
+%ignore nupic::algorithms::spatial_pooler::SpatialPooler::read;
+%ignore nupic::algorithms::spatial_pooler::SpatialPooler::write;
 
 // In these SWIG wrapper methods, don't use the `const` qualifier. There has to
 // be some difference in the method signature so that C++ function overloading
@@ -1312,6 +1261,14 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 }
 
 
+//----------------------------------------------------------------------
+// CLA Classifier
+//----------------------------------------------------------------------
+
+%template(SerializableClaClassifierProto) nupic::Serializable<ClaClassifierProto>;
+%ignore nupic::algorithms::cla_classifier::FastCLAClassifier::read;
+%ignore nupic::algorithms::cla_classifier::FastCLAClassifier::write;
+
 %include <nupic/algorithms/FastClaClassifier.hpp>
 
 %pythoncode %{
@@ -1476,6 +1433,14 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 }
 
 
+//----------------------------------------------------------------------
+// SDR Classifier
+//----------------------------------------------------------------------
+
+%template(SerializableSdrClassifierProto) nupic::Serializable<SdrClassifierProto>;
+%ignore nupic::algorithms::sdr_classifier::SDRClassifier::read;
+%ignore nupic::algorithms::sdr_classifier::SDRClassifier::write;
+
 %include <nupic/algorithms/SDRClassifier.hpp>
 
 %pythoncode %{
@@ -1639,6 +1604,15 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 
 }
 
+
+//----------------------------------------------------------------------
+// Connections
+//----------------------------------------------------------------------
+
+%template(SerializableConnectionsProto) nupic::Serializable<ConnectionsProto>;
+%ignore nupic::algorithms::connections::Connections::read;
+%ignore nupic::algorithms::connections::Connections::write;
+
 //--------------------------------------------------------------------------------
 // Data structures (Connections)
 %rename(ConnectionsSynapse) nupic::algorithms::connections::Synapse;
@@ -1742,9 +1716,14 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 }
 
 
-//--------------------------------------------------------------------------------
+//----------------------------------------------------------------------
 // Temporal Memory
-//--------------------------------------------------------------------------------
+//----------------------------------------------------------------------
+
+%template(SerializableTemporalMemoryProto) nupic::Serializable<TemporalMemoryProto>;
+%ignore nupic::algorithms::temporal_memory::TemporalMemory::read;
+%ignore nupic::algorithms::temporal_memory::TemporalMemory::write;
+
 %inline %{
   template <typename IntType>
   inline PyObject* vectorToList(const vector<IntType> &cellIdxs)

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -950,6 +950,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // Spatial Pooler
 //----------------------------------------------------------------------
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::algorithms::spatial_pooler::SpatialPooler;
 %template(SerializableSpatialPoolerProto) nupic::Serializable<SpatialPoolerProto>;
 %ignore nupic::algorithms::spatial_pooler::SpatialPooler::read;
 %ignore nupic::algorithms::spatial_pooler::SpatialPooler::write;
@@ -1265,6 +1267,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // CLA Classifier
 //----------------------------------------------------------------------
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::algorithms::cla_classifier::FastCLAClassifier;
 %template(SerializableClaClassifierProto) nupic::Serializable<ClaClassifierProto>;
 %ignore nupic::algorithms::cla_classifier::FastCLAClassifier::read;
 %ignore nupic::algorithms::cla_classifier::FastCLAClassifier::write;
@@ -1437,6 +1441,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // SDR Classifier
 //----------------------------------------------------------------------
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::algorithms::sdr_classifier::SDRClassifier;
 %template(SerializableSdrClassifierProto) nupic::Serializable<SdrClassifierProto>;
 %ignore nupic::algorithms::sdr_classifier::SDRClassifier::read;
 %ignore nupic::algorithms::sdr_classifier::SDRClassifier::write;
@@ -1609,6 +1615,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // Connections
 //----------------------------------------------------------------------
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::algorithms::connections::Connections;
 %template(SerializableConnectionsProto) nupic::Serializable<ConnectionsProto>;
 %ignore nupic::algorithms::connections::Connections::read;
 %ignore nupic::algorithms::connections::Connections::write;
@@ -1720,6 +1728,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 // Temporal Memory
 //----------------------------------------------------------------------
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::algorithms::temporal_memory::TemporalMemory;
 %template(SerializableTemporalMemoryProto) nupic::Serializable<TemporalMemoryProto>;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::read;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::write;

--- a/src/nupic/bindings/engine_internal.i
+++ b/src/nupic/bindings/engine_internal.i
@@ -46,9 +46,6 @@
  * ----------------------------------------------------------------------
 */
 
-#include <nupic/engine/Input.hpp>
-#include <nupic/engine/Link.hpp>
-
 #include <nupic/types/Types.hpp>
 #include <nupic/types/Types.h>
 #include <nupic/types/BasicType.hpp>
@@ -75,6 +72,7 @@
 
 #include <nupic/engine/Spec.hpp>
 #include <nupic/utils/Watcher.hpp>
+#include <nupic/engine/Input.hpp>
 #include <nupic/engine/Region.hpp>
 #include <nupic/engine/Link.hpp>
 #include <nupic/os/Timer.hpp>
@@ -129,6 +127,10 @@ class IterablePair(object):
 %include <nupic/types/BasicType.hpp>
 %include <nupic/types/Exception.hpp>
 
+// Needed so SWIG knows about the base class but doesn't actually wrap
+// the class.
+%import "nupic/types/Serializable.hpp"
+
 // For Network::get/setPhases()
 %template(UInt32Set) std::set<nupic::UInt32>;
 
@@ -148,6 +150,10 @@ class IterablePair(object):
 %template(ParameterCollection) nupic::Collection<nupic::ParameterSpec>;
 %template(CommandCollection) nupic::Collection<nupic::CommandSpec>;
 %template(RegionCollection) nupic::Collection<nupic::Region *>;
+
+%template(SerializableLinkProto) nupic::Serializable<LinkProto>;
+%ignore nupic::Link::read;
+%ignore nupic::Link::write;
 %template(LinkCollection) nupic::Collection<nupic::Link *>;
 %extend nupic::Collection< nupic::Link * >
 {
@@ -158,10 +164,18 @@ class IterablePair(object):
 }
 
 %include <nupic/engine/NuPIC.hpp>
+
+%template(SerializableNetworkProto) nupic::Serializable<NetworkProto>;
+%ignore nupic::Network::read;
+%ignore nupic::Network::write;
 %include <nupic/engine/Network.hpp>
+
 %ignore nupic::Region::getInputData;
 %ignore nupic::Region::getOutputData;
+
+%template(SerializableRegionProto) nupic::Serializable<RegionProto>;
 %include <nupic/engine/Region.hpp>
+
 %include <nupic/utils/Watcher.hpp>
 %include <nupic/engine/Spec.hpp>
 %include <nupic/engine/Link.hpp>
@@ -171,6 +185,7 @@ class IterablePair(object):
 %template(ParameterPair) std::pair<std::string, nupic::ParameterSpec>;
 %template(CommandPair) std::pair<std::string, nupic::CommandSpec>;
 %template(RegionPair) std::pair<std::string, nupic::Region *>;
+
 %template(LinkPair) std::pair<std::string, nupic::Link *>;
 %extend std::pair<std::string, nupic::Link *>
 {
@@ -222,6 +237,10 @@ class IterablePair(object):
 }
 
 
+//----------------------------------------------------------------------
+// Region
+//----------------------------------------------------------------------
+
 %extend nupic::Region
 {
 
@@ -254,6 +273,11 @@ class IterablePair(object):
     }
   }
 }
+
+
+//----------------------------------------------------------------------
+// Network
+//----------------------------------------------------------------------
 
 %extend nupic::Network
 {

--- a/src/nupic/bindings/engine_internal.i
+++ b/src/nupic/bindings/engine_internal.i
@@ -151,6 +151,8 @@ class IterablePair(object):
 %template(CommandCollection) nupic::Collection<nupic::CommandSpec>;
 %template(RegionCollection) nupic::Collection<nupic::Region *>;
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::Link;
 %template(SerializableLinkProto) nupic::Serializable<LinkProto>;
 %ignore nupic::Link::read;
 %ignore nupic::Link::write;
@@ -165,6 +167,8 @@ class IterablePair(object):
 
 %include <nupic/engine/NuPIC.hpp>
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::Network;
 %template(SerializableNetworkProto) nupic::Serializable<NetworkProto>;
 %ignore nupic::Network::read;
 %ignore nupic::Network::write;
@@ -173,6 +177,8 @@ class IterablePair(object):
 %ignore nupic::Region::getInputData;
 %ignore nupic::Region::getOutputData;
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::Region;
 %template(SerializableRegionProto) nupic::Serializable<RegionProto>;
 %include <nupic/engine/Region.hpp>
 

--- a/src/nupic/bindings/math.i
+++ b/src/nupic/bindings/math.i
@@ -175,6 +175,8 @@ import_array();
 
 // ----- Random -----
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::Random;
 %template(SerializableRandomProto) nupic::Serializable<RandomProto>;
 %ignore nupic::Random::read;
 %ignore nupic::Random::write;

--- a/src/nupic/bindings/math.i
+++ b/src/nupic/bindings/math.i
@@ -84,10 +84,11 @@ import_array();
 %include <nupic/bindings/types.i>
 %include <nupic/bindings/reals.i>
 
+%import "nupic/types/Serializable.hpp"
+
 ///////////////////////////////////////////////////////////////////
 /// Utility functions that are expensive in Python but fast in C.
 ///////////////////////////////////////////////////////////////////
-
 
 %include <nupic/bindings/sparse_matrix.i>
 %include <nupic/bindings/sparse_tensor.i>
@@ -169,9 +170,15 @@ import_array();
 
 %include <nupic/math/Functions.hpp>
 
+%import <nupic/types/Exception.hpp>
+%include <nupic/utils/LoggingException.hpp>
+
 // ----- Random -----
 
-%include <nupic/utils/LoggingException.hpp>
+%template(SerializableRandomProto) nupic::Serializable<RandomProto>;
+%ignore nupic::Random::read;
+%ignore nupic::Random::write;
+
 %include <nupic/utils/Random.hpp>
 
 %extend nupic::Random {

--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -55,9 +55,19 @@ import numbers
 //--------------------------------------------------------------------------------
 %include <nupic/math/Math.hpp>
 %include <nupic/math/Domain.hpp>
+
+%template(SerializableSparseMatrixProto) nupic::Serializable<SparseMatrixProto>;
+%ignore nupic::SparseMatrix::read;
+%ignore nupic::SparseMatrix::write;
 %include <nupic/math/SparseMatrix.hpp>
+
 %include <nupic/math/SparseMatrixAlgorithms.hpp>
+
+%template(SerializableSparseBinaryMatrixProto) nupic::Serializable<SparseBinaryMatrixProto>;
+%ignore nupic::SparseBinaryMatrix::read;
+%ignore nupic::SparseBinaryMatrix::write;
 %include <nupic/math/SparseBinaryMatrix.hpp>
+
  //%include <nupic/math/SparseRLEMatrix.hpp>
 
 %template(_Domain32) nupic::Domain<nupic::UInt32>;

--- a/src/nupic/bindings/sparse_matrix.i
+++ b/src/nupic/bindings/sparse_matrix.i
@@ -56,17 +56,20 @@ import numbers
 %include <nupic/math/Math.hpp>
 %include <nupic/math/Domain.hpp>
 
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::SparseMatrix;
 %template(SerializableSparseMatrixProto) nupic::Serializable<SparseMatrixProto>;
 %ignore nupic::SparseMatrix::read;
 %ignore nupic::SparseMatrix::write;
-%include <nupic/math/SparseMatrix.hpp>
-
-%include <nupic/math/SparseMatrixAlgorithms.hpp>
-
+// Ensure constructor is generated even if SWIG thinks the class is abstract
+%feature("notabstract") nupic::SparseBinaryMatrix;
 %template(SerializableSparseBinaryMatrixProto) nupic::Serializable<SparseBinaryMatrixProto>;
 %ignore nupic::SparseBinaryMatrix::read;
 %ignore nupic::SparseBinaryMatrix::write;
+%include <nupic/math/SparseMatrix.hpp>
 %include <nupic/math/SparseBinaryMatrix.hpp>
+
+%include <nupic/math/SparseMatrixAlgorithms.hpp>
 
  //%include <nupic/math/SparseRLEMatrix.hpp>
 


### PR DESCRIPTION
…ite functions that can't be wrapped. Also removed some dead code and tried to organize the code a little better.

fixes #759 