### PR TITLE
Change segments to UInt32 to speed up the bindings

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -97,12 +97,12 @@ Segment Connections::createSegment(CellIdx cell)
   }
   else
   {
-    segment.flatIdx = segments_.size();
+    segment = segments_.size();
     segments_.push_back(SegmentData());
     segmentOrdinals_.push_back(0);
   }
 
-  SegmentData& segmentData = segments_[segment.flatIdx];
+  SegmentData& segmentData = segments_[segment];
   segmentData.cell = cell;
   segmentData.lastUsedIteration = iteration_;
 
@@ -287,6 +287,21 @@ CellIdx Connections::cellForSegment(Segment segment) const
   return segments_[segment].cell;
 }
 
+void Connections::mapSegmentsToCells(
+  Segment* segments_begin, Segment* segments_end,
+  CellIdx* cells_begin) const
+{
+  CellIdx* out = cells_begin;
+
+  for (Segment* segment = segments_begin;
+       segment != segments_end;
+       ++segment, ++out)
+  {
+    NTA_ASSERT(segmentExists_(*segment));
+    *out = segments_[*segment].cell;
+  }
+}
+
 Segment Connections::segmentForSynapse(Synapse synapse) const
 {
   return synapses_[synapse].segment;
@@ -300,11 +315,6 @@ const SegmentData& Connections::dataForSegment(Segment segment) const
 const SynapseData& Connections::dataForSynapse(Synapse synapse) const
 {
   return synapses_[synapse];
-}
-
-Segment Connections::segmentForFlatIdx(UInt32 flatIdx) const
-{
-  return {flatIdx};
 }
 
 UInt32 Connections::segmentFlatListLength() const
@@ -571,7 +581,7 @@ void Connections::load(std::istream& inStream)
 
         if (!destroyedSegment)
         {
-          segment.flatIdx = segments_.size();
+          segment = segments_.size();
           cellData.segments.push_back(segment);
           segments_.push_back(segmentData);
           segmentOrdinals_.push_back(nextSegmentOrdinal_++);
@@ -647,7 +657,7 @@ void Connections::read(ConnectionsProto::Reader& proto)
         const SegmentData segmentData = {vector<Synapse>(),
                                          protoSegments[j].getLastUsedIteration(),
                                          cell};
-        segment.flatIdx = segments_.size();
+        segment = segments_.size();
         cellData.segments.push_back(segment);
         segments_.push_back(segmentData);
         segmentOrdinals_.push_back(nextSegmentOrdinal_++);

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -288,12 +288,12 @@ CellIdx Connections::cellForSegment(Segment segment) const
 }
 
 void Connections::mapSegmentsToCells(
-  Segment* segments_begin, Segment* segments_end,
+  const Segment* segments_begin, const Segment* segments_end,
   CellIdx* cells_begin) const
 {
   CellIdx* out = cells_begin;
 
-  for (Segment* segment = segments_begin;
+  for (auto segment = segments_begin;
        segment != segments_end;
        ++segment, ++out)
   {

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -313,7 +313,7 @@ namespace nupic
          * Output array with the same length as 'segments'
          */
         void mapSegmentsToCells(
-          Segment* segments_begin, Segment* segments_end,
+          const Segment* segments_begin, const Segment* segments_end,
           CellIdx* cells_begin) const;
 
         /**

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -49,30 +49,7 @@ namespace nupic
       typedef UInt16 SynapseIdx;
       typedef Real32 Permanence;
       typedef UInt64 Iteration;
-
-      /**
-       * Segment struct used by Connections consumers.
-       *
-       * @b Description
-       * The Segment struct is used to refer to a segment. It contains a path to
-       * a SegmentData.
-       *
-       * @param flatIdx This segment's index in flattened lists of all segments.
-       */
-      struct Segment
-      {
-        UInt32 flatIdx;
-
-        // Use Segments as vector indices.
-        operator unsigned long() const { return flatIdx; };
-
-      private:
-        // The flatIdx ordering is not meaningful.
-        bool operator<=(const Segment &other) const;
-        bool operator<(const Segment &other) const;
-        bool operator>=(const Segment &other) const;
-        bool operator>(const Segment &other) const;
-      };
+      typedef UInt32 Segment;
 
       /**
        * Synapse struct used by Connections consumers.
@@ -216,8 +193,7 @@ namespace nupic
        * This class assigns each segment a unique "flatIdx" so that it's
        * possible to use a simple vector to associate segments with values.
        * Create a vector of length `connections.segmentFlatListLength()`,
-       * iterate over segments and update the vector at index `segment.flatIdx`,
-       * and then recover the segments using `connections.segmentForFlatIdx(i)`.
+       * iterate over segments and update the vector at index `segment`.
        *
        */
       class Connections : public Serializable<ConnectionsProto>
@@ -328,6 +304,19 @@ namespace nupic
         CellIdx cellForSegment(Segment segment) const;
 
         /**
+         * Get the cell for each provided segment.
+         *
+         * @param segments
+         * The segments to query
+         *
+         * @param cells
+         * Output array with the same length as 'segments'
+         */
+        void mapSegmentsToCells(
+          Segment* segments_begin, Segment* segments_end,
+          CellIdx* cells_begin) const;
+
+        /**
          * Gets the segment that this synapse is on.
          *
          * @param synapse Synapse to get Segment for.
@@ -365,17 +354,7 @@ namespace nupic
         Segment getSegment(CellIdx cell, SegmentIdx idx) const;
 
         /**
-         * Do a reverse-lookup of a segment from its flatIdx.
-         *
-         * @param flatIdx the flatIdx of the segment
-         *
-         * @retval Segment
-         */
-        Segment segmentForFlatIdx(UInt32 flatIdx) const;
-
-        /**
-         * Get the vector length needed to use the segments' flatIdx for
-         * indexing.
+         * Get the vector length needed to use segments as indices.
          *
          * @retval A vector length
          */

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -271,13 +271,6 @@ namespace nupic {
         */
         vector<CellIdx> getWinnerCells() const;
 
-        /**
-        * Returns the indices of the matching cells.
-        *
-        * @returns (std::vector<CellIdx>) Vector of indices of matching cells.
-        */
-        vector<CellIdx> getMatchingCells() const;
-
         vector<Segment> getActiveSegments() const;
         vector<Segment> getMatchingSegments() const;
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1642,9 +1642,7 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 //--------------------------------------------------------------------------------
 // Data structures (Connections)
 %rename(ConnectionsSynapse) nupic::algorithms::connections::Synapse;
-%rename(ConnectionsSegment) nupic::algorithms::connections::Segment;
 %template(ConnectionsSynapseVector) vector<nupic::algorithms::connections::Synapse>;
-%template(ConnectionsSegmentVector) vector<nupic::algorithms::connections::Segment>;
 %feature("director") nupic::algorithms::connections::ConnectionsEventHandler;
 %include <nupic/algorithms/Connections.hpp>
 
@@ -1693,6 +1691,23 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
     throw std::logic_error(
         "Connections.read is not implemented when compiled with CAPNP_LITE=1.");
   %#endif
+  }
+
+  %pythoncode %{
+    def mapSegmentsToCells(self, segments):
+      segments = numpy.asarray(segments, dtype="uint32")
+      return self._mapSegmentsToCells(segments)
+  %}
+
+  PyObject* _mapSegmentsToCells(PyObject *py_segments) const
+  {
+    nupic::NumpyVectorWeakRefT<nupic::UInt32> segments(py_segments);
+
+    nupic::NumpyVectorT<nupic::UInt32> cellsOut(segments.size());
+    self->mapSegmentsToCells(segments.begin(), segments.end(),
+                             cellsOut.begin());
+
+    return cellsOut.forPython();
   }
 
 }
@@ -1850,32 +1865,56 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 
   inline PyObject* getActiveCells()
   {
-    const vector<CellIdx> cellIdxs = self->getActiveCells();
-    return vectorToList(cellIdxs);
+    const vector<CellIdx> activeCells = self->getActiveCells();
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      activeCells.size(), activeCells.data()
+    ).forPython();
   }
 
   inline PyObject* getPredictiveCells()
   {
-    const vector<CellIdx> cellIdxs = self->getPredictiveCells();
-    return vectorToList(cellIdxs);
+    const vector<CellIdx> predictiveCells = self->getPredictiveCells();
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      predictiveCells.size(), predictiveCells.data()
+    ).forPython();
   }
 
   inline PyObject* getWinnerCells()
   {
-    const vector<CellIdx> cellIdxs = self->getWinnerCells();
-    return vectorToList(cellIdxs);
+    const vector<CellIdx> winnerCells = self->getWinnerCells();
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      winnerCells.size(), winnerCells.data()
+    ).forPython();
   }
 
