### PR TITLE
Move segment/synapse cleanup out of Connections

### DIFF
--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -48,7 +48,6 @@ namespace nupic
       typedef UInt16 SegmentIdx;
       typedef UInt16 SynapseIdx;
       typedef Real32 Permanence;
-      typedef UInt64 Iteration;
       typedef UInt32 Segment;
 
       /**
@@ -102,16 +101,12 @@ namespace nupic
        * @param synapses
        * Synapses on this segment.
        *
-       * @param lastUsedIteration
-       * The iteration that this segment was last used.
-       *
        * @param cell
        * The cell that this segment is on.
        */
       struct SegmentData
       {
         std::vector<Synapse> synapses;
-        Iteration lastUsedIteration;
         CellIdx cell;
       };
 
@@ -211,11 +206,9 @@ namespace nupic
          * Connections constructor.
          *
          * @param numCells              Number of cells.
-         * @param maxSegmentsPerCell    Maximum number of segments per cell.
          * @param maxSynapsesPerSegment Maximum number of synapses per segment.
          */
         Connections(CellIdx numCells,
-                    SegmentIdx maxSegmentsPerCell=255,
                     SynapseIdx maxSynapsesPerSegment=255);
 
         virtual ~Connections() {}
@@ -224,11 +217,9 @@ namespace nupic
          * Initialize connections.
          *
          * @param numCells              Number of cells.
-         * @param maxSegmentsPerCell    Maximum number of segments per cell.
          * @param maxSynapsesPerSegment Maximum number of synapses per segment.
          */
         void initialize(CellIdx numCells,
-                        SegmentIdx maxSegmentsPerCell,
                         SynapseIdx maxSynapsesPerSegment);
 
         /**
@@ -433,21 +424,6 @@ namespace nupic
           CellIdx activePresynapticCell,
           Permanence connectedPermanence) const;
 
-        /**
-         * Record the fact that a segment had some activity. This information is
-         * used during segment cleanup.
-         *
-         * @param segment
-         * The segment that had some activity.
-         */
-        void recordSegmentActivity(Segment segment);
-
-        /**
-         * Mark the passage of time. This information is used during segment
-         * cleanup.
-         */
-        void startNewIteration();
-
         // Serialization
 
         /**
@@ -549,16 +525,6 @@ namespace nupic
       protected:
 
         /**
-         * Gets the segment that was least recently used from among all the
-         * segments on the given cell.
-         *
-         * @param cell Cell whose segments to consider.
-         *
-         * @retval The least recently used segment.
-         */
-        Segment leastRecentlyUsedSegment_(CellIdx cell) const;
-
-        /**
          * Gets the synapse with the lowest permanence on the segment.
          *
          * @param segment Segment whose synapses to consider.
@@ -607,9 +573,7 @@ namespace nupic
         UInt64 nextSegmentOrdinal_;
         UInt64 nextSynapseOrdinal_;
 
-        SegmentIdx maxSegmentsPerCell_;
         SynapseIdx maxSynapsesPerSegment_;
-        Iteration iteration_;
         UInt32 nextEventToken_;
         std::map<UInt32, ConnectionsEventHandler*> eventHandlers_;
       }; // end class Connections

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -206,10 +206,8 @@ namespace nupic
          * Connections constructor.
          *
          * @param numCells              Number of cells.
-         * @param maxSynapsesPerSegment Maximum number of synapses per segment.
          */
-        Connections(CellIdx numCells,
-                    SynapseIdx maxSynapsesPerSegment=255);
+        Connections(CellIdx numCells);
 
         virtual ~Connections() {}
 
@@ -217,10 +215,8 @@ namespace nupic
          * Initialize connections.
          *
          * @param numCells              Number of cells.
-         * @param maxSynapsesPerSegment Maximum number of synapses per segment.
          */
