### PR TITLE
NUP-2492: Add constructor vs initialize test regarding Issue #1386

### DIFF
--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -2269,4 +2269,51 @@ namespace {
     ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
   }
 
+  TEST(SpatialPoolerTest, testConstructorVsInitialize)
+  {
+    // Initialize SP using the constructor
+    SpatialPooler sp1(
+      /*inputDimensions*/{100},
+      /*columnDimensions*/{100},
+      /*potentialRadius*/ 16,
+      /*potentialPct*/ 0.5,
+      /*globalInhibition*/ true,
+      /*localAreaDensity*/ -1.0,
+      /*numActiveColumnsPerInhArea*/ 10,
+      /*stimulusThreshold*/ 0,
+      /*synPermInactiveDec*/ 0.008,
+      /*synPermActiveInc*/ 0.05,
+      /*synPermConnected*/ 0.1,
+      /*minPctOverlapDutyCycles*/ 0.001,
+      /*dutyCyclePeriod*/ 1000,
+      /*boostStrength*/ 0.0,
+      /*seed*/ 1,
+      /*spVerbosity*/ 0,
+      /*wrapAround*/ true);
+
+    // Initialize SP using the "initialize" method
+    SpatialPooler sp2;
+    sp2.initialize(
+      /*inputDimensions*/{100},
+      /*columnDimensions*/{100},
+      /*potentialRadius*/ 16,
+      /*potentialPct*/ 0.5,
+      /*globalInhibition*/ true,
+      /*localAreaDensity*/ -1.0,
+      /*numActiveColumnsPerInhArea*/ 10,
+      /*stimulusThreshold*/ 0,
+      /*synPermInactiveDec*/ 0.008,
+      /*synPermActiveInc*/ 0.05,
+      /*synPermConnected*/ 0.1,
+      /*minPctOverlapDutyCycles*/ 0.001,
+      /*dutyCyclePeriod*/ 1000,
+      /*boostStrength*/ 0.0,
+      /*seed*/ 1,
+      /*spVerbosity*/ 0,
+      /*wrapAround*/ true);
+
+    // The two SP should be the same  
+    check_spatial_eq(sp1, sp2);
+  }
+
 } // end anonymous namespace


### PR DESCRIPTION
Closes #1386 
Add simple test to validate SP initialized directly from the constructor vs SP initialized via `initialize()` method