### PR TITLE
NUP-2505: Remove win32 build from CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ init:
   - git config --global core.autocrlf input
 
 clone_folder: c:\projects\nupic-core
-clone_depth: 50
+clone_depth: 1
 
 # Can't have a shallow clone because the CMake process will be
 # calling into git to write the current SHA into the binaries.
@@ -51,12 +51,12 @@ environment:
       wheel_name_suffix: "win_amd64"
 
     # Win32-gcc
-    - PYTHON_VERSION: "2.7.9"
-      PYTHON_ARCH: "32"
-      PYTHONHOME: "C:\\Python27"
-      NC_CMAKE_GENERATOR: "MinGW Makefiles"
-      external_static_subdir: "windows32-gcc"
-      wheel_name_suffix: "win32"
+#    - PYTHON_VERSION: "2.7.9"
+#      PYTHON_ARCH: "32"
+#      PYTHONHOME: "C:\\Python27"
+#      NC_CMAKE_GENERATOR: "MinGW Makefiles"
+#      external_static_subdir: "windows32-gcc"
+#      wheel_name_suffix: "win32"
 
 #    # Win64-Visual Studio
 #    - PYTHON_VERSION: "2.7.9"


### PR DESCRIPTION
Windows 32 is not supported by nupic. I will update bamboo once this PR is merged
@rhyolight Please review