### PR TITLE
Stop messing up the refcount on Py_True and Py_False

### DIFF
--- a/src/nupic/py_support/PyHelpers.cpp
+++ b/src/nupic/py_support/PyHelpers.cpp
@@ -385,6 +385,7 @@ namespace nupic { namespace py
 
   Bool::Bool(bool b) : Ptr(b ? Py_True : Py_False)
   {
+    Py_XINCREF(p_);
   }
 
   Bool::Bool(PyObject * p) : Ptr(p)

--- a/src/nupic/py_support/PyHelpers.cpp
+++ b/src/nupic/py_support/PyHelpers.cpp
@@ -391,6 +391,7 @@ namespace nupic { namespace py
   Bool::Bool(PyObject * p) : Ptr(p)
   {
     NTA_CHECK(PyBool_Check(p_));
+    Py_XINCREF(p_);
   }
 
   Bool::operator bool()

--- a/src/test/unit/py_support/PyHelpersTest.cpp
+++ b/src/test/unit/py_support/PyHelpersTest.cpp
@@ -188,8 +188,8 @@ TEST_F(PyHelpersTest, pyFloat)
 
 TEST_F(PyHelpersTest, pyBool)
 {
-  const auto trueRefcount = Py_True->ob_refcnt;
-  const auto falseRefcount = Py_False->ob_refcnt;
+  const auto trueRefcount = Py_REFCNT(Py_True);
+  const auto falseRefcount = Py_REFCNT(Py_False);
 
   // Construct from true.
   {
@@ -198,8 +198,8 @@ TEST_F(PyHelpersTest, pyBool)
   }
 
   // Verify refcounts were preserved.
-  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
-  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+  ASSERT_EQ(trueRefcount, Py_REFCNT(Py_True));
+  ASSERT_EQ(falseRefcount, Py_REFCNT(Py_False));
 
   // Construct from false.
   {
@@ -208,8 +208,8 @@ TEST_F(PyHelpersTest, pyBool)
   }
 
   // Verify refcounts were preserved.
-  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
-  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+  ASSERT_EQ(trueRefcount, Py_REFCNT(Py_True));
+  ASSERT_EQ(falseRefcount, Py_REFCNT(Py_False));
 
   // Construct from an existing PyObject.
   {
@@ -219,8 +219,8 @@ TEST_F(PyHelpersTest, pyBool)
   }
 
   // Verify refcounts were preserved.
-  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
-  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+  ASSERT_EQ(trueRefcount, Py_REFCNT(Py_True));
+  ASSERT_EQ(falseRefcount, Py_REFCNT(Py_False));
 }
 
 TEST_F(PyHelpersTest, pyTupleEmpty)

--- a/src/test/unit/py_support/PyHelpersTest.cpp
+++ b/src/test/unit/py_support/PyHelpersTest.cpp
@@ -186,6 +186,30 @@ TEST_F(PyHelpersTest, pyFloat)
   ASSERT_TRUE(n5 == 0.02);
 }
 
+TEST_F(PyHelpersTest, pyBool)
+{
+  const auto trueRefcount = Py_True->ob_refcnt;
+  const auto falseRefcount = Py_False->ob_refcnt;
+
+  {
+    py::Bool t(true);
+    ASSERT_TRUE((bool)t);
+  }
+
+  // Verify refcounts were preserved.
+  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
+  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+
+  {
+    py::Bool f(false);
+    ASSERT_FALSE((bool)f);
+  }
+
+  // Verify refcounts were preserved.
+  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
+  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+}
+
 TEST_F(PyHelpersTest, pyTupleEmpty)
 {
   py::String s1("item_1");

--- a/src/test/unit/py_support/PyHelpersTest.cpp
+++ b/src/test/unit/py_support/PyHelpersTest.cpp
@@ -191,6 +191,7 @@ TEST_F(PyHelpersTest, pyBool)
   const auto trueRefcount = Py_True->ob_refcnt;
   const auto falseRefcount = Py_False->ob_refcnt;
 
+  // Construct from true.
   {
     py::Bool t(true);
     ASSERT_TRUE((bool)t);
@@ -200,9 +201,21 @@ TEST_F(PyHelpersTest, pyBool)
   ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
   ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
 
+  // Construct from false.
   {
     py::Bool f(false);
     ASSERT_FALSE((bool)f);
+  }
+
+  // Verify refcounts were preserved.
+  ASSERT_EQ(trueRefcount, Py_True->ob_refcnt);
+  ASSERT_EQ(falseRefcount, Py_False->ob_refcnt);
+
+  // Construct from an existing PyObject.
+  {
+    py::Bool t1(true);
+    py::Bool t2(&*t1);
+    ASSERT_TRUE((bool)t2);
   }
 
   // Verify refcounts were preserved.


### PR DESCRIPTION
Fixes #1294 

See the description in the issue.

Thanks @oxtopus for finding that this segfault often happens shortly after a time when we call `setParameter` with a `bool`.