### PR TITLE
 Issue #1380: Validate python parameters passed to SP compute method

### DIFF
--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1163,10 +1163,22 @@ void forceRetentionOfImageSensorLiteLibrary(void) {
       self._initFromCapnpPyBytes(proto.as_builder().to_bytes()) # copy * 2
   %}
 
-  inline void compute(PyObject *py_x, bool learn, PyObject *py_y)
+  inline void compute(PyObject *py_inputArray, bool learn, PyObject *py_activeArray)
   {
-    PyArrayObject* x = (PyArrayObject*) py_x;
-    PyArrayObject* y = (PyArrayObject*) py_y;
+    PyArrayObject* x = (PyArrayObject*) py_inputArray;
+    PyArrayObject* y = (PyArrayObject*) py_activeArray;
+    if (!PyArray_ISUNSIGNED(x) || PyArray_DTYPE(x)->elsize != sizeof(nupic::UInt))
+    {
+      NTA_THROW << "Invalid data type given for input array."
+                << " Expecting 'uint" << sizeof(nupic::UInt) * 8 << "'"
+                << " but got '" << PyArray_DTYPE(x)->type << "'";
+    }
+    if (!PyArray_ISUNSIGNED(y) || PyArray_DTYPE(y)->elsize != sizeof(nupic::UInt))
+    {
+      NTA_THROW << "Invalid data type given for active array."
+                << " Expecting 'uint" << sizeof(nupic::UInt) * 8 << "'"
+                << " but got '" << PyArray_DTYPE(y)->type << "'";
+    }
     self->compute((nupic::UInt*) PyArray_DATA(x), (bool)learn, (nupic::UInt*) PyArray_DATA(y));
   }
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1165,8 +1165,8 @@ void forceRetentionOfImageSensorLiteLibrary(void) {
 
   inline void compute(PyObject *py_inputArray, bool learn, PyObject *py_activeArray)
   {
-    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt32> inputArray(py_inputArray);
-    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt32> activeArray(py_activeArray);
+    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt> inputArray(py_inputArray);
+    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt> activeArray(py_activeArray);
     self->compute(inputArray.begin(), learn, activeArray.begin());
   }
 

--- a/src/nupic/bindings/algorithms.i
+++ b/src/nupic/bindings/algorithms.i
@@ -1165,21 +1165,9 @@ void forceRetentionOfImageSensorLiteLibrary(void) {
 
   inline void compute(PyObject *py_inputArray, bool learn, PyObject *py_activeArray)
   {
-    PyArrayObject* x = (PyArrayObject*) py_inputArray;
-    PyArrayObject* y = (PyArrayObject*) py_activeArray;
-    if (!PyArray_ISUNSIGNED(x) || PyArray_DTYPE(x)->elsize != sizeof(nupic::UInt))
-    {
-      NTA_THROW << "Invalid data type given for input array."
-                << " Expecting 'uint" << sizeof(nupic::UInt) * 8 << "'"
-                << " but got '" << PyArray_DTYPE(x)->type << "'";
-    }
-    if (!PyArray_ISUNSIGNED(y) || PyArray_DTYPE(y)->elsize != sizeof(nupic::UInt))
-    {
-      NTA_THROW << "Invalid data type given for active array."
-                << " Expecting 'uint" << sizeof(nupic::UInt) * 8 << "'"
-                << " but got '" << PyArray_DTYPE(y)->type << "'";
-    }
-    self->compute((nupic::UInt*) PyArray_DATA(x), (bool)learn, (nupic::UInt*) PyArray_DATA(y));
+    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt32> inputArray(py_inputArray);
+    nupic::CheckedNumpyVectorWeakRefT<nupic::UInt32> activeArray(py_activeArray);
+    self->compute(inputArray.begin(), learn, activeArray.begin());
   }
 
   inline void stripUnlearnedColumns(PyObject *py_x)

--- a/src/nupic/py_support/NumpyVector.hpp
+++ b/src/nupic/py_support/NumpyVector.hpp
@@ -31,7 +31,7 @@
 #include <nupic/types/Types.hpp> // For nupic::Real.
 #include <nupic/utils/Log.hpp> // For NTA_ASSERT
 #include <algorithm> // For std::copy.
-#include <boost/compute/type_traits/type_name.hpp> // for 'type_name'
+#include <boost/type_index/stl_type_index.hpp> // for 'type_id'
 
 namespace nupic {
 
@@ -457,7 +457,9 @@ namespace nupic {
         if (!PyArray_EquivTypenums(
               PyArray_TYPE(this->pyArray_), LookupNumpyDType((const T *) 0)))
         {
-          NTA_THROW << "Expecting '" << boost::compute::type_name<T>() << "' "
+          boost::typeindex::stl_type_index expectedType = 
+            boost::typeindex::stl_type_index::type_id<T>();
+          NTA_THROW << "Expecting '" << expectedType.pretty_name() << "' "
                     << "but got '" << PyArray_DTYPE(this->pyArray_)->type << "'";
         }
       }


### PR DESCRIPTION
Fixes #1380 
The `swig` interface now validates the `numpy.array` type making sure it matches the C++ implementation (`nupic::UInt`).  It will now throw an exception when the `compute` method is called with the wrong data type. 

