### PR TITLE
Fix not include ClassifierResult.hpp error

### DIFF
--- a/src/nupic/algorithms/SDRClassifier.hpp
+++ b/src/nupic/algorithms/SDRClassifier.hpp
@@ -33,8 +33,8 @@
 #include <string>
 #include <vector>
 
-#include <nupic/math/DenseMatrix.hpp>
 #include <nupic/algorithms/ClassifierResult.hpp>
+#include <nupic/math/DenseMatrix.hpp>
 #include <nupic/proto/SdrClassifier.capnp.h>
 #include <nupic/types/Serializable.hpp>
 #include <nupic/types/Types.hpp>

--- a/src/nupic/algorithms/SDRClassifier.hpp
+++ b/src/nupic/algorithms/SDRClassifier.hpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include <nupic/math/DenseMatrix.hpp>
+#include <nupic/algorithms/ClassifierResult.hpp>
 #include <nupic/proto/SdrClassifier.capnp.h>
 #include <nupic/types/Serializable.hpp>
 #include <nupic/types/Types.hpp>


### PR DESCRIPTION
This error occur
```
nupic.core/src/nupic/algorithms/SDRClassifier.hpp:45:9: error: 'cla_classifier' does not name a type
 typedef cla_classifier::ClassifierResult ClassifierResult;
         ^
```

It is necessary to insert `#include <nupic/algorithms/ClassifierResult.hpp>` into SDRClassifier.hpp