### PR TITLE
Fix Directory::Iterator::~Iterator() implicitly being no-except

### DIFF
--- a/src/nupic/os/Directory.cpp
+++ b/src/nupic/os/Directory.cpp
@@ -252,7 +252,7 @@ void Iterator::init(const std::string &path) {
                       << ". OS num: " << APR_TO_OS_ERROR(res);
 }
 
-Iterator::~Iterator() {
+Iterator::~Iterator() noexcept(false) {
   apr_status_t res = ::apr_dir_close(handle_);
   ::apr_pool_destroy(pool_);
   NTA_CHECK(res == 0) << "Couldn't close directory."

--- a/src/nupic/os/Directory.hpp
+++ b/src/nupic/os/Directory.hpp
@@ -79,7 +79,7 @@ class Iterator {
 public:
   Iterator(const Path &path);
   Iterator(const std::string &path);
-  ~Iterator();
+  ~Iterator() noexcept(false);
 
   // Resets directory to start. Subsequent call to next()
   // will retrieve the first entry


### PR DESCRIPTION
This was causing an error for me (due to `-Werror`) when building using the latest LLVM.