### PR TITLE
Fix SP unstable output, synapse decay

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -488,6 +488,17 @@ const vector<Real>& SpatialPooler::getBoostedOverlaps() const
   return boostedOverlaps_;
 }
 
+/** helper method that checks SP output is stable for given configuration */
+bool checkUnstableParams_(SpatialPooler &sp) {
+  vector<UInt> input(sp.getNumInputs(), 1); //auto size of input
+  vector<UInt> out1(sp.getNumColumns(), 0); 
+  vector<UInt> out2(sp.getNumColumns(), 0); 
+  sp.compute(input.data(), true, out1.data());
+  sp.compute(input.data(), true, out2.data());
+  //TODO should we add SP.reset() and call it here? 
+  return std::equal(std::begin(out1), std::end(out1), std::begin(out2)); //compare all, element wise
+}
+
 void SpatialPooler::initialize(vector<UInt> inputDimensions,
   vector<UInt> columnDimensions,
   UInt potentialRadius,
@@ -593,6 +604,9 @@ void SpatialPooler::initialize(vector<UInt> inputDimensions,
     printParameters();
     std::cout << "CPP SP seed                 = " << seed << std::endl;
   }
+
+  //check for reasonable params
+  NTA_CHECK(checkUnstableParams_(*this)); //TODO the assert runs only at debug builds, make mandatory?
 }
 
 void SpatialPooler::compute(UInt inputArray[], bool learn,

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -493,9 +493,8 @@ bool checkUnstableParams_(SpatialPooler &sp) {
   vector<UInt> input(sp.getNumInputs(), 1); //auto size of input
   vector<UInt> out1(sp.getNumColumns(), 0); 
   vector<UInt> out2(sp.getNumColumns(), 0); 
-  sp.compute(input.data(), true, out1.data());
-  sp.compute(input.data(), true, out2.data());
-  //TODO should we add SP.reset() and call it here? 
+  sp.compute(input.data(), false, out1.data());
+  sp.compute(input.data(), false, out2.data());
   return std::equal(std::begin(out1), std::end(out1), std::begin(out2)); //compare all, element wise
 }
 

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -2222,6 +2222,23 @@ namespace {
     EXPECT_EQ(0, countNonzero(activeColumns));
   }
 
+
+  TEST(SpatialPoolerTest, testSameOutputForSameInputNoLearningNoBoosting)
+  {
+    const UInt inputSize = 10;
+    const UInt nColumns = 20;
+    SpatialPooler sp;
+    sp.initialize({inputSize}, {nColumns});
+    sp.setBoostStrength(0);
+
+    vector<UInt> input = { 1, 1, 0, 0, 1, 1, 0, 0, 1, 1 };
+    vector<UInt> out1(nColumns, 0);
+    vector<UInt> out2(nColumns, 0);
+    sp.compute(input.data(), false, out1.data());
+    sp.compute(input.data(), false, out2.data());
+    EXPECT_EQ(out1, out2);
+  }
+
   TEST(SpatialPoolerTest, testSaveLoad)
   {
     const char* filename = "SpatialPoolerSerialization.tmp";

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -2223,21 +2223,30 @@ namespace {
   }
 
 
-  TEST(SpatialPoolerTest, testSameOutputForSameInputNoLearningNoBoosting)
+  TEST(SpatialPoolerTest, testConstructorInitParamsUnstable)
   {
-    const UInt inputSize = 10;
-    const UInt nColumns = 20;
-    SpatialPooler sp;
-    sp.initialize({inputSize}, {nColumns});
-    sp.setBoostStrength(0);
+  /** this test exposes bug where c++ SP (wrongly) produces
+  different output for the same input. 
+  XXX sensitive - marks (empirically!) discovered set of parameter 
+  that produce the err behavior; changing any of the XXX params 
+  may cause the SP to behave "normally"
+  */
+    SpatialPooler sp{std::vector<UInt>{10} /* input*/, std::vector<UInt>{2048}/* SP output cols XXX sensitive*/, 
+                        /*pot radius*/ 20, //each col sees
+                        /*pot pct*/ 0.5, //XXX sensitive
+                        /*global inhibition*/ false, //XXX sensitive
+                       /*Real localAreaDensity=*/0.02, //2% active cols
+                       /*UInt numActiveColumnsPerInhArea=*/0, //mutex with above ^^ //XXX sensitive
+};
 
-    vector<UInt> input = { 1, 1, 0, 0, 1, 1, 0, 0, 1, 1 };
-    vector<UInt> out1(nColumns, 0);
-    vector<UInt> out2(nColumns, 0);
-    sp.compute(input.data(), false, out1.data());
-    sp.compute(input.data(), false, out2.data());
+    vector<UInt> input = { 1, 1, 0, 0, 1, 1, 0, 0, 1, 1};
+    vector<UInt> out1(sp.getNumColumns(), 0); 
+    vector<UInt> out2(sp.getNumColumns(), 0); 
+    sp.compute(input.data(), true, out1.data());
+    sp.compute(input.data(), true, out2.data());
     EXPECT_EQ(out1, out2);
-  }
+}
+
 
   TEST(SpatialPoolerTest, testSaveLoad)
   {

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -2244,7 +2244,7 @@ namespace {
     vector<UInt> out2(sp.getNumColumns(), 0); 
     sp.compute(input.data(), true, out1.data());
     sp.compute(input.data(), true, out2.data());
-    EXPECT_EQ(out1, out2);
+    EXPECT_EQ(out1, out2); //not necessary with the check in SP initialize(), but keep here as example
 }
 
 


### PR DESCRIPTION
This PR adds tests for identified issue where c++ SP starts to misbehave under certain conditions and returns (random) different values for the same inputs. 
Identified at least 2 cases
- [x] unstable set of params test
  - [ ] fix for unstable

Fixes: #1380 
Obsoletes: #1381 

EDIT: 
separate into several atomic PRs