### PR TITLE
DEVOPS-353: Add SDR links to the Network API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,15 @@
 *.DS_Store
 *.swp
 *.pyc
+*.pkl
+
+# Coverage files 
+.coverage
+htmlcov/
 
 # IDE project files
 /nbproject/
+.vscode
 
 # Build files
 build/
@@ -20,6 +26,8 @@ build/
 html/
 
 # SWIG
-bindings/py/nupic/bindings/*.cxx
-bindings/py/nupic/bindings/*.py
-bindings/py/nupic/bindings/*.so
+bindings/py/src/nupic/bindings/*.cxx
+bindings/py/src/nupic/bindings/*.py
+bindings/py/src/nupic/bindings/*.so
+bindings/py/src/nupic/*.so
+bindings/py/src/nupic.bindings.egg-info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # -----------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.3)
-project(nupic_core_main CXX)
+project(nupic_core CXX)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")
 

--- a/bindings/py/src/nupic/bindings/regions/PyRegion.py
+++ b/bindings/py/src/nupic/bindings/regions/PyRegion.py
@@ -123,6 +123,7 @@ class PyRegion(object):
            - ``required`` (bool) whether the input is must be connected
            - ``isDefaultInput`` (bool) must be True for exactly one input
            - ``requireSplitterMap`` (bool) [just set this to False.]
+           - ``isSparse`` (bool) whether the input is sparse
 
       - ``outputs`` (dict) similar structure to inputs. The keys
         are:
@@ -132,6 +133,7 @@ class PyRegion(object):
            - ``count``
            - ``regionLevel``
            - ``isDefaultOutput``
+           - ``isSparse``
 
       - ``parameters`` (dict) of dicts with the following keys:
 

--- a/bindings/py/src/nupic/bindings/regions/PyRegion.py
+++ b/bindings/py/src/nupic/bindings/regions/PyRegion.py
@@ -432,7 +432,7 @@ class PyRegion(object):
     if outputs[name].size < value.size:
       raise Exception(
         "Output {} must be less than {}. Given value size is {}".format(
-          name, value.size))
+          name, outputs[name].size, value.size))
           
     outputs[lenAttr][0] = value.size
     outputs[name][:value.size] = value

--- a/bindings/py/src/nupic/bindings/regions/PyRegion.py
+++ b/bindings/py/src/nupic/bindings/regions/PyRegion.py
@@ -419,8 +419,9 @@ class PyRegion(object):
     :param outputs: (dict) of numpy arrays. This is the original outputs dict 
            owned by the C++ caller, passed to region via the compute method to 
            be updated.
-    :param name: (string) name of output
-    :param value: (object) the sparse array to assign to the output
+    :param name: (string) name of an existing output to modify
+    :param value: (list) list of UInt32 indices of all the nonzero entries 
+           representing the sparse array to be set 
     """
     # The region output memory is owned by the c++ and cannot be changed from
     # python. We use a special attribule named "__{name}_len__" to pass

--- a/bindings/py/src/nupic/bindings/regions/PyRegion.py
+++ b/bindings/py/src/nupic/bindings/regions/PyRegion.py
@@ -406,3 +406,31 @@ class PyRegion(object):
       raise Exception('Command: ' + methodName + ' must be callable')
 
     return m(*args)
+
+  @staticmethod
+  def setSparseOutput(outputs, name, value):
+    """
+    Set region sparse output value.
+
+    The region output memory is owned by the c++ caller and cannot be changed  
+    directly from python. Use this method to update the sparse output fields in  
+    the "outputs" array so it can be resized from the c++ code.
+
+    :param outputs: (dict) of numpy arrays (one per output)
+    :param name: (string) name of output
+    :param value: (object) the sparse array to assign to the output
+    """
+    # The region output memory is owned by the c++ and cannot be changed from
+    # python. We use a special attribule named "__{name}_len__" to pass
+    # the sparse array length back to c++
+    lenAttr = "__{}_len__".format(name)
+    if lenAttr not in outputs:
+      raise Exception("Output {} is not a valid sparse output".format(name))
+
+    if outputs[name].size < value.size:
+      raise Exception(
+        "Output {} must be less than {}. Given value size is {}".format(
+          name, value.size))
+          
+    outputs[lenAttr][0] = value.size
+    outputs[name][:value.size] = value

--- a/bindings/py/src/nupic/bindings/regions/PyRegion.py
+++ b/bindings/py/src/nupic/bindings/regions/PyRegion.py
@@ -416,7 +416,9 @@ class PyRegion(object):
     directly from python. Use this method to update the sparse output fields in  
     the "outputs" array so it can be resized from the c++ code.
 
-    :param outputs: (dict) of numpy arrays (one per output)
+    :param outputs: (dict) of numpy arrays. This is the original outputs dict 
+           owned by the C++ caller, passed to region via the compute method to 
+           be updated.
     :param name: (string) name of output
     :param value: (object) the sparse array to assign to the output
     """

--- a/bindings/py/tests/sparse_link_test.py
+++ b/bindings/py/tests/sparse_link_test.py
@@ -23,7 +23,7 @@ import unittest
 import numpy as np
 import numpy.testing
 from nupic.bindings.regions.PyRegion import PyRegion
-from nupic.engine import Network
+import nupic.bindings.engine_internal as engine
 
 TEST_DATA_SPARSE = np.array([4, 7])
 MAX_ACTIVE = TEST_DATA_SPARSE.size
@@ -170,7 +170,7 @@ class DenseRegion(PyRegion):
 
 def createNetwork(fromRegion, toRegion):
   """Create test network"""
-  network = Network()
+  network = engine.Network()
   config = str({"maxActive": MAX_ACTIVE, "outputWidth": OUTPUT_WIDTH})
   network.addRegion("from", fromRegion, config)
   network.addRegion("to", toRegion, config)
@@ -185,8 +185,8 @@ class SparseLinkTest(unittest.TestCase):
 
   def setUp(self):
     """Register test regions"""
-    Network.registerPyRegion(SparseRegion.__module__, SparseRegion.__name__)
-    Network.registerPyRegion(DenseRegion.__module__, DenseRegion.__name__)
+    engine.Network.registerPyRegion(SparseRegion.__module__, SparseRegion.__name__)
+    engine.Network.registerPyRegion(DenseRegion.__module__, DenseRegion.__name__)
 
   def testSparseToSparse(self):
     """Test links between sparse to sparse"""
@@ -194,7 +194,8 @@ class SparseLinkTest(unittest.TestCase):
     net.initialize()
     net.run(1)
 
-    actual = net.regions["to"].getOutputData("dataOut")
+    region = net.getRegions().getByName("to")
+    actual = region.getOutputArray("dataOut")
     np.testing.assert_array_equal(actual, TEST_DATA_SPARSE)
 
   def testSparseToDense(self):
@@ -203,7 +204,8 @@ class SparseLinkTest(unittest.TestCase):
     net.initialize()
     net.run(1)
 
-    actual = net.regions["to"].getOutputData("dataOut")
+    region = net.getRegions().getByName("to")
+    actual = region.getOutputArray("dataOut")
     np.testing.assert_array_equal(actual, TEST_DATA_DENSE)
 
   def testDenseToSparse(self):
@@ -212,7 +214,8 @@ class SparseLinkTest(unittest.TestCase):
     net.initialize()
     net.run(1)
 
-    actual = net.regions["to"].getOutputData("dataOut")
+    region = net.getRegions().getByName("to")
+    actual = region.getOutputArray("dataOut")
     np.testing.assert_array_equal(actual, TEST_DATA_SPARSE)
 
   def testDenseToDense(self):
@@ -221,7 +224,8 @@ class SparseLinkTest(unittest.TestCase):
     net.initialize()
     net.run(1)
 
-    actual = net.regions["to"].getOutputData("dataOut")
+    region = net.getRegions().getByName("to")
+    actual = region.getOutputArray("dataOut")
     np.testing.assert_array_equal(actual, TEST_DATA_DENSE)
 
 

--- a/bindings/py/tests/sparse_link_test.py
+++ b/bindings/py/tests/sparse_link_test.py
@@ -1,0 +1,229 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+import unittest
+
+import numpy as np
+import numpy.testing
+from nupic.bindings.regions.PyRegion import PyRegion
+from nupic.engine import Network
+
+TEST_DATA_SPARSE = np.array([4, 7])
+MAX_ACTIVE = TEST_DATA_SPARSE.size
+OUTPUT_WIDTH = 10
+TEST_DATA_DENSE = np.zeros(OUTPUT_WIDTH, dtype=np.bool)
+TEST_DATA_DENSE[TEST_DATA_SPARSE] = True
+
+
+class SparseRegion(PyRegion):
+  """
+  This region receives sparse input and returns the same sparse output
+  
+  :param maxActive: Max active bits in the sparse data
+  :param outputWidth: Size of output vector
+  """
+
+  def __init__(self, maxActive, outputWidth, **kwargs):
+    PyRegion.__init__(self, **kwargs)
+
+    self.maxActive = maxActive
+    self.outputWidth = outputWidth
+
+  @classmethod
+  def getSpec(cls):
+    return {
+      "description": "Sparse Region",
+      "singleNodeOnly": True,
+      "inputs": {
+        "dataIn": {
+          "description": "Sparse Data In",
+          "dataType": "UInt32",
+          "isDefaultInput": True,
+          "required": False,
+          "sparse": True,
+          "count": 0
+        },
+      },
+      "outputs": {
+        "dataOut": {
+          "description": "Sparse Data Out",
+          "dataType": "UInt32",
+          "isDefaultOutput": True,
+          "sparse": True,
+          "count": 0
+        },
+      },
+      "parameters": {
+        "maxActive": {
+          "description": "Max active bits in the sparse data",
+          "dataType": "UInt32",
+          "accessMode": "ReadWrite",
+          "count": 1,
+          "constraints": "",
+        },
+        "outputWidth": {
+          "description": "Size of output vector",
+          "dataType": "UInt32",
+          "accessMode": "ReadWrite",
+          "count": 1,
+          "constraints": "",
+        }
+      }
+    }
+
+  def compute(self, inputs, outputs):
+    if "dataIn" in inputs:
+      PyRegion.setSparseOutput(outputs, "dataOut", inputs["dataIn"])
+    else:
+      PyRegion.setSparseOutput(outputs, "dataOut", self.data)
+
+  def initialize(self):
+    self.data = TEST_DATA_SPARSE
+
+  def getOutputElementCount(self, name):
+    return self.outputWidth
+
+
+class DenseRegion(PyRegion):
+  """
+  This region receives dense input and returns the same dense output
+
+  :param maxActive: Max active bits in the sparse data
+  :param outputWidth: Size of output vector
+  """
+
+  def __init__(self, maxActive, outputWidth, **kwargs):
+    PyRegion.__init__(self, **kwargs)
+
+    self.maxActive = maxActive
+    self.outputWidth = outputWidth
+
+  @classmethod
+  def getSpec(cls):
+    return {
+      "description": "Dense Region",
+      "singleNodeOnly": True,
+      "inputs": {
+        "dataIn": {
+          "description": "Dense Data In",
+          "dataType": "Bool",
+          "isDefaultInput": True,
+          "required": False,
+          "count": 0
+        },
+      },
+      "outputs": {
+        "dataOut": {
+          "description": "Dense Data Out",
+          "dataType": "Bool",
+          "isDefaultOutput": True,
+          "count": 0
+        },
+      },
+      "parameters": {
+        "maxActive": {
+          "description": "Max active bits in the sparse data",
+          "dataType": "UInt32",
+          "accessMode": "ReadWrite",
+          "count": 1,
+          "constraints": "",
+        },
+        "outputWidth": {
+          "description": "Size of output vector",
+          "dataType": "UInt32",
+          "accessMode": "ReadWrite",
+          "count": 1,
+          "constraints": "",
+        }
+      }
+    }
+
+  def compute(self, inputs, outputs):
+    if "dataIn" in inputs:
+      outputs["dataOut"][:] = inputs["dataIn"]
+    else:
+      outputs["dataOut"][:] = self.data
+
+  def initialize(self):
+    self.data = TEST_DATA_DENSE
+
+  def getOutputElementCount(self, name):
+    return self.outputWidth
+
+
+def createNetwork(fromRegion, toRegion):
+  """Create test network"""
+  network = Network()
+  config = str({"maxActive": MAX_ACTIVE, "outputWidth": OUTPUT_WIDTH})
+  network.addRegion("from", fromRegion, config)
+  network.addRegion("to", toRegion, config)
+
+  network.link("from", "to", "UniformLink", "")
+  return network
+
+
+class SparseLinkTest(unittest.TestCase):
+  """Test sparse link"""
+  __name__ = "SparseLinkTest"
+
+  def setUp(self):
+    """Register test regions"""
+    Network.registerPyRegion(SparseRegion.__module__, SparseRegion.__name__)
+    Network.registerPyRegion(DenseRegion.__module__, DenseRegion.__name__)
+
+  def testSparseToSparse(self):
+    """Test links between sparse to sparse"""
+    net = createNetwork("py.SparseRegion", "py.SparseRegion")
+    net.initialize()
+    net.run(1)
+
+    actual = net.regions["to"].getOutputData("dataOut")
+    np.testing.assert_array_equal(actual, TEST_DATA_SPARSE)
+
+  def testSparseToDense(self):
+    """Test links between sparse to dense"""
+    net = createNetwork("py.SparseRegion", "py.DenseRegion")
+    net.initialize()
+    net.run(1)
+
+    actual = net.regions["to"].getOutputData("dataOut")
+    np.testing.assert_array_equal(actual, TEST_DATA_DENSE)
+
+  def testDenseToSparse(self):
+    """Test links between dense to sparse"""
+    net = createNetwork("py.DenseRegion", "py.SparseRegion")
+    net.initialize()
+    net.run(1)
+
+    actual = net.regions["to"].getOutputData("dataOut")
+    np.testing.assert_array_equal(actual, TEST_DATA_SPARSE)
+
+  def testDenseToDense(self):
+    """Test links between dense to dense"""
+    net = createNetwork("py.DenseRegion", "py.DenseRegion")
+    net.initialize()
+    net.run(1)
+
+    actual = net.regions["to"].getOutputData("dataOut")
+    np.testing.assert_array_equal(actual, TEST_DATA_DENSE)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -20,7 +20,7 @@
 # -----------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.3)
-project(nupic_core_main CXX)
+project(nupic_core CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 include(GNUInstallDirs)

--- a/src/NupicLibraryUtils.cmake
+++ b/src/NupicLibraryUtils.cmake
@@ -21,8 +21,8 @@
 
 # Utilities for manipulating libraries
 
-cmake_minimum_required(VERSION 2.8)
-project(nupic_core_library_utils CXX)
+cmake_minimum_required(VERSION 3.3)
+project(nupic_core CXX)
 
 
 # function MERGE_STATIC_LIBRARIES

--- a/src/nupic/engine/Input.hpp
+++ b/src/nupic/engine/Input.hpp
@@ -62,8 +62,11 @@ public:
    *        The type of the input, i.e. TODO
    * @param isRegionLevel
    *        Whether the input is region level, i.e. TODO
+   * @param isSparse
+   *        Whether the input is sparse. Default false
    */
