### PR TITLE
Catch exceptions by const ref.

### DIFF
--- a/src/test/unit/ntypes/ArrayTest.cpp
+++ b/src/test/unit/ntypes/ArrayTest.cpp
@@ -181,7 +181,7 @@ TEST_F(ArrayTest, testArrayCreation) {
 
       try {
         arrayP.reset(new ArrayBase(testCase->second.dataType));
-      } catch (nupic::Exception) {
+      } catch (nupic::Exception const&) {
         caughtException = true;
       }
 
@@ -261,7 +261,7 @@ TEST_F(ArrayTest, testBufferAllocation) {
 
       try {
         a.allocateBuffer(10);
-      } catch (nupic::Exception) {
+      } catch (nupic::Exception const&) {
         caughtException = true;
       }
 
@@ -303,7 +303,7 @@ TEST_F(ArrayTest, testBufferAssignment) {
 
     try {
       a.setBuffer(buf2.get(), testCase->second.allocationSize);
-    } catch (nupic::Exception) {
+    } catch (nupic::Exception const&) {
       caughtException = true;
     }
 


### PR DESCRIPTION
Catching by value triggers '-Werror=catch-value=';
tested with g++ 8.2.0.