-        void initialize(CellIdx numCells,
-                        SynapseIdx maxSynapsesPerSegment);
+        void initialize(CellIdx numCells);
 
         /**
          * Creates a segment on the specified cell.
@@ -573,7 +569,6 @@ namespace nupic
         UInt64 nextSegmentOrdinal_;
         UInt64 nextSynapseOrdinal_;
 
-        SynapseIdx maxSynapsesPerSegment_;
         UInt32 nextEventToken_;
         std::map<UInt32, ConnectionsEventHandler*> eventHandlers_;
       }; // end class Connections

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -291,6 +291,15 @@ namespace nupic
         CellIdx cellForSegment(Segment segment) const;
 
         /**
+         * Gets the index of this segment on its respective cell.
+         *
+         * @param segment Segment to get the idx for.
+         *
+         * @retval Index of the segment.
+         */
+        SegmentIdx idxOnCellForSegment(Segment segment) const;
+
+        /**
          * Get the cell for each provided segment.
          *
          * @param segments

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -302,7 +302,6 @@ static void destroyMinPermanenceSynapses(
 
   // Find cells one at a time. This is slow, but this code rarely runs, and it
   // needs to work around floating point differences between environments.
-  vector<Synapse> toDestroy;
   for (Int32 i = 0; i < nDestroy && !destroyCandidates.empty(); i++)
   {
     Permanence minPermanence = std::numeric_limits<Permanence>::max();
@@ -324,13 +323,8 @@ static void destroyMinPermanenceSynapses(
       }
     }
 
-    toDestroy.push_back(*minSynapse);
+    connections.destroySynapse(*minSynapse);
     destroyCandidates.erase(minSynapse);
-  }
-
-  for (Synapse synapse : toDestroy)
-  {
-    connections.destroySynapse(synapse);
   }
 }
 
@@ -369,7 +363,7 @@ static void growSynapses(
 
   // Check if we're going to surpass the maximum number of synapses.
   const Int32 overrun = (connections.numSynapses(segment) +
-                         nDesiredNewSynapses - maxSynapsesPerSegment);
+                         nActual - maxSynapsesPerSegment);
   if (overrun > 0)
   {
     destroyMinPermanenceSynapses(connections, rng, segment, overrun,
@@ -446,7 +440,7 @@ static Segment createSegment(
   UInt64 iteration,
   UInt maxSegmentsPerCell)
 {
-  if (connections.numSegments(cell) >= maxSegmentsPerCell)
+  while (connections.numSegments(cell) >= maxSegmentsPerCell)
   {
     const vector<Segment>& destroyCandidates =
       connections.segmentsForCell(cell);

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -375,6 +375,20 @@ namespace nupic {
         void setPredictedSegmentDecrement(Permanence);
 
         /**
+         * Returns the maxSegmentsPerCell.
+         *
+         * @returns Max segments per cell
+         */
+        Permanence getMaxSegmentsPerCell() const;
+
+        /**
+         * Returns the maxSynapsesPerSegment.
+         *
+         * @returns Max synapses per segment
+         */
+        Permanence getMaxSynapsesPerSegment() const;
+
+        /**
          * Raises an error if cell index is invalid.
          *
          * @param cell Cell index
@@ -461,6 +475,7 @@ namespace nupic {
         vector<UInt32> numActivePotentialSynapsesForSegment_;
 
         UInt maxSegmentsPerCell_;
+        UInt maxSynapsesPerSegment_;
         UInt64 iteration_;
         vector<UInt64> lastUsedIterationForSegment_;
 

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -235,6 +235,20 @@ namespace nupic {
         // ==============================
 
         /**
+         * Create a segment on the specified cell. This method calls
+         * createSegment on the underlying connections, and it does some extra
+         * bookkeeping. Unit tests should call this method, and not
+         * connections.createSegment().
+         *
+         * @param cell
+         * Cell to add a segment to.
+         *
+         * @return Segment
+         * The created segment.
+         */
+        Segment createSegment(CellIdx cell);
+
+        /**
          * Returns the indices of cells that belong to a column.
          *
          * @param column Column index
@@ -445,6 +459,10 @@ namespace nupic {
         vector<Segment> matchingSegments_;
         vector<UInt32> numActiveConnectedSynapsesForSegment_;
         vector<UInt32> numActivePotentialSynapsesForSegment_;
+
+        UInt maxSegmentsPerCell_;
+        UInt64 iteration_;
+        vector<UInt64> lastUsedIterationForSegment_;
 
         Random rng_;
 

--- a/src/nupic/proto/ConnectionsProto.capnp
+++ b/src/nupic/proto/ConnectionsProto.capnp
@@ -1,25 +1,17 @@
 @0xb1b8a459d70716ad;
 
-# Next ID: 3
+# Next ID: 2
 struct ConnectionsProto {
 
-  # Next ID: 3
+  # Next ID: 2
   struct SynapseProto {
     presynapticCell @0 :UInt32;
     permanence @1 :Float32;
-
-    # Obsolete
-    destroyed @2 :Bool;
   }
 
-  # Next ID: 3
+  # Next ID: 1
   struct SegmentProto {
     synapses @0 :List(SynapseProto);
-
-    # Obsolete
-    destroyed @1 :Bool;
-
-    lastUsedIteration @2 :UInt64;
   }
 
   # Next ID: 1
@@ -27,14 +19,6 @@ struct ConnectionsProto {
     segments @0 :List(SegmentProto);
   }
 
-  # Next ID: 3
-  struct SegmentOverlapProto {
-    cell @0 :UInt32;
-    segment @1 :UInt32;
-    overlap @2 :UInt32;
-  }
-
   cells @0 :List(CellProto);
   version @1 :UInt16;
-
 }

--- a/src/nupic/proto/ConnectionsProto.capnp
+++ b/src/nupic/proto/ConnectionsProto.capnp
@@ -1,6 +1,6 @@
 @0xb1b8a459d70716ad;
 
-# Next ID: 5
+# Next ID: 3
 struct ConnectionsProto {
 
   # Next ID: 3
@@ -35,9 +35,7 @@ struct ConnectionsProto {
   }
 
   cells @0 :List(CellProto);
-  maxSegmentsPerCell @1 :UInt16;
-  iteration @2 :UInt64;
-  maxSynapsesPerSegment @3 :UInt16;
-  version @4 :UInt16;
+  maxSynapsesPerSegment @1 :UInt16;
+  version @2 :UInt16;
 
 }

--- a/src/nupic/proto/ConnectionsProto.capnp
+++ b/src/nupic/proto/ConnectionsProto.capnp
@@ -35,7 +35,6 @@ struct ConnectionsProto {
   }
 
   cells @0 :List(CellProto);
-  maxSynapsesPerSegment @1 :UInt16;
-  version @2 :UInt16;
+  version @1 :UInt16;
 
 }

--- a/src/nupic/proto/TemporalMemoryProto.capnp
+++ b/src/nupic/proto/TemporalMemoryProto.capnp
@@ -2,11 +2,27 @@
 
 # TODO: Use absolute path
 using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto;
-using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto.SegmentOverlapProto;
 using import "/nupic/proto/RandomProto.capnp".RandomProto;
 
-# Next ID: 23
+# Next ID: 22
 struct TemporalMemoryProto {
+
+  struct SegmentPath {
+    cell @0 :UInt32;
+    idxOnCell @1 :UInt32;
+  }
+
+  struct SegmentUInt32Pair {
+    cell @0 :UInt32;
+    idxOnCell @1 :UInt32;
+    number @2 :UInt32;
+  }
+
+  struct SegmentUInt64Pair {
+    cell @0 :UInt32;
+    idxOnCell @1 :UInt32;
+    number @2 :UInt64;
+  }
 
   columnDimensions @0 :List(UInt32);
   cellsPerColumn @1 :UInt32;
@@ -17,32 +33,23 @@ struct TemporalMemoryProto {
   minThreshold @6 :UInt32;
   maxNewSynapseCount @7 :UInt32;
   permanenceIncrement @8 :Float32;
-  permanenceDecrement @9 :Float32;  
+  permanenceDecrement @9 :Float32;
+  predictedSegmentDecrement @10 :Float32;
+  maxSegmentsPerCell @11 :UInt16;
+  maxSynapsesPerSegment @12 :UInt16;
 
-  connections @10 :ConnectionsProto;
-  random @11 :RandomProto;
+  connections @13 :ConnectionsProto;
+  random @14 :RandomProto;
 
   # Lists of indices
-  activeCells @12 :List(UInt32);
+  activeCells @15 :List(UInt32);
+  winnerCells @16 :List(UInt32);
 
-  # Obsolete, information contained in activeSegmentOverlaps
-  predictiveCells @13 :List(UInt32);
+  activeSegments @17 :List(SegmentPath);
+  matchingSegments @18 :List(SegmentPath);
 
-  # Obsolete, replaced by activeSegmentOverlaps
-  activeSegments @14 :List(UInt32);
+  numActivePotentialSynapsesForSegment @19 :List(SegmentUInt32Pair);
 
-  winnerCells @15 :List(UInt32);
-
-  # Obsolete, replaced by matchingSegmentOverlaps
-  matchingSegments @16 :List(UInt32);
-
-  # Obsolete, information contained in matchingSegmentOverlaps
-  matchingCells @17 :List(UInt32);
-
-  predictedSegmentDecrement @18 :Float32;
-  activeSegmentOverlaps @19 :List(SegmentOverlapProto);
-  matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
-
-  maxSegmentsPerCell @21 :UInt16;
-  maxSynapsesPerSegment @22 :UInt16;
+  iteration @20 :UInt64;
+  lastUsedIterationForSegment @21 :List(SegmentUInt64Pair);
 }

--- a/src/nupic/proto/TemporalMemoryProto.capnp
+++ b/src/nupic/proto/TemporalMemoryProto.capnp
@@ -42,4 +42,6 @@ struct TemporalMemoryProto {
   predictedSegmentDecrement @18 :Float32;
   activeSegmentOverlaps @19 :List(SegmentOverlapProto);
   matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
+
+  maxSegmentsPerCell @21 :UInt16;
 }

--- a/src/nupic/proto/TemporalMemoryProto.capnp
+++ b/src/nupic/proto/TemporalMemoryProto.capnp
@@ -5,7 +5,7 @@ using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto;
 using import "/nupic/proto/ConnectionsProto.capnp".ConnectionsProto.SegmentOverlapProto;
 using import "/nupic/proto/RandomProto.capnp".RandomProto;
 
-# Next ID: 21
+# Next ID: 23
 struct TemporalMemoryProto {
 
   columnDimensions @0 :List(UInt32);
@@ -44,4 +44,5 @@ struct TemporalMemoryProto {
   matchingSegmentOverlaps @20 :List(SegmentOverlapProto);
 
   maxSegmentsPerCell @21 :UInt16;
+  maxSynapsesPerSegment @22 :UInt16;
 }

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -156,7 +156,7 @@ namespace nupic
   {
     clock_t timer = clock();
 
-    Connections connections(numCells, 1, numInputs);
+    Connections connections(numCells, numInputs);
     Segment segment;
     vector<CellIdx> sdr;
 

--- a/src/test/integration/ConnectionsPerformanceTest.cpp
+++ b/src/test/integration/ConnectionsPerformanceTest.cpp
@@ -156,7 +156,7 @@ namespace nupic
   {
     clock_t timer = clock();
 
-    Connections connections(numCells, numInputs);
+    Connections connections(numCells);
     Segment segment;
     vector<CellIdx> sdr;
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -112,49 +112,6 @@ namespace {
   }
 
   /**
-   * Creates many segments on a cell, until hits segment limit. Then creates
-   * another segment, and checks that it destroyed the least recently used
-   * segment and created a new one in its place.
-   */
-  TEST(ConnectionsTest, testCreateSegmentReuse)
-  {
-    Connections connections(1024, 2);
-
-    Segment segment1 = connections.createSegment(42);
-    connections.createSynapse(segment1, 1, 0.5);
-    connections.createSynapse(segment1, 2, 0.5);
-
-    // Let some time pass.
-    connections.startNewIteration();
-    connections.startNewIteration();
-    connections.startNewIteration();
-
-    // Create a segment with 1 synapse.
-    Segment segment2 = connections.createSegment(42);
-    connections.createSynapse(segment2, 3, 0.5);
-
-    connections.startNewIteration();
-
-    // Give the first segment some activity.
-    connections.recordSegmentActivity(segment1);
-
-    // Create a new segment with no synapses.
-    connections.createSegment(42);
-
-    vector<Segment> segments = connections.segmentsForCell(42);
-    ASSERT_EQ(2, segments.size());
-
-    // Verify first segment is still there with the same synapses.
-    vector<Synapse> synapses1 = connections.synapsesForSegment(segments[0]);
-    ASSERT_EQ(2, synapses1.size());
-    ASSERT_EQ(1, connections.dataForSynapse(synapses1[0]).presynapticCell);
-    ASSERT_EQ(2, connections.dataForSynapse(synapses1[1]).presynapticCell);
-
-    // Verify second segment has been replaced.
-    ASSERT_EQ(0, connections.numSynapses(segments[1]));
-  }
-
-  /**
    * Creates a synapse, and makes sure that it got created on the correct
    * segment, and that its data was correctly stored.
    */