-  inline PyObject* getMatchingCells()
+  inline PyObject* getActiveSegments()
   {
-    const vector<CellIdx> cellIdxs = self->getMatchingCells();
-    return vectorToList(cellIdxs);
+    const vector<UInt32> activeSegments = self->getActiveSegments();
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      activeSegments.size(), activeSegments.data()
+    ).forPython();
+  }
+
+  inline PyObject* getMatchingSegments()
+  {
+    const vector<UInt32> matchingSegments = self->getMatchingSegments();
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      matchingSegments.size(), matchingSegments.data()
+    ).forPython();
   }
 
   inline PyObject* cellsForColumn(UInt columnIdx)
   {
-    const vector<CellIdx> cellIdxs = self->cellsForColumn(columnIdx);
-    return vectorToList(cellIdxs);
+    const vector<CellIdx> cells = self->cellsForColumn(columnIdx);
+
+    return nupic::NumpyVectorT<nupic::UInt32>(
+      cells.size(), cells.data()
+    ).forPython();
   }
 
   inline void convertedActivateCells(PyObject *py_activeColumns,
@@ -1951,7 +1990,8 @@ inline PyObject* generate2DGaussianSample(nupic::UInt32 nrows, nupic::UInt32 nco
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::getActiveCells;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::getPredictiveCells;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::getWinnerCells;
-%ignore nupic::algorithms::temporal_memory::TemporalMemory::getMatchingCells;
+%ignore nupic::algorithms::temporal_memory::TemporalMemory::getActiveSegments;
+%ignore nupic::algorithms::temporal_memory::TemporalMemory::getMatchingSegments;
 %ignore nupic::algorithms::temporal_memory::TemporalMemory::cellsForColumn;
 
 

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -300,9 +300,11 @@ namespace nupic
   {
     // Activate every segment, then choose the top few.
     vector<Segment> activeSegments;
-    for (size_t i = 0; i < numActiveSynapsesForSegment.size(); i++)
+    for (Segment segment = 0;
+         segment < numActiveSynapsesForSegment.size();
+         segment++)
     {
-      activeSegments.push_back(connections.segmentForFlatIdx(i));
+      activeSegments.push_back(segment);
     }
 
     set<CellIdx> winnerCells;
@@ -310,8 +312,8 @@ namespace nupic
               [&](Segment a, Segment b)
               {
                 return
-                  numActiveSynapsesForSegment[a.flatIdx] >
-                  numActiveSynapsesForSegment[b.flatIdx];
+                  numActiveSynapsesForSegment[a] >
+                  numActiveSynapsesForSegment[b];
               });
 
     for (Segment segment : activeSegments)

--- a/src/test/integration/ConnectionsPerformanceTest.hpp
+++ b/src/test/integration/ConnectionsPerformanceTest.hpp
@@ -45,7 +45,7 @@ namespace nupic
 
     namespace connections
     {
-      struct Segment;
+      typedef UInt32 Segment;
     }
   }
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -261,8 +261,8 @@ namespace {
                                 {80, 81, 82},
                                 0.5);
 
-    ASSERT_EQ(0, numActiveConnectedSynapsesForSegment[segment2.flatIdx]);
-    ASSERT_EQ(0, numActivePotentialSynapsesForSegment[segment2.flatIdx]);
+    ASSERT_EQ(0, numActiveConnectedSynapsesForSegment[segment2]);
+    ASSERT_EQ(0, numActivePotentialSynapsesForSegment[segment2]);
   }
 
   /**
@@ -294,8 +294,8 @@ namespace {
                                 {80, 81, 82},
                                 0.5);
 
-    ASSERT_EQ(1, numActiveConnectedSynapsesForSegment[segment.flatIdx]);
-    ASSERT_EQ(2, numActivePotentialSynapsesForSegment[segment.flatIdx]);
+    ASSERT_EQ(1, numActiveConnectedSynapsesForSegment[segment]);
+    ASSERT_EQ(2, numActivePotentialSynapsesForSegment[segment]);
   }
 
   /**
@@ -537,11 +537,11 @@ namespace {
                                 input,
                                 0.5);
 
-    ASSERT_EQ(1, numActiveConnectedSynapsesForSegment[segment1_1.flatIdx]);
-    ASSERT_EQ(2, numActivePotentialSynapsesForSegment[segment1_1.flatIdx]);
+    ASSERT_EQ(1, numActiveConnectedSynapsesForSegment[segment1_1]);
+    ASSERT_EQ(2, numActivePotentialSynapsesForSegment[segment1_1]);
 
-    ASSERT_EQ(2, numActiveConnectedSynapsesForSegment[segment2_1.flatIdx]);
-    ASSERT_EQ(3, numActivePotentialSynapsesForSegment[segment2_1.flatIdx]);
+    ASSERT_EQ(2, numActiveConnectedSynapsesForSegment[segment2_1]);
+    ASSERT_EQ(3, numActivePotentialSynapsesForSegment[segment2_1]);
   }
 
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -545,6 +545,29 @@ namespace {
   }
 
 
+  /**
+   * Test the mapSegmentsToCells method.
+   */
+  TEST(ConnectionsTest, testMapSegmentsToCells)
+  {
+    Connections connections(1024);
+
+    const Segment segment1 = connections.createSegment(42);
+    const Segment segment2 = connections.createSegment(42);
+    const Segment segment3 = connections.createSegment(43);
+
+    const vector<Segment> segments = {segment1, segment2, segment3, segment1};
+    vector<CellIdx> cells(segments.size());
+
+    connections.mapSegmentsToCells(segments.data(),
+                                   segments.data() + segments.size(),
+                                   cells.data());
+
+    const vector<CellIdx> expected = {42, 42, 43, 42};
+    ASSERT_EQ(expected, cells);
+  }
+
+
 
   bool TEST_EVENT_HANDLER_DESTRUCTED = false;
 


### PR DESCRIPTION
Fixes #1254

Also add `mapSegmentsToCells` to take advantage of this.

Also remove `getMatchingCells`, which doesn't need to exist.