### PR TITLE
Output: fix for gcc 4.7 / c++11 destructor noexcept(true)

### DIFF
--- a/src/nupic/engine/Output.cpp
+++ b/src/nupic/engine/Output.cpp
@@ -41,7 +41,7 @@ Output::Output(Region &region, NTA_BasicType type, bool isRegionLevel,
   data_ = new Array(type);
 }
 
-Output::~Output() {
+Output::~Output() noexcept(false) {
   // If we have any outgoing links, then there has been an
   // error in the shutdown process. Not good to thow an exception
   // from a destructor, but we need to catch this error, and it

--- a/src/nupic/engine/Output.hpp
+++ b/src/nupic/engine/Output.hpp
@@ -58,8 +58,10 @@ public:
 
   /**
    * Destructor
+   * noexcept(false) : as C++11 forces noexcept(true) in destructors by default, 
+   * we override that here to throw NTA_CHECK
    */
-  ~Output();
+  ~Output() noexcept(false);
 
   /**
    * Set the name for the output.


### PR DESCRIPTION
https://stackoverflow.com/questions/42976461/exception-in-destructor-c
We locally allow throwing an exception from the ~Output destructor.

Fixes: #1000 #1414 
Replaces: #1415 