### PR TITLE
Fix sp no winners crash

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1218,17 +1218,17 @@ void SpatialPooler::inhibitColumns_(
 bool SpatialPooler::isWinner_(Real score, vector<pair<UInt, Real> >& winners,
                               UInt numWinners)
 {
-  if (score < stimulusThreshold_)
+  if (score < stimulusThreshold_) //does not pass threshold, cannot win
   {
     return false;
   }
 
-  if (winners.size() < numWinners)
+  if (winners.size() < numWinners)  //we haven't populated enough winners yet, accept everybody
   {
     return true;
   }
 
-  if (score >= winners[numWinners-1].second)
+  if (winners.size() > 0 && score >= winners.back().second)  //winners full, see if better than last accepted, replace
   {
     return true;
   }

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1463,6 +1463,22 @@ namespace {
     ASSERT_TRUE(check_vector_eq(trueActive,active));
   }
 
+  TEST(SpatialPoolerTest, testFewColumnsGlobalInhibitionCrash)
+  {
+  /** this test exposes bug where too small (few columns) SP crashes with global inhibition  */
+  SpatialPooler sp{std::vector<UInt>{1000} /* input*/, std::vector<UInt>{20}/* SP output cols XXX sensitive*/ };
+  sp.setBoostStrength(0.0);
+  sp.setPotentialRadius(20); 
+  sp.setPotentialPct(0.5);
+  sp.setGlobalInhibition(true);
+  sp.setLocalAreaDensity(0.02);
+
+    vector<UInt> input(sp.getNumInputs(), 1);
+   vector<UInt> out1(sp.getNumColumns(), 0);
+
+      EXPECT_NO_THROW(sp.compute(input.data(), false, out1.data()));
+}
+
   TEST(SpatialPoolerTest, testInhibitColumnsLocal)
   {
     // wrapAround = false


### PR DESCRIPTION
Small PR that just avoids detected crash

- [x] adds test with small SP that would crash
  - [x] fix by avoiding out-of-bounds indexing in `isWinner_` method.

Fixes #1390 