### PR TITLE
NUP-2491: Validate global inhibition parameters

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1259,6 +1259,9 @@ void SpatialPooler::inhibitColumnsGlobal_(
 {
   activeColumns.clear();
   const UInt numDesired = (UInt) (density * numColumns_);
+  NTA_CHECK(numDesired > 0) 
+    << "Not enough columns (" << numColumns_ << ") "
+    << "for desired density (" << density << ").";
   vector<pair<UInt, Real> > winners;
   for (UInt i = 0; i < numColumns_; i++)
   {

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1463,6 +1463,18 @@ namespace {
     ASSERT_TRUE(check_vector_eq(trueActive,active));
   }
 
+  TEST(SpatialPoolerTest, testValidateGlobalInhibitionParameters) {
+    // With 10 columns the minimum sparsity for global inhibition is 10%
+    // Setting sparsity to 2% should throw an exception
+    SpatialPooler sp;
+    setup(sp, 10, 10);
+    sp.setGlobalInhibition(true);
+    sp.setLocalAreaDensity(0.02);
+    vector<UInt> input(sp.getNumInputs(), 1);
+    vector<UInt> out1(sp.getNumColumns(), 0);
+    EXPECT_THROW(sp.compute(input.data(), false, out1.data()), nupic::LoggingException);
+  }
+
   TEST(SpatialPoolerTest, testInhibitColumnsLocal)
   {
     // wrapAround = false


### PR DESCRIPTION
Fixes #1390 
This PR Adds an extra validation to SP global inhibition parameters. It will throw an exception if requesting a global sparsity that cannot be calculated using the available columns. 