### PR TITLE
Give clear exception when clients try to reuse ClassiferResults

### DIFF
--- a/src/nupic/algorithms/ClassifierResult.cpp
+++ b/src/nupic/algorithms/ClassifierResult.cpp
@@ -49,8 +49,7 @@ namespace nupic
       vector<Real64>* ClassifierResult::createVector(Int step, UInt size,
                                                 Real64 value)
       {
-        map<Int, vector<Real64>*>::const_iterator it = result_.find(step);
-        NTA_CHECK(it == result_.end())
+        NTA_CHECK(result_.count(step) == 0)
           << "The ClassifierResult cannot be reused!";
         vector<Real64>* v = new vector<Real64>(size, value);
         result_.insert(pair<Int, vector<Real64>*>(step, v));

--- a/src/nupic/algorithms/ClassifierResult.cpp
+++ b/src/nupic/algorithms/ClassifierResult.cpp
@@ -26,6 +26,7 @@
 
 #include <nupic/algorithms/ClassifierResult.hpp>
 #include <nupic/types/Types.hpp>
+#include <nupic/utils/Log.hpp>
 
 using namespace std;
 
@@ -48,15 +49,11 @@ namespace nupic
       vector<Real64>* ClassifierResult::createVector(Int step, UInt size,
                                                 Real64 value)
       {
-        vector<Real64>* v;
         map<Int, vector<Real64>*>::const_iterator it = result_.find(step);
-        if (it != result_.end())
-        {
-          v = it->second;
-        } else {
-          v = new vector<Real64>(size, value);
-          result_.insert(pair<Int, vector<Real64>*>(step, v));
-        }
+        NTA_CHECK(it == result_.end())
+          << "The ClassifierResult cannot be reused!";
+        vector<Real64>* v = new vector<Real64>(size, value);
+        result_.insert(pair<Int, vector<Real64>*>(step, v));
         return v;
       }
 

--- a/src/nupic/algorithms/SDRClassifier.cpp
+++ b/src/nupic/algorithms/SDRClassifier.cpp
@@ -96,6 +96,7 @@ namespace nupic
           if (recordNum < lastRecordNum)
             NTA_THROW << "the record number has to increase monotonically";
         }
+
         // update pattern history if this is a new record
         if (recordNumHistory_.size() == 0 || recordNum > lastRecordNum)
         {
@@ -127,7 +128,7 @@ namespace nupic
         // if in inference mode, compute likelihood and update return value
         if (infer)
         {
-            infer_(patternNZ, actValueList, result);
+          infer_(patternNZ, actValueList, result);
         }
 
         // update weights if in learning mode


### PR DESCRIPTION
This is to address a community reported segfault by making it clear that you cannot reuse ClassificationResult instances across calls to SDRClassifier.compute. I looked into having `compute` simply return a new ClassifierResult but it looked like a major refactoring and I wasn't sure I was doing the right thing so punting on that for now.

@mrcslws please review
@ywcui1990 fyi