@@ -193,7 +150,7 @@ namespace {
   TEST(ConnectionsTest, testSynapseReuse)
   {
     // Limit to only two synapses per segment
-    Connections connections(1024, 1024, 2);
+    Connections connections(1024, 2);
     UInt32 cell = 10;
     Segment segment = connections.createSegment(cell);
     Synapse synapse;
@@ -387,39 +344,12 @@ namespace {
   }
 
   /**
-   * Destroy some segments then verify that the maxSegmentsPerCell is still
-   * correctly applied.
-   */
-  TEST(ConnectionsTest, DestroySegmentsThenReachLimit)
-  {
-    Connections connections(1024, 2, 2);
-
-    {
-      Segment segment1 = connections.createSegment(11);
-      Segment segment2 = connections.createSegment(11);
-      ASSERT_EQ(2, connections.numSegments());
-      connections.destroySegment(segment1);
-      connections.destroySegment(segment2);
-      ASSERT_EQ(0, connections.numSegments());
-    }
-
-    {
-      connections.createSegment(11);
-      EXPECT_EQ(1, connections.numSegments());
-      connections.createSegment(11);
-      EXPECT_EQ(2, connections.numSegments());
-      EXPECT_EQ(2, connections.numSegments(11));
-      EXPECT_EQ(2, connections.numSegments());
-    }
-  }
-
-  /**
    * Destroy some synapses then verify that the maxSynapsesPerSegment is still
    * correctly applied.
    */
   TEST(ConnectionsTest, DestroySynapsesThenReachLimit)
   {
-    Connections connections(1024, 2, 2);
+    Connections connections(1024, 2);
 
     Segment segment = connections.createSegment(10);
 
@@ -444,30 +374,12 @@ namespace {
   }
 
   /**
-   * Hit the maxSegmentsPerCell threshold multiple times. Make sure it works
-   * more than once.
-   */
-  TEST(ConnectionsTest, ReachSegmentLimitMultipleTimes)
-  {
-    Connections connections(1024, 2, 2);
-
-    connections.createSegment(10);
-    ASSERT_EQ(1, connections.numSegments());
-    connections.createSegment(10);
-    ASSERT_EQ(2, connections.numSegments());
-    connections.createSegment(10);
-    ASSERT_EQ(2, connections.numSegments());
-    connections.createSegment(10);
-    EXPECT_EQ(2, connections.numSegments());
-  }
-
-  /**
    * Hit the maxSynapsesPerSegment threshold multiple times. Make sure it works
    * more than once.
    */
   TEST(ConnectionsTest, ReachSynapseLimitMultipleTimes)
   {
-    Connections connections(1024, 2, 2);
+    Connections connections(1024, 2);
 
     Segment segment = connections.createSegment(10);
     connections.createSynapse(segment, 201, 0.85);
@@ -700,7 +612,7 @@ namespace {
   TEST(ConnectionsTest, testWriteRead)
   {
     const char* filename = "ConnectionsSerialization.tmp";
-    Connections c1(1024, 1024, 1024), c2;
+    Connections c1(1024, 1024), c2;
     setupSampleConnections(c1);
 
     Segment segment = c1.createSegment(10);
@@ -725,7 +637,7 @@ namespace {
 
   TEST(ConnectionsTest, testSaveLoad)
   {
-    Connections c1(1024, 1024, 1024), c2;
+    Connections c1(1024, 1024), c2;
     setupSampleConnections(c1);
 
     auto segment = c1.createSegment(10);

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -142,7 +142,7 @@ namespace {
     const vector<CellIdx> expectedActiveCells = {4};
 
     Segment activeSegment =
-      tm.connections.createSegment(expectedActiveCells[0]);
+      tm.createSegment(expectedActiveCells[0]);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
@@ -209,7 +209,7 @@ namespace {
     const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
     const vector<CellIdx> expectedActiveCells = {4};
 
-    Segment segment = tm.connections.createSegment(expectedActiveCells[0]);
+    Segment segment = tm.createSegment(expectedActiveCells[0]);
     tm.connections.createSynapse(segment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(segment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(segment, previousActiveCells[2], 0.5);
@@ -255,13 +255,13 @@ namespace {
     const vector<CellIdx> expectedWinnerCells = {4, 6};
 
     Segment activeSegment1 =
-      tm.connections.createSegment(expectedWinnerCells[0]);
+      tm.createSegment(expectedWinnerCells[0]);
     tm.connections.createSynapse(activeSegment1, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment1, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment1, previousActiveCells[2], 0.5);
 
     Segment activeSegment2 =
-      tm.connections.createSegment(expectedWinnerCells[1]);
+      tm.createSegment(expectedWinnerCells[1]);
     tm.connections.createSynapse(activeSegment2, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment2, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment2, previousActiveCells[2], 0.5);
@@ -329,7 +329,7 @@ namespace {
     const vector<CellIdx> activeCells = {5};
     const CellIdx activeCell = 5;
 
-    Segment activeSegment = tm.connections.createSegment(activeCell);
+    Segment activeSegment = tm.createSegment(activeCell);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     Synapse activeSynapse2 =
@@ -379,7 +379,7 @@ namespace {
     const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
     Segment selectedMatchingSegment =
-      tm.connections.createSegment(burstingCells[0]);
+      tm.createSegment(burstingCells[0]);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(selectedMatchingSegment,
                                    previousActiveCells[0], 0.3);
@@ -395,7 +395,7 @@ namespace {
 
     // Add some competition.
     Segment otherMatchingSegment =
-      tm.connections.createSegment(burstingCells[1]);
+      tm.createSegment(burstingCells[1]);
     tm.connections.createSynapse(otherMatchingSegment,
                                  previousActiveCells[0], 0.3);
     tm.connections.createSynapse(otherMatchingSegment,
@@ -442,7 +442,7 @@ namespace {
     const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
     Segment selectedMatchingSegment =
-      tm.connections.createSegment(burstingCells[0]);
+      tm.createSegment(burstingCells[0]);
     tm.connections.createSynapse(selectedMatchingSegment,
                                  previousActiveCells[0], 0.3);
     tm.connections.createSynapse(selectedMatchingSegment,
@@ -453,7 +453,7 @@ namespace {
                                  81, 0.3);
 
     Segment otherMatchingSegment =
-      tm.connections.createSegment(burstingCells[1]);
+      tm.createSegment(burstingCells[1]);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(otherMatchingSegment,
                                    previousActiveCells[0], 0.3);
@@ -502,14 +502,14 @@ namespace {
     const vector<CellIdx> otherBurstingCells = {5, 6, 7};
 
     Segment activeSegment =
-      tm.connections.createSegment(expectedActiveCells[0]);
+      tm.createSegment(expectedActiveCells[0]);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[3], 0.5);
 
     Segment matchingSegmentOnSameCell =
-      tm.connections.createSegment(expectedActiveCells[0]);
+      tm.createSegment(expectedActiveCells[0]);
     Synapse synapse1 =
       tm.connections.createSynapse(matchingSegmentOnSameCell,
                                    previousActiveCells[0], 0.3);
@@ -518,7 +518,7 @@ namespace {
                                    previousActiveCells[1], 0.3);
 
     Segment matchingSegmentOnOtherCell =
-      tm.connections.createSegment(otherBurstingCells[0]);
+      tm.createSegment(otherBurstingCells[0]);
     Synapse synapse3 =
       tm.connections.createSynapse(matchingSegmentOnOtherCell,
                                    previousActiveCells[0], 0.3);
@@ -690,7 +690,7 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(4);
+    Segment matchingSegment = tm.createSegment(4);
     tm.connections.createSynapse(matchingSegment, 0, 0.5);
 
     tm.compute(4, previousActiveColumns);
@@ -737,7 +737,7 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(4);
+    Segment matchingSegment = tm.createSegment(4);
     tm.connections.createSynapse(matchingSegment, 0, 0.5);
 
     tm.compute(2, previousActiveColumns);
@@ -781,7 +781,7 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3, 4};
     const UInt activeColumns[1] = {5};
 
-    Segment activeSegment = tm.connections.createSegment(5);
+    Segment activeSegment = tm.createSegment(5);
     tm.connections.createSynapse(activeSegment, 0, 0.5);
     tm.connections.createSynapse(activeSegment, 1, 0.5);
     tm.connections.createSynapse(activeSegment, 2, 0.2);
@@ -828,7 +828,7 @@ namespace {
     const UInt activeColumns[1] = {2};
     const CellIdx expectedActiveCell = 5;
 
-    Segment activeSegment = tm.connections.createSegment(expectedActiveCell);
+    Segment activeSegment = tm.createSegment(expectedActiveCell);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
@@ -868,7 +868,7 @@ namespace {
     const UInt activeColumns[1] = {1};
     const CellIdx activeCell = 5;
 
-    Segment activeSegment = tm.connections.createSegment(activeCell);
+    Segment activeSegment = tm.createSegment(activeCell);
     tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[1], 0.5);
     tm.connections.createSynapse(activeSegment, previousActiveCells[2], 0.5);
@@ -909,7 +909,7 @@ namespace {
     const vector<CellIdx> prevWinnerCells = {0, 1, 2};
     const UInt activeColumns[1] = {4};
 
-    Segment matchingSegment = tm.connections.createSegment(4);
+    Segment matchingSegment = tm.createSegment(4);
 
     // Create a synapse with a high permanence.
     tm.connections.createSynapse(matchingSegment, 31, 0.6);
@@ -1034,7 +1034,7 @@ namespace {
     const UInt activeColumns[1] = {2};
     const CellIdx expectedActiveCell = 5;
 
-    Segment matchingSegment = tm.connections.createSegment(expectedActiveCell);
+    Segment matchingSegment = tm.createSegment(expectedActiveCell);
     tm.connections.createSynapse(matchingSegment, previousActiveCells[0], 0.015);
     tm.connections.createSynapse(matchingSegment, previousActiveCells[1], 0.015);
     tm.connections.createSynapse(matchingSegment, previousActiveCells[2], 0.015);
@@ -1077,7 +1077,7 @@ namespace {
     const UInt activeColumns[1] = {1};
     const CellIdx previousInactiveCell = 81;
 
-    Segment activeSegment = tm.connections.createSegment(42);
+    Segment activeSegment = tm.createSegment(42);
     Synapse activeSynapse1 =
       tm.connections.createSynapse(activeSegment, previousActiveCells[0], 0.5);
     Synapse activeSynapse2 =
@@ -1087,7 +1087,7 @@ namespace {
     Synapse inactiveSynapse1 =
       tm.connections.createSynapse(activeSegment, previousInactiveCell, 0.5);
 
-    Segment matchingSegment = tm.connections.createSegment(43);
+    Segment matchingSegment = tm.createSegment(43);
     Synapse activeSynapse4 =
       tm.connections.createSynapse(matchingSegment, previousActiveCells[0], 0.5);
     Synapse activeSynapse5 =
@@ -1146,9 +1146,9 @@ namespace {
       vector<CellIdx> nonmatchingCells = {0, 3};
       vector<CellIdx> activeCells = {0, 1, 2, 3};
 
-      Segment segment1 = tm.connections.createSegment(nonmatchingCells[0]);
+      Segment segment1 = tm.createSegment(nonmatchingCells[0]);
       tm.connections.createSynapse(segment1, previousActiveCells[0], 0.5);
-      Segment segment2 = tm.connections.createSegment(nonmatchingCells[1]);
+      Segment segment2 = tm.createSegment(nonmatchingCells[1]);
       tm.connections.createSynapse(segment2, previousActiveCells[1], 0.5);
 
       tm.compute(4, previousActiveColumns, true);
@@ -1219,7 +1219,7 @@ namespace {
       /*seed*/ 42
       );
 
-    Segment segment = tm.connections.createSegment(8);
+    Segment segment = tm.createSegment(8);
     tm.connections.createSynapse(segment, 0, 0.2);
     tm.connections.createSynapse(segment, 1, 0.2);
     tm.connections.createSynapse(segment, 2, 0.2);
@@ -1275,7 +1275,7 @@ namespace {
     const vector<CellIdx> expectedActiveCells = {4};
 
     Segment correctActiveSegment =
-      tm.connections.createSegment(expectedActiveCells[0]);
+      tm.createSegment(expectedActiveCells[0]);
     tm.connections.createSynapse(correctActiveSegment,
                                  previousActiveCells[0], 0.5);
     tm.connections.createSynapse(correctActiveSegment,
@@ -1283,7 +1283,7 @@ namespace {
     tm.connections.createSynapse(correctActiveSegment,
                                  previousActiveCells[2], 0.5);
 
-    Segment wrongMatchingSegment = tm.connections.createSegment(43);
+    Segment wrongMatchingSegment = tm.createSegment(43);
     tm.connections.createSynapse(wrongMatchingSegment,
                                  previousActiveCells[0], 0.5);
     tm.connections.createSynapse(wrongMatchingSegment,
@@ -1297,6 +1297,138 @@ namespace {
     tm.compute(2, activeColumns, false);
 
     EXPECT_EQ(before, tm.connections);
+  }
+
+   /**
+   * Destroy some segments then verify that the maxSegmentsPerCell is still
+   * correctly applied.
+   */
+  TEST(TemporalMemoryTest, DestroySegmentsThenReachLimit)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.50,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.02,
+      /*permanenceDecrement*/ 0.02,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42,
+      /*maxSegmentsPerCell*/ 2
+      );
+
+    {
+      Segment segment1 = tm.createSegment(11);
+      Segment segment2 = tm.createSegment(11);
+      ASSERT_EQ(2, tm.connections.numSegments());
+      tm.connections.destroySegment(segment1);
+      tm.connections.destroySegment(segment2);
+      ASSERT_EQ(0, tm.connections.numSegments());
+    }
+
+    {
+      tm.createSegment(11);
+      EXPECT_EQ(1, tm.connections.numSegments());
+      tm.createSegment(11);
+      EXPECT_EQ(2, tm.connections.numSegments());
+      tm.createSegment(11);
+      EXPECT_EQ(2, tm.connections.numSegments());
+      EXPECT_EQ(2, tm.connections.numSegments(11));
+    }
+  }
+
+   /**
+   * Creates many segments on a cell, until hits segment limit. Then creates
+   * another segment, and checks that it destroyed the least recently used
+   * segment and created a new one in its place.
+   */
+  TEST(TemporalMemoryTest, CreateSegmentDestroyOld)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.50,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.02,
+      /*permanenceDecrement*/ 0.02,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42,
+      /*maxSegmentsPerCell*/ 2
+      );
+
+    Segment segment1 = tm.createSegment(12);
+
+    tm.connections.createSynapse(segment1, 1, 0.5);
+    tm.connections.createSynapse(segment1, 2, 0.5);
+    tm.connections.createSynapse(segment1, 3, 0.5);
+
+    // Let some time pass.
+    tm.compute(0, nullptr);
+    tm.compute(0, nullptr);
+    tm.compute(0, nullptr);
+
+    // Create a segment with 1 synapse.
+    Segment segment2 = tm.createSegment(12);
+    tm.connections.createSynapse(segment2, 1, 0.5);
+
+    tm.compute(0, nullptr);
+
+    // Give the first segment some activity.
+    const UInt activeColumns[3] = {1, 2, 3};
+    tm.compute(3, activeColumns);
+
+    // Create a new segment with no synapses.
+    tm.createSegment(12);
+
+    vector<Segment> segments = tm.connections.segmentsForCell(12);
+    ASSERT_EQ(2, segments.size());
+
+    // Verify first segment is still there with the same synapses.
+    vector<Synapse> synapses1 = tm.connections.synapsesForSegment(segments[0]);
+    ASSERT_EQ(3, synapses1.size());
+    ASSERT_EQ(1, tm.connections.dataForSynapse(synapses1[0]).presynapticCell);
+    ASSERT_EQ(2, tm.connections.dataForSynapse(synapses1[1]).presynapticCell);
+    ASSERT_EQ(3, tm.connections.dataForSynapse(synapses1[2]).presynapticCell);
+
+    // Verify second segment has been replaced.
+    ASSERT_EQ(0, tm.connections.numSynapses(segments[1]));
+  }
+
+   /**
+    * Hit the maxSegmentsPerCell threshold multiple times. Make sure it works
+    * more than once.
+    */
+  TEST(ConnectionsTest, ReachSegmentLimitMultipleTimes)
+  {
+    TemporalMemory tm(
+      /*columnDimensions*/ {32},
+      /*cellsPerColumn*/ 1,
+      /*activationThreshold*/ 3,
+      /*initialPermanence*/ 0.50,
+      /*connectedPermanence*/ 0.50,
+      /*minThreshold*/ 2,
+      /*maxNewSynapseCount*/ 3,
+      /*permanenceIncrement*/ 0.02,
+      /*permanenceDecrement*/ 0.02,
+      /*predictedSegmentDecrement*/ 0.0,
+      /*seed*/ 42,
+      /*maxSegmentsPerCell*/ 2
+      );
+
+    tm.createSegment(10);
+    ASSERT_EQ(1, tm.connections.numSegments());
+    tm.createSegment(10);
+    ASSERT_EQ(2, tm.connections.numSegments());
+    tm.createSegment(10);
+    ASSERT_EQ(2, tm.connections.numSegments());
+    tm.createSegment(10);
+    EXPECT_EQ(2, tm.connections.numSegments());
   }
 
   TEST(TemporalMemoryTest, testColumnForCell1D)
@@ -1353,10 +1485,10 @@ namespace {
   {
     // Create an active segment and a two matching segments.
     // Destroy a few to exercise the code.
-    Segment destroyMe1 = tm.connections.createSegment(4);
+    Segment destroyMe1 = tm.createSegment(4);
     tm.connections.destroySegment(destroyMe1);
 
-    Segment activeSegment = tm.connections.createSegment(4);
+    Segment activeSegment = tm.createSegment(4);
     tm.connections.createSynapse(activeSegment, 0, 0.5);
     tm.connections.createSynapse(activeSegment, 1, 0.5);
     Synapse destroyMe2 = tm.connections.createSynapse(activeSegment, 42, 0.5);
@@ -1364,12 +1496,12 @@ namespace {
     tm.connections.createSynapse(activeSegment, 2, 0.5);
     tm.connections.createSynapse(activeSegment, 3, 0.5);
 
-    Segment matchingSegment1 = tm.connections.createSegment(8);
+    Segment matchingSegment1 = tm.createSegment(8);
     tm.connections.createSynapse(matchingSegment1, 0, 0.4);
     tm.connections.createSynapse(matchingSegment1, 1, 0.4);
     tm.connections.createSynapse(matchingSegment1, 2, 0.4);
 
-    Segment matchingSegment2 = tm.connections.createSegment(9);
+    Segment matchingSegment2 = tm.createSegment(9);
     tm.connections.createSynapse(matchingSegment2, 0, 0.4);
     tm.connections.createSynapse(matchingSegment2, 1, 0.4);
     tm.connections.createSynapse(matchingSegment2, 2, 0.4);


### PR DESCRIPTION
Fixes #986

This change removes `maxSegmentsPerCell` and `maxSynapsesPerSegment` parameters from the `Connections` class, and adds their logic to the `TemporalMemory`. In this new code I fixed the synapse destroy bug mentioned in the issue above.

This change is ~performance neutral. If anything, it's slightly faster.

I've wanted to make this change for a long time. Code that enforces segment/synapse limits is algorithm code, not data structure code. There's no obvious right way to do it, and different algorithms should choose whether/how to handle it explicitly.