### PR TITLE
Initialize numpy API in "algorithms" module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ message(STATUS "PYTHON_LIBRARIES    = ${PYTHON_LIBRARIES}")
 # Python support
 #
 set(src_py_support_files
+    nupic/py_support/NumpyArrayObject.cpp
     nupic/py_support/NumpyVector.cpp
     nupic/py_support/PyArray.cpp
     nupic/py_support/PyHelpers.cpp

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -101,9 +101,20 @@ _ALGORITHMS = _algorithms
 #include <nupic/proto/ConnectionsProto.capnp.h>
 #include <nupic/proto/SpatialPoolerProto.capnp.h>
 #include <nupic/proto/TemporalMemoryProto.capnp.h>
+%}
 
+//
+// Numpy API
+//
+%{
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
+%}
+%init %{
+  import_array();
+%}
+
+%{
 #include <nupic/py_support/NumpyVector.hpp>
 #include <nupic/py_support/PyCapnp.hpp>
 #include <nupic/py_support/PythonStream.hpp>

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -107,11 +107,10 @@ _ALGORITHMS = _algorithms
 // Numpy API
 //
 %{
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
+#include <nupic/py_support/NumpyArrayObject.hpp>
 %}
 %init %{
-  import_array();
+  nupic::initializeNumpy();
 %}
 
 %{

--- a/src/nupic/bindings/engine_internal.i
+++ b/src/nupic/bindings/engine_internal.i
@@ -194,7 +194,15 @@ class IterablePair(object):
 
 %include <nupic/os/Timer.hpp>
 
-%include <nupic/bindings/numpy.i>
+//
+// Numpy API
+//
+%{
+#include <nupic/py_support/NumpyArrayObject.hpp>
+%}
+%init %{
+  nupic::initializeNumpy();
+%}
 
 
 %include <nupic/py_support/PyArray.hpp>

--- a/src/nupic/bindings/math.i
+++ b/src/nupic/bindings/math.i
@@ -70,25 +70,20 @@ _MATH = _math
 #include <nupic/math/ArrayAlgo.hpp>
 #include <nupic/proto/RandomProto.capnp.h>
 #include <nupic/utils/Random.hpp>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 
 #include <nupic/py_support/PyCapnp.hpp>
 %}
 
 %naturalvar;
 
+//
+// Numpy API
+//
 %{
-#define SWIG_FILE_WITH_INIT
+#include <nupic/py_support/NumpyArrayObject.hpp>
 %}
-
-%include <nupic/bindings/numpy.i> // %import does not work.
-
 %init %{
-
-// Perform necessary library initialization (in C++).
-import_array();
-
+  nupic::initializeNumpy();
 %}
 
 

--- a/src/nupic/py_support/NumpyArrayObject.cpp
+++ b/src/nupic/py_support/NumpyArrayObject.cpp
@@ -1,0 +1,43 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * The home of the NTA_NumpyArray_API symbol
+ */
+
+#define NTA_OVERRIDE_NO_IMPORT_ARRAY
+#include <nupic/py_support/NumpyArrayObject.hpp>
+
+#include <stdexcept>
+
+namespace nupic {
+  void initializeNumpy()
+  {
+    // Use _import_array() because import_array() is a macro that contains a
+    // return statement.
+    if (_import_array() != 0)
+    {
+      throw std::runtime_error(
+        "initializeNumpy: numpy.core.multiarray failed to import.");
+    }
+  }
+}

--- a/src/nupic/py_support/NumpyArrayObject.hpp
+++ b/src/nupic/py_support/NumpyArrayObject.hpp
@@ -1,0 +1,56 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * Wrapper for <numpy/arrayobject.h>.
+ *
+ * Normally when you include <numpy/arrayobject.h>, it creates a static
+ * "PyArray_API" variable for each cpp file. Each of these variables must be
+ * initialized via "import_array()".
+ *
+ * Include this file to use a shared PyArray_API variable across multiple cpp
+ * files. Run "initializeNumpy()" to initialize this shared variable.
+ */
+
+#ifndef NTA_NUMPY_ARRAY_OBJECT
+
+#ifndef NTA_OVERRIDE_NO_IMPORT_ARRAY
+#define NO_IMPORT_ARRAY
+#endif
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define PY_ARRAY_UNIQUE_SYMBOL NTA_NumpyArray_API
+#include <numpy/arrayobject.h>
+#undef NO_IMPORT_ARRAY
+
+namespace nupic {
+  /**
+   * This method needs to be called some time in the process lifetime before
+   * calling the numpy C APIs.
+   *
+   * It initializes the global "NTA_NumpyArray_API" to an array of function
+   * pointers -- i.e. it dynamically links with the numpy library.
+   */
+  void initializeNumpy();
+};
+
+#endif // NTA_NUMPY_ARRAY_OBJECT

--- a/src/nupic/py_support/NumpyVector.cpp
+++ b/src/nupic/py_support/NumpyVector.cpp
@@ -25,11 +25,7 @@
 
 
 
-//#define NO_IMPORT_ARRAY
 #include <Python.h>
-
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 
 // workaround for change in numpy config.h for python2.5 on windows
 // Must come after python includes.
@@ -93,27 +89,11 @@ NTA_DEF_NUMPY_DTYPE_TRAIT(nupic::Real64, NPY_FLOAT64);
 
 // --------------------------------------------------------------
 
-
-void NumpyArray::init()
-{
-  int rc = _import_array();
-  if (rc < 0) {
-    throw std::runtime_error("NumpyArray::init(): "
-      "numpy.core.multiarray failed to import.");
-  }
-}
-
-inline void CheckInit()
-  { NumpyArray::init(); }
-
 NumpyArray::NumpyArray(int nd, const int *ndims, int dtype)
   : p_(0), dtype_(dtype)
 {
-
   // declare static to avoid new/delete with every call
   static npy_intp ndims_intp[NPY_MAXDIMS];
-
-  CheckInit();
 
   if(nd < 0)
     throw runtime_error("Negative dimensioned arrays not supported.");
@@ -137,8 +117,6 @@ NumpyArray::NumpyArray(int nd, const int *ndims, int dtype)
 NumpyArray::NumpyArray(PyObject *p, int dtype, int requiredDimension)
   : p_(0), dtype_(dtype)
 {
-  CheckInit();
-
   PyObject *contiguous = PyArray_ContiguousFromObject(p, NPY_NOTYPE, 0, 0);
   if(!contiguous)
     throw std::runtime_error("Array could not be made contiguous.");

--- a/src/nupic/py_support/NumpyVector.hpp
+++ b/src/nupic/py_support/NumpyVector.hpp
@@ -27,11 +27,10 @@
  * Contains the NumpyArray class, a wrapper for Python numpy arrays.
  */
 
+#include <nupic/py_support/NumpyArrayObject.hpp>
 #include <nupic/types/Types.hpp> // For nupic::Real.
 #include <nupic/utils/Log.hpp> // For NTA_ASSERT
 #include <algorithm> // For std::copy.
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 
 namespace nupic {
 
@@ -74,12 +73,6 @@ namespace nupic {
     /// Releases the reference to the internal numpy array.
     ///////////////////////////////////////////////////////////
     virtual ~NumpyArray();
-
-    ///////////////////////////////////////////////////////////
-    /// Initializes the numpy library.
-    /// Called automatically when constructing a NumpyArray.
-    ///////////////////////////////////////////////////////////
-    static void init();
 
     ///////////////////////////////////////////////////////////
     /// The number of dimensions of the internal numpy array.

--- a/src/nupic/py_support/PyArray.cpp
+++ b/src/nupic/py_support/PyArray.cpp
@@ -28,10 +28,9 @@
 #include <Python.h>
 
 #include "PyArray.hpp"
+#include <nupic/py_support/NumpyArrayObject.hpp>
 #include <nupic/utils/Log.hpp>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -61,16 +60,8 @@ namespace nupic
   //
   // -------------------------------------
   // Wrap an Array object with a numpy array PyObject
-
-  static void initNumpy()
-  {
-    import_array();
-  }
-
   PyObject * array2numpy(const ArrayBase & a)
   {
-    initNumpy();
-
     npy_intp dims[1];
     dims[0] = npy_intp(a.getCount());
 

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -21,8 +21,7 @@
  */
 
 #include <nupic/regions/PyRegion.hpp>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
+
 #include <Python.h>
 #include <iostream>
 #include <sstream>
@@ -44,6 +43,7 @@
 #include <nupic/ntypes/BundleIO.hpp>
 #include <nupic/utils/Log.hpp>
 #include <nupic/os/Path.hpp>
+#include <nupic/py_support/NumpyArrayObject.hpp>
 #include <nupic/py_support/PyArray.hpp>
 #include <nupic/py_support/PyCapnp.hpp>
 
@@ -59,39 +59,13 @@ extern "C"
   // NTA_createPyNode()
   void PyRegion::NTA_initPython()
   {
-    finalizePython = false;
-    // Initialize Python if it is not initialized already. Python will be initialized
-    // if NuPIC is accessed through the Python bindings and hence is already runnning
-    // inside a Python process.
-    if (!Py_IsInitialized())
-    {
-      //NTA_DEBUG << "Called Py_Initialize()";
-      Py_Initialize();
-      NTA_ASSERT(Py_IsInitialized());
-      finalizePython = true;
-    }
-    else
+    if(Py_IsInitialized())
     {
       // Set the PyHelpers flag so it knows its running under Python.
       // This is necessary for PyHelpers to determine if it should
       // clear or restore Python exceptions (see NPC-113)
       py::setRunningUnderPython();
-    }
-
-    // Important! the following statements must be outside the PyInitialize()
-    // conditional block because Python may already be initialized if used
-    // through the Python bindings.
-
-    // NOTE we use the function _import_array directly (just like in
-    // NumpyVector.cpp) because import_array is a macro that incorporates a
-    // return statement on failure, intended to be used directly in
-    // a python extension's init function rather than deeply nested.
-    if (_import_array() != 0)
-    {
-      // _import_array sets PyErr on failure
-      PyErr_Print();
-
-      NTA_THROW << "numpy _import_array failed";
+      finalizePython = true;
     }
   }
 

--- a/src/test/integration/PyRegionTest.cpp
+++ b/src/test/integration/PyRegionTest.cpp
@@ -37,6 +37,7 @@
 #include <nupic/ntypes/Dimensions.hpp>
 #include <nupic/ntypes/Array.hpp>
 #include <nupic/ntypes/ArrayRef.hpp>
+#include <nupic/py_support/NumpyArrayObject.hpp>
 #include <nupic/types/Exception.hpp>
 #include <nupic/os/OS.hpp> // memory leak detection
 #include <nupic/os/Env.hpp>
@@ -517,6 +518,11 @@ int realmain(bool leakTest)
 
 int main(int argc, char *argv[])
 {
+  // This isn't running inside one of the SWIG modules, so we need to
+  // initialize the numpy C API.
+  Py_Initialize();
+  NTA_CHECK(Py_IsInitialized());
+  nupic::initializeNumpy();
 
   /*
    * Without arguments, this program is a simple end-to-end demo


### PR DESCRIPTION
Fixes #1331

See the description in the issue.

This populates the `PyArray_API` array with function pointers, allowing C code in `algorithms.so` to run numpy APIs like `PyArray_EquivTypenums`. Without this line, any calls to these APIs will segfault.