-  Input(Region &region, NTA_BasicType type, bool isRegionLevel);
+  Input(Region &region, NTA_BasicType type, bool isRegionLevel,
+        bool isSparse = false);
 
   /**
    *
@@ -157,6 +160,11 @@ public:
   const Array &getData() const;
 
   /**
+   *  Get the data type of the output
+   */
+  NTA_BasicType getDataType() const;
+
+  /**
    *
    * Get the Region that the input belongs to.
    *
@@ -238,6 +246,14 @@ public:
   template <typename T>
   void getInputForNode(size_t nodeIndex, std::vector<T> &input) const;
 
+  /*
+   * Tells whether the input is sparse.
+   *
+   * @returns
+   *     Whether the input is sparse
+   */
+  bool isSparse();
+
 private:
   Region &region_;
   // buffer is concatenation of input buffers (after prepare), or,
@@ -268,6 +284,9 @@ private:
 
   // Useful for us to know our own name
   std::string name_;
+
+  // Whether or not to use sparse data
+  bool isSparse_;
 
   // Internal methods
 

--- a/src/nupic/engine/Link.cpp
+++ b/src/nupic/engine/Link.cpp
@@ -384,7 +384,7 @@ void Link::compute() {
 
     size_t srcLen = src.getCount();
     size_t destLen = dest.getBufferSize();
-    ::memset(destBuf, 0, destLen * sizeof(bool));
+    ::memset(destBuf, 0, destLen);
     size_t destIdx;
     for (size_t i = 0; i < srcLen; i++) {
       destIdx = srcBuf[i];

--- a/src/nupic/engine/Link.cpp
+++ b/src/nupic/engine/Link.cpp
@@ -348,7 +348,7 @@ void Link::compute() {
     ::memcpy((char *)(dest.getBuffer()) + destByteOffset, src.getBuffer(),
              srcSize);
     if (dest_->isSparse()) {
-      // Remove 'const' to update the variable lenght array
+      // Remove 'const' to update the variable length array
       const_cast<Array &>(dest).setCount(src.getCount());
     }
   } else if (dest_->isSparse()) {
@@ -371,7 +371,7 @@ void Link::compute() {
         destBuf[destIdx++] = i;
       }
     }
-    // Remove 'const' to update the variable lenght array
+    // Remove 'const' to update the variable length array
     const_cast<Array &>(dest).setCount(destIdx);
   } else {
     // Destination is dense, convert source from sparse to dense

--- a/src/nupic/engine/Link.cpp
+++ b/src/nupic/engine/Link.cpp
@@ -173,6 +173,17 @@ void Link::initialize(size_t destinationOffset) {
               destD == dest_->getRegion().getDimensions());
   }
 
+  // Validate sparse link
+  if (src_->isSparse() && !dest_->isSparse()) {
+    // Sparse to dense: unit32 -> bool
+    NTA_CHECK(dest_->getDataType() == NTA_BasicType_Bool)
+        << "Sparse to Dense link destination must be boolean";
+  } else if (!src_->isSparse() && dest_->isSparse()) {
+    // Dense to sparse:  NTA_BasicType -> uint32
+    NTA_CHECK(dest_->getDataType() == NTA_BasicType_UInt32)
+        << "Dense to Sparse link destination must be uint32";
+  }
+
   destOffset_ = destinationOffset;
   impl_->initialize();
 

--- a/src/nupic/engine/Output.cpp
+++ b/src/nupic/engine/Output.cpp
@@ -34,9 +34,10 @@
 
 namespace nupic {
 
-Output::Output(Region &region, NTA_BasicType type, bool isRegionLevel)
+Output::Output(Region &region, NTA_BasicType type, bool isRegionLevel,
+               bool isSparse)
     : region_(region), isRegionLevel_(isRegionLevel), name_("Unnamed"),
-      nodeOutputElementCount_(0) {
+      nodeOutputElementCount_(0), isSparse_(isSparse) {
   data_ = new Array(type);
 }
 
@@ -56,6 +57,12 @@ void Output::initialize(size_t count) {
   // exception (elsewhere) and was retried.
   if (data_->getBuffer() != nullptr)
     return;
+
+  if (isSparse_) {
+    NTA_CHECK(isRegionLevel_) << "Sparse data must be region level";
+    NTA_CHECK(data_->getType() == NTA_BasicType_UInt32)
+        << "Sparse data must be uint32";
+  }
 
   nodeOutputElementCount_ = count;
   size_t dataCount;
@@ -97,6 +104,7 @@ const Array &Output::getData() const { return *data_; }
 bool Output::isRegionLevel() const { return isRegionLevel_; }
 
 Region &Output::getRegion() const { return region_; }
+bool Output::isSparse() const { return isSparse_; }
 
 void Output::setName(const std::string &name) { name_ = name; }
 
@@ -107,5 +115,7 @@ size_t Output::getNodeOutputElementCount() const {
 }
 
 bool Output::hasOutgoingLinks() { return (!links_.empty()); }
+
+NTA_BasicType Output::getDataType() const { return data_->getType(); }
 
 } // namespace nupic

--- a/src/nupic/engine/Output.hpp
+++ b/src/nupic/engine/Output.hpp
@@ -50,8 +50,11 @@ public:
    *        The type of the output, TODO
    * @param isRegionLevel
    *        Whether the output is region level, i.e. TODO
+   * @param isSparse
+   *        Whether the output is sparse. Default false
    */
-  Output(Region &region, NTA_BasicType type, bool isRegionLevel);
+  Output(Region &region, NTA_BasicType type, bool isRegionLevel,
+         bool isSparse = false);
 
   /**
    * Destructor
@@ -130,10 +133,15 @@ public:
    * @returns
    *         A constant reference to the data of the output as an @c Array
    *
-   * @note It's mportant to return a const array so caller can't
+   * @note It's important to return a const array so caller can't
    * reallocate the buffer.
    */
   const Array &getData() const;
+
+  /**
+   *  Get the data type of the output
+   */
+  NTA_BasicType getDataType() const;
 
   /**
    *
@@ -161,6 +169,15 @@ public:
    */
   size_t getNodeOutputElementCount() const;
 
+  /**
+   *
+   * Tells whether the output is sparse.
+   *
+   * @returns
+   *     Whether the output is sparse.
+   */
+  bool isSparse() const;
+
 private:
   Region &region_; // needed for number of nodes
   Array *data_;
@@ -170,6 +187,8 @@ private:
   std::set<Link *> links_;
   std::string name_;
   size_t nodeOutputElementCount_;
+  // Whether or not the output is sparse
+  bool isSparse_;
 };
 
 } // namespace nupic

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -112,7 +112,7 @@ void Region::createInputsAndOutputs_() {
     const std::pair<std::string, OutputSpec> &p = spec_->outputs.getByIndex(i);
     std::string outputName = p.first;
     const OutputSpec &os = p.second;
-    auto output = new Output(*this, os.dataType, os.regionLevel);
+    auto output = new Output(*this, os.dataType, os.regionLevel, os.sparse);
     outputs_[outputName] = output;
     // keep track of name in the output also -- see note in Region.hpp
     output->setName(outputName);
@@ -124,7 +124,7 @@ void Region::createInputsAndOutputs_() {
     std::string inputName = p.first;
     const InputSpec &is = p.second;
 
-    auto input = new Input(*this, is.dataType, is.regionLevel);
+    auto input = new Input(*this, is.dataType, is.regionLevel, is.sparse);
     inputs_[inputName] = input;
     // keep track of name in the input also -- see note in Region.hpp
     input->setName(inputName);

--- a/src/nupic/engine/Spec.cpp
+++ b/src/nupic/engine/Spec.cpp
@@ -82,15 +82,18 @@ std::string Spec::getDefaultOutputName() const {
 
 InputSpec::InputSpec(std::string description, NTA_BasicType dataType,
                      UInt32 count, bool required, bool regionLevel,
-                     bool isDefaultInput, bool requireSplitterMap)
+                     bool isDefaultInput, bool requireSplitterMap, bool sparse)
     : description(std::move(description)), dataType(dataType), count(count),
       required(required), regionLevel(regionLevel),
-      isDefaultInput(isDefaultInput), requireSplitterMap(requireSplitterMap) {}
+      isDefaultInput(isDefaultInput), requireSplitterMap(requireSplitterMap),
+      sparse(sparse) {}
 
 OutputSpec::OutputSpec(std::string description, NTA_BasicType dataType,
-                       size_t count, bool regionLevel, bool isDefaultOutput)
+                       size_t count, bool regionLevel, bool isDefaultOutput,
+                       bool sparse)
     : description(std::move(description)), dataType(dataType), count(count),
-      regionLevel(regionLevel), isDefaultOutput(isDefaultOutput) {}
+      regionLevel(regionLevel), isDefaultOutput(isDefaultOutput),
+      sparse(sparse) {}
 
 CommandSpec::CommandSpec(std::string description)
     : description(std::move(description)) {}

--- a/src/nupic/engine/Spec.hpp
+++ b/src/nupic/engine/Spec.hpp
@@ -38,7 +38,7 @@ public:
   InputSpec() {}
   InputSpec(std::string description, NTA_BasicType dataType, UInt32 count,
             bool required, bool regionLevel, bool isDefaultInput,
-            bool requireSplitterMap = true);
+            bool requireSplitterMap = true, bool sparse = false);
 
   std::string description;
   NTA_BasicType dataType;
@@ -50,13 +50,15 @@ public:
   bool regionLevel;
   bool isDefaultInput;
   bool requireSplitterMap;
+  bool sparse;
 };
 
 class OutputSpec {
 public:
   OutputSpec() {}
   OutputSpec(std::string description, const NTA_BasicType dataType,
-             size_t count, bool regionLevel, bool isDefaultOutput);
+             size_t count, bool regionLevel, bool isDefaultOutput,
+             bool sparse = false);
 
   std::string description;
   NTA_BasicType dataType;
@@ -65,6 +67,7 @@ public:
   size_t count;
   bool regionLevel;
   bool isDefaultOutput;
+  bool sparse;
 };
 
 class CommandSpec {

--- a/src/nupic/ntypes/ArrayBase.hpp
+++ b/src/nupic/ntypes/ArrayBase.hpp
@@ -45,7 +45,8 @@ namespace nupic {
 /**
  * An ArrayBase is used for passing arrays of data back and forth between
  * a client application and NuPIC, minimizing copying. It facilitates
- * both zero-copy and one-copy operations.
+ * both zero-copy and one-copy operations. The array can be of variable length
+ * independent of buffer size. Array length cannot exceed buffer size.
  */
 class ArrayBase {
 public:
@@ -83,6 +84,17 @@ public:
   // number of elements of given type in the buffer
   size_t getCount() const;
 
+  /**
+   * Returns the allocated buffer size in bytes independent of array length
+   */
+  size_t getBufferSize() const;
+
+  /**
+   * Set array length independent of buffer size. Array length cannot exceed
+   * buffer size
+   */
+  void setCount(size_t count);
+
   NTA_BasicType getType() const;
 
 protected:
@@ -92,6 +104,7 @@ protected:
   size_t count_;
   NTA_BasicType type_;
   bool own_;
+  size_t bufferSize_;
 
 private:
   /**

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -1048,9 +1048,15 @@ void PyRegion::createSpec(const char *nodeType, Spec &ns,
       requireSplitterMap = py::Int(input.getItem("requireSplitterMap")) != 0;
     }
 
+    // make sparse optional and default to false.
+    bool sparse = false;
+    if (input.getItem("sparse") != nullptr) {
+      sparse = py::Int(input.getItem("sparse")) != 0;
+    }
+
     ns.inputs.add(name,
                   InputSpec(description, dataType, count, required, regionLevel,
-                            isDefaultInput, requireSplitterMap));
+                            isDefaultInput, requireSplitterMap, sparse));
   }
 
   // Add outputs
@@ -1102,8 +1108,14 @@ void PyRegion::createSpec(const char *nodeType, Spec &ns,
         << outputMessagePrefix.str() << "isDefaultOutput";
     bool isDefaultOutput = py::Int(output.getItem("isDefaultOutput")) != 0;
 
+    // make sparse optional and default to true.
+    bool sparse = false;
+    if (output.getItem("sparse") != nullptr) {
+      sparse = py::Int(output.getItem("sparse")) != 0;
+    }
+
     ns.outputs.add(name, OutputSpec(description, dataType, count, regionLevel,
-                                    isDefaultOutput));
+                                    isDefaultOutput, sparse));
   }
 
   // Add parameters

--- a/src/nupic/regions/PyRegion.cpp
+++ b/src/nupic/regions/PyRegion.cpp
@@ -974,7 +974,7 @@ void PyRegion::compute() {
       name << "__" << p.first << "_len__";
       py::List len(outputs.getItem(name.str()));
 
-      // Remove 'const' to update the variable lenght array
+      // Remove 'const' to update the variable length array
       Array &data = const_cast<Array &>(out->getData());
       data.setCount(py::Int(len.getItem(0)));
     }


### PR DESCRIPTION
The current network API implementation expects the data exchanged between regions to be dense arrays.

This PR extends the network API by allowing regions to use both sparse or dense arrays as their inputs and outputs. Only when necessary the network API will convert the sparse arrays into dense arrays, and vice-versa.

To use this feature, you must first specify which inputs/outputs are sparse using the new `sparse` attribute in the region spec and on the region's `compute` method, use `PyRegion.setSparseOutput` method to update the sparse output. See `bindings/py/tests/sparse_link_test.py`

@subutai, @scottpurdy